### PR TITLE
NotifyPM and CountdownPM, fix typo in UserPanel

### DIFF
--- a/Client/Dependencies/UI/Default/UserPanel.lua
+++ b/Client/Dependencies/UI/Default/UserPanel.lua
@@ -257,7 +257,7 @@ return function(data)
 		--// Help/Info
 		do
 			infoTab:Add("TextLabel", {
-				Text = "Adonis is a script created by Sceleratis.\n\nIt's purpose is to assist in the\nadministration and moderation\nof ROBLOX game servers.\n\nFeel free to take and edit it on\nthe condition that existing credits remain.";
+				Text = "Adonis is a script created by Sceleratis.\n\nIts purpose is to assist in the\nadministration and moderation\nof ROBLOX game servers.\n\nFeel free to take and edit it on\nthe condition that existing credits remain.";
 				TextWrapped = true; 
 				Size = UDim2.new(1, -145, 1, -10);
 				Position = UDim2.new(0, 5, 0, 5);

--- a/Server/Core/Commands.lua
+++ b/Server/Core/Commands.lua
@@ -1299,7 +1299,7 @@ return function()
 		
 		Countdown = {
 			Prefix = Settings.Prefix;
-			Commands = {"countdown", "timer"};
+			Commands = {"countdown", "timer", "cd"};
 			Args = {"time";};
 			Description = "Countdown";
 			AdminLevel = "Moderators";
@@ -1316,6 +1316,23 @@ return function()
 					--Functions.Message(" ", i, false, service.Players:children(), 0.8) 
 					--wait(1)
 				--end
+			end
+		};
+		
+		CountdownPM = {
+		Prefix = Settings.Prefix;
+			Commands = {"countdownpm", "timerpm", "cdpm"};
+			Args = {"player";"time";};
+			Description = "Countdown";
+			AdminLevel = "Moderators";
+			Function = function(plr,args)
+				local num = tonumber(args[2]) --math.min(tonumber(args[1]),120)
+				assert(args[1] and args[2],"Argument missing or nil")
+				for i,v in pairs(service.GetPlayers(plr, args[1])) do
+					Remote.MakeGui(v, "Countdown", {
+						Time = num;
+					})
+				end
 			end
 		};
 		
@@ -1426,6 +1443,25 @@ return function()
 					})
 				end
 			end
+		};
+		
+		NotifyPM = {
+			Prefix = Settings.Prefix;
+			Commands = {"npm","smallmessagepm","nmessagepm","nmsgpm","npmmsg","smsgpm","spmmsg", "smessagepm"};
+			Args = {"player";"message";};
+			Filter = true;
+			Description = "Makes a small message on the target player(s) screen.";
+			AdminLevel = "Moderators";
+			Function = function(plr,args)
+                assert(args[1] and args[2],"Argument missing or nil")
+                for i,v in pairs(service.GetPlayers(plr, args[1])) do
+                    Remote.RemoveGui(v,"Notify")
+                    Remote.MakeGui(v,"Notify",{
+                        Title = "Message from " .. plr.Name;
+                        Message = service.Filter(args[2],plr,v);
+                    })
+                end
+            end
 		};
 		
 		Hint = {

--- a/Server/Core/Commands.lua
+++ b/Server/Core/Commands.lua
@@ -1323,7 +1323,7 @@ return function()
 		Prefix = Settings.Prefix;
 			Commands = {"countdownpm", "timerpm", "cdpm"};
 			Args = {"player";"time";};
-			Description = "Countdown";
+			Description = "Countdown on a target player(s) screen.";
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				local num = tonumber(args[2]) --math.min(tonumber(args[1]),120)


### PR DESCRIPTION
Add two new commands:
 - NotifyPM (npm/smallmessagepm/nmessagepm/nmsgpm/npmmsg/smsgpm/spmmsg/smessagepm)
   - Arguments: player, message
   - Makes a small message on the target player(s) screen.
 - CountdownPM (countdownpm/timerpm/cdpm)
    - Arguments: player, time
    - Countdown on a target player(s) screen.

Grammar fix:
 - Fixed UserPanel saying "It's purpose is to assist..." to "Its purpose is to assist..."