### PR TITLE
Fixed an issue introduced in #233

### DIFF
--- a/MainModule/Server/Plugins/WebPanel.lua
+++ b/MainModule/Server/Plugins/WebPanel.lua
@@ -244,6 +244,9 @@ return function()
 
 			if code ~= 524 then
 				server.Logs:AddLog("Script", "WebPanel Polling Error: "..msg.." ("..code..")")
+				server.Logs:AddLog("Errors", "WebPanel Polling Error: "..msg.." ("..code..")")
+			else
+				server.Logs:AddLog("Script", "WebPanel Server Timeout")
 			end
 		end
 		wait()

--- a/MainModule/Server/Plugins/WebPanel.lua
+++ b/MainModule/Server/Plugins/WebPanel.lua
@@ -243,7 +243,7 @@ return function()
 			local code, msg = res.StatusCode, res.StatusMessage
 
 			if code ~= 524 then
-				print("WebPanel: Server Timeout")
+				server.Logs:AddLog("Script", "WebPanel Polling Error: "..msg.." ("..code..")")
 			end
 		end
 		wait()


### PR DESCRIPTION
In #233 an issue was introduced where it changed to a debug print instead of keeping it as a script log. Also when it was changed to a debug print it would always log it as web panel polling error when the error could be different.