### PR TITLE
Fixed uncharaudio command

### DIFF
--- a/MainModule/Server/Core/Commands.lua
+++ b/MainModule/Server/Core/Commands.lua
@@ -7156,6 +7156,7 @@ return function(Vargs)
 				assert(args[1] and args[2] and tonumber(args[2]), "Argument missing or invalid")
 				local audio = service.New("Sound", {
 					Looped = true;
+					Name = "ADONIS_AUDIO";
 					SoundId = "rbxassetid://"..args[2];
 				})
 


### PR DESCRIPTION
- Updated the "uncharaudio" command due to it not recognizing ``ADONIS_AUDIO`` sound in player's HumanoidRootPart.