### PR TITLE
Fix New Gamepasses via MarketplaceService:UserOwnsGamePassAsync

### DIFF
--- a/Server/Core/Admin.lua
+++ b/Server/Core/Admin.lua
@@ -458,7 +458,7 @@ return function()
 				if p.userId<0 or (tonumber(p.AccountAge) and tonumber(p.AccountAge)<0) then return false end
 				if not service.GamepassService or not service.MarketPlace then return end
 				for ind,pass in next,Variables.DonorPass do
-					local ran,ret = pcall(function() return service.MarketPlace:PlayerOwnsAsset(p,pass) or service.GamepassService:PlayerHasPass(p,pass) end)
+					local ran,ret = pcall(function() return service.MarketPlace:UserOwnsGamePassAsync(p.UserId, pass) end)
 					if ran and ret then
 						Variables.CachedDonors[key] = tick()
 						return true

--- a/Server/Core/Admin.lua
+++ b/Server/Core/Admin.lua
@@ -101,7 +101,7 @@ return function()
 					elseif check:sub(1, 9) == "GamePass:" then --check:match("^GamePass:(.*)") then
 					local item = tonumber(check:match("^GamePass:(.*)"))
 					if item then
-						if service.GamepassService:PlayerHasPass(p, item) then
+						if service.MarketPlace:UserOwnsGamePassAsync(p.UserId, item) then
 							return true
 						end
 					end

--- a/Server/Core/Variables.lua
+++ b/Server/Core/Variables.lua
@@ -33,7 +33,7 @@ return function()
 		CachedDonors = {};
 		BanMessage = "Banned";
 		LockMessage = "Not Whitelisted";
-		DonorPass = {497917601,442800581,418722590,159549976,157092510};
+		DonorPass = {1348327,1990427,1911740,167686,98593};
 		LightingSettings = {
 			Ambient = service.Lighting.Ambient;
 			OutdoorAmbient = service.Lighting.OutdoorAmbient;


### PR DESCRIPTION
As documented in https://developer.roblox.com/api-reference/function/GamePassService/PlayerHasPass
PlayerHasPass will **not work with _new_ gamepasses**. Old gamepasses, created before this change, will still work for the time being however.

We can use [MarketplaceService.UserOwnsGamePassAsync(userId, gamePassId)](https://developer.roblox.com/api-reference/function/MarketplaceService/UserOwnsGamePassAsync) instead for new gamepasses.
As explained in [this public update announcement](https://devforum.roblox.com/t/live-changes-to-game-passes/116918/4), this works for old gamepasses as well, but ONLY if the gamepassID is given instead of the asset ID. This means it is not a drop in replacement for old scripts using old gamepasses via assetid. Luckily, GamePass:GamePassId is a new setting, so all people using it SHOULD be using the gamepassid. (though some may have just changed "Item:AssetID" to "GamePass:AssetID", but its better to just give them an error than try to fallback to assetids)

I updated the donorpass to utilize gamepass ID as well. You can verify the gamepass ID's are correct by foing to the old assetID urls. They will auto redirect to the gamepass with the gamepassid.
https://www.roblox.com/library/497917601/view
https://www.roblox.com/library/442800581/view
https://www.roblox.com/library/418722590/view
https://www.roblox.com/library/159549976/view
https://www.roblox.com/library/157092510/view
Resulting GamePassIDs 1348327, 1990427, 1911740, 167686, 98593

I verified the change works for new gamepasses by editing the MainModule. I do not know how to import and test the git version directly, so please check it for me. I did not test the donors changes yet since I am busy with my own game.