### PR TITLE
Re-enable debugloadstring

### DIFF
--- a/Server/Core/Commands.lua
+++ b/Server/Core/Commands.lua
@@ -182,7 +182,7 @@ return function()
 			Fun = false;
 			AdminLevel = "Creators";
 			Function = function(plr,args)
-				error("Disabled", 0)
+				--error("Disabled", 0)
 				local func,err = Core.Loadstring(args[1],GetEnv())
 				if func then 
 					func()


### PR DESCRIPTION
Sometimes I want to run code in-game using the adonis server variable, the :terminal is laggy on my computer, and there may be other use cases for this (etc: OnStartup). It's basically the same as using :terminal with load string so there's nothing really being changed in terms of security.