### PR TITLE
Allowed ServiceSpecific to be used in server

### DIFF
--- a/MainModule/Server/Server.lua
+++ b/MainModule/Server/Server.lua
@@ -452,7 +452,8 @@ return service.NewProxy({__metatable = "Adonis"; __tostring = function() return 
 	server.Core.Loadstring = require(server.Deps.Loadstring)
 	server.HTTP.Trello.API = require(server.Deps.TrelloAPI)
 	server.LoadModule = LoadModule
-
+	server.ServiceSpecific = ServiceSpecific
+			
 	--// Bind cleanup
 	service.DataModel:BindToClose(CleanUp)
 


### PR DESCRIPTION
I find it interesting that plugins could use ``ServiceSpecific`` for necessary connections with functions/variables.