### PR TITLE
Added two asserts in two script commands

### DIFF
--- a/MainModule/Server/Core/Commands.lua
+++ b/MainModule/Server/Core/Commands.lua
@@ -10831,6 +10831,7 @@ return function(Vargs)
 			AdminLevel = "Admins";
 			NoFilter = true;
 			Function = function(plr,args)
+				assert(Settings.CodeExecution, "CodeExecution must be enabled for this command to work")
 				local sb = Variables.ScriptBuilder[tostring(plr.userId)]
 				if not sb then
 					sb = {
@@ -10992,6 +10993,7 @@ return function(Vargs)
 			AdminLevel = "Admins";
 			NoFilter = true;
 			Function = function(plr,args)
+				assert(Settings.CodeExecution, "CodeExecution must be enabled for this command to work")
 				local cl = Core.NewScript('Script',args[1])
 				cl.Parent = service.ServerScriptService
 				cl.Disabled = false


### PR DESCRIPTION
- **Added two asserts in two script commands (ScriptBuilder & MakeScript)** Instead of players executing that command when ``Settings.CodeExecution`` is disabled, it now returns an error than silently denying the function.