### PR TITLE
Disable Dropper after first load

### DIFF
--- a/Loader/Loader/Dropper.lua
+++ b/Loader/Loader/Dropper.lua
@@ -7,3 +7,6 @@ loader.Parent = script.Parent
 loader.Name = "\0"
 loader.Archivable = false
 loader.Disabled = false
+
+-- Disable the Dropper so Adonis doesn't try to load on BindToClose()
+script.Disabled = true


### PR DESCRIPTION
Added line 12, which disables the Dropper script after Adonis has loaded, so when the loader runs BindToClose(), it doesn't attempt to load Adonis again.