### PR TITLE
Removed client print statements from ;dizzy

### DIFF
--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -111,15 +111,12 @@ return function()
 		
 		Dizzy = function(speed)
 			service.StopLoop("DizzyLoop")
-			print("dizzy")
 			if speed then
-				print("start")
 				local cam = workspace.CurrentCamera
 				local last = tick()
 				local rot = 0
 				local flip = false
 				service.StartLoop("DizzyLoop","RenderStepped",function()
-					print("in loop")
 					local dt = tick() - last
 					if flip then
 						rot = rot+math.rad(speed*dt)


### PR DESCRIPTION
The print statements fired whenever the player had ;dizzy ran on them and every time the command looped, causing hundreds of logs on the client.

They are not needed for the commands operation - as far as I know anyway...