### PR TITLE
Update WebPanel.lua

### DIFF
--- a/MainModule/Server/Plugins/WebPanel.lua
+++ b/MainModule/Server/Plugins/WebPanel.lua
@@ -182,6 +182,8 @@ return function()
 			--// Aliases, Perms/Disabling
 			for i,v in pairs(data.CommandOverrides) do
 				local index,command = server.Admin.GetCommand(server.Settings.Prefix..i)
+				if not index or not command then index,command = server.Admin.GetCommand(server.Settings.PlayerPrefix..i) end
+				
 				if index and command then
 					if v.disabled then
 						command.Function = function()


### PR DESCRIPTION
Essentially what was happening was command overrides only worked for admin commands and the GetCommand function requires a prefix, so I had to make it check for a player command if it could not find an admin command.