### PR TITLE
:Fly Fix

### DIFF
--- a/MainModule/Server/Core/Commands.lua
+++ b/MainModule/Server/Core/Commands.lua
@@ -8112,10 +8112,6 @@ return function(Vargs)
 				scr.Name = "ADONIS_FLIGHT"
 
 				for i,v in next,Functions.GetPlayers(plr, args[1]) do
-					local human = v.Character:FindFirstChildOfClass("Humanoid")
-					if human then
-						human.PlatformStand = true
-					end
 					local part = v.Character:FindFirstChild("HumanoidRootPart")
 					if part then
 						local oldp = part:FindFirstChild("ADONIS_FLIGHT_POSITION")
@@ -8187,10 +8183,6 @@ return function(Vargs)
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				for i,v in pairs(service.GetPlayers(plr,args[1])) do
-					local human = v.Character:FindFirstChildOfClass("Humanoid")
-					if human then
-						human.PlatformStand = false
-					end
 					local part = v.Character:FindFirstChild("HumanoidRootPart")
 					if part then
 						local oldp = part:FindFirstChild("ADONIS_FLIGHT_POSITION")


### PR DESCRIPTION
Bug here was that the server set the player's PlatformStand to true, but the Fly localscript only toggled it locally, causing a bug where players couldn't sit in seats because they were still in PlatformStand server-side.
I removed the lines that did this as the fly localscript should be fine handling this by itself.
(This is my first proper pull request btw :P)