### PR TITLE
Made coreclears table read only.

### DIFF
--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -411,7 +411,7 @@ return function()
 			local menuOpened = false
 			local gotGoodTime = tick()
 			local coreNums = {}
-			local coreClears = {
+			local coreClears = service.ReadOnly({
 				FriendStatus = true;
 				ImageButton = false;
 				ButtonHoverText = true;
@@ -427,7 +427,7 @@ return function()
 				ColumnName = true;
 				Frame = false;
 				StatText = false;
-			}
+			})
 			
 			local lookFor = {
 				--'stigma';


### PR DESCRIPTION
Made the CoreClears table read only in the client sided anticheat to harden from tampering.