### PR TITLE
Fix missing filter on multiple commands

### DIFF
--- a/MainModule/Server/Core/Commands.lua
+++ b/MainModule/Server/Core/Commands.lua
@@ -6671,6 +6671,7 @@ return function(Vargs)
 			Prefix = Settings.Prefix;
 			Commands = {"newteam","createteam","maketeam"};
 			Args = {"name";"BrickColor";};
+			Filter = true;
 			Hidden = false;
 			Description = "Make a new team with the specified name and color";
 			Fun = false;
@@ -9710,7 +9711,7 @@ return function(Vargs)
 		Char = {
 			Prefix = Settings.Prefix;
 			Commands = {"char";"character";"appearance";};
-			Args = {"player";"ID or player";};
+			Args = {"player";"username";};
 			Hidden = false;
 			Description = "Changes the target player(s)'s character appearence to <ID/Name>. If you want to supply a UserId, supply with 'userid-', followed by a number after 'userid'.";
 			Fun = false;
@@ -11916,7 +11917,7 @@ return function(Vargs)
 		Bots = {
 			Prefix = Settings.Prefix;
 			Commands = {"bot";"trainingbot"};
-			Args = {"plr";"num";"walk";"attack","friendly","health","speed","damage"};
+			Args = {"player";"num";"walk";"attack","friendly","health","speed","damage"};
 			Hidden = false;
 			Description = "AI bots made for training; ':bot scel 5 true true'";
 			Fun = false;
@@ -12017,7 +12018,7 @@ return function(Vargs)
 		Bots = {
 			Prefix = Settings.Prefix;
 			Commands = {"bot";"tbot";"trainingbot";"bots";"robot";"robots";"dummy";"dummys";"testdummy";"testdummys";"dolls";"doll";};
-			Args = {"plr";"num";"walk";"attk";"swarm";"speed";"dmg";"hp";"dist";};
+			Args = {"player";"num";"walk";"attk";"swarm";"speed";"dmg";"hp";"dist";};
 			Hidden = false;
 			Description = "Configurable AIs made for training";
 			Fun = false;

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -202,14 +202,13 @@ return function(Vargs)
 							local safe = {
 								plr = true;
 								plrs = true;
-								name = true;
-								names = true;
 								username = true;
 								usernames = true;
 								players = true;
 								player = true;
 								users = true;
 								user = true;
+								brickcolor = true;
 							}
 
 							for i,arg in next,args do


### PR DESCRIPTION
Although ``Filter = true`` was set for multiple commands, the "name" argument type was being excluded from the filter which caused some commands, like :makecam, :waypoint, and :maketeam to display unfiltered text to other users.

This pull request will fix this issue and also make a few other command arguments consistent.