### PR TITLE
Added service.SelfEvent

### DIFF
--- a/MainModule/Server/Core/Service.lua
+++ b/MainModule/Server/Core/Service.lua
@@ -1030,6 +1030,7 @@ return function(errorHandler, eventChecker, fenceSpecific)
 		Gamepasses = game:service("GamePassService");
 		Delete = function(obj,num) game:service("Debris"):AddItem(obj,(num or 0)) pcall(obj.Delete, obj) end;
 		RbxEvent = function(signal, func) local event = signal:connect(func) table.insert(RbxEvents, event) return event end;
+		SelfEvent = function(signal, func) local rbxevent = service.RbxEvent(signal, function(...) func(...) end) end;
 		DelRbxEvent = function(signal) for i,v in next,RbxEvents do if v == signal then v:Disconnect() table.remove(RbxEvents, i) end end end;
 		SanitizeString = function(str) str = service.Trim(str) local new = "" for i = 1,#str do if str:sub(i,i) ~= "\n" and str:sub(i,i) ~= "\0" then new = new..str:sub(i,i) end end return new end;
 		Trim = function(str) return str:match("^%s*(.-)%s*$") end; 


### PR DESCRIPTION
**Purpose of service.SelfEvent:**
SelfEvent allows the function to manage the event. *(Helpful for developers who wanted an easier method to disconnect the event)*

- **NOTE** SelfEvent function uses RbxEvent !!

For example:
__Kill client after player parent turns into nil__

```
service.SelfEvent(service.Player.Changed, function(self, p)
    if p == "Parent" and not service.Player.Parent then
        self:Disconnect()
        wait(10)
        client.Kill("Nil detected")
    end
end)
```

Instead of:

```
local event; event = service.RbxEvent(service.Player.Changed, function(p)
    if p == "Parent" and not service.Player.Parent then
        event:Disconnect()
        wait(10)
        client.Kill("Nil detected")
    end
end)
```