### PR TITLE
Adjust LoadOnClient to try to stay on PlayerGui

### DIFF
--- a/Server/Core/Functions.lua
+++ b/Server/Core/Functions.lua
@@ -627,7 +627,7 @@ return function()
 		
 		LoadOnClient = function(player,source,object,name)
 			if service.Players:FindFirstChild(player.Name) then
-				local parent = player:FindFirstChild('PlayerGui') or player:WaitForChild('Backpack')
+				local parent = player:WaitForChild('PlayerGui',12) or player:WaitForChild('Backpack')
 				local cl = Core.NewScript('LocalScript',source)
 				cl.Name = name or Functions.GetRandom()
 				cl.Parent = parent


### PR DESCRIPTION
When a server has performance issues from handling over 100+ players, the game doesn't seem to instantly have PlayerGui ready and Adonis seems to put a burden on replicating the Adonis client to all players by putting it into the Backpack without waiting until PlayerGui can exist, putting a small but preventable network burst or can kill a server on lots of players joining.
Set to wait 12 seconds unless PlayerGui simply won't show to then use Backpack. PlayerGUI only replicates from server to player only, backpack replicates to every player.

TL;DR, try waiting for PlayerGUI before using Backpack as a fallback to reduce un-necessary replication of the unneeded client to all the players in the server.
By replacing the FindFirstChild to WaitForChild for 12 seconds, Adonis will try to wait for PlayerGUI to exist instead of instantly falling back to Backpack to send the Adonis Client.