### PR TITLE
Emergency fix for AddAdmin

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -464,17 +464,7 @@ return function(Vargs)
 			local list = Admin.LevelToList(current)
 
 			Admin.RemoveAdmin(p,temp)
-			
-			if Admin.GetUpdatedLevel(p) == 0 then
-				for i,v in next,Settings.Blacklist do
-					if checkTab(p,v) then
-						return false	
-					end
-				end
-			end
-			
 			Admin.SetLevel(p,level)
-			
 			if temp then table.insert(Admin.TempAdmins,p) end
 
 			if list and type(list)=="table" then 
@@ -530,7 +520,7 @@ return function(Vargs)
 			end
 
 			Admin.UpdateCachedLevel(p)
-		end;	
+		end;		
 
 		CheckDonor = function(p)
 			--if not Settings.DonorPerks then return false end


### PR DESCRIPTION
This fixes a bug that caused all commands that give admin (:admin/:pa/:owner/etc) from working, introduced in #221.

There is no new code here, it simply reverts the file back to its previous state.