### PR TITLE
Fixed the issue joritochip was mentioning

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -467,7 +467,7 @@ return function(Vargs)
 			
 			if Admin.GetUpdatedLevel(p) == 0 then
 				for i,v in next,Settings.Blacklist do
-					if checkTab(p,v) then
+					if Admin.DoCheck(p,v) then -- I deeply apologize, it was supposed to be Admin.DoCheck, not checkTab. My bad.... :/
 						return false	
 					end
 				end


### PR DESCRIPTION
#229 didn't necessarily need to destroy the entire code—the whole purpose of ``Settings.Blacklist`` was to prevent the blacklisted users from getting admin. In terms of destroying, it wouldn't be quite beneficial, in fact, that this code is useful. I apologize for one variable that didn't exist and replace it with an existing function.