### PR TITLE
Added another check for Admin.DoCheck

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -71,6 +71,7 @@ return function(Vargs)
 		GroupRanks = {};
 		TempAdmins = {};
 		SlowCache = {};
+		UserIdCache = {};
 		BlankPrefix = false;
 
 		GetTrueRank = function(p, group)
@@ -174,6 +175,26 @@ return function(Vargs)
 					end
 				elseif p.Name == check then
 					return true
+				elseif type(check) == "string" then
+					local cache = Admin.UserIdCache[check]
+					
+					if cache and p.UserId == cache then
+						return true
+					elseif cache==false then
+						return
+					end
+					
+					local suc,userId = pcall(function() return service.Players:GetUserIdFromNameAsync(check) end)
+					
+					if suc and userId then
+						Admin.UserIdCache[check] = userId
+						
+						if p.UserId == userId then
+							return true
+						end
+					elseif not suc then
+						Admin.UserIdCache[check] = false
+					end
 				end
 			elseif cType == "table" and pType == "userdata" and p and p:IsA("Player") then
 				if check.Group and check.Rank then


### PR DESCRIPTION
There was a problem with not recognizing players not receiving their admin after changing their username from settings. For example, if player ``Bob`` has a user id ``325324``, Adonis would still recognize him; however, if he changes his username to something else, Adonis would think Bob isn't Bob anymore. This goes to all settings on Mods/Admins/Owners/Creators with ``Username``, not ``Username: UserId``.