### PR TITLE
Added Place Owner (Level 5) to the LevelToListName func and :broadcast

### DIFF
--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -65,6 +65,20 @@ return function(Vargs, env)
 			end
 		};
 
+		Broadcast = {
+			Prefix = Settings.Prefix;
+			Commands = {"broadcast";"bc";};
+			Args = {"Message";};
+			Filter = true;
+			Description = "Makes a message in the chat window";
+			AdminLevel = "Moderators";
+			Function = function(plr,args)
+				for i,v in next,service.GetPlayers(plr,"all") do
+					Remote.Send(v,"Function","ChatMessage","["..Settings.SystemTitle.."] "..service.Filter(args[1],plr,v),Color3.new(1,64/255,77/255))
+				end
+			end
+		};
+				
 		ShutdownLogs = {
 			Prefix = Settings.Prefix;
 			Commands = {"shutdownlogs";"shutdownlog";"slogs";"shutdowns";};

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -71,7 +71,7 @@ return function(Vargs, env)
 			Args = {"Message";};
 			Filter = true;
 			Description = "Makes a message in the chat window";
-			AdminLevel = "Moderators";
+			AdminLevel = "Admins";
 			Function = function(plr,args)
 				for i,v in next,service.GetPlayers(plr,"all") do
 					Remote.Send(v,"Function","ChatMessage","["..Settings.SystemTitle.."] "..service.Filter(args[1],plr,v),Color3.new(1,64/255,77/255))

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -265,6 +265,7 @@ return function(Vargs)
 				[2] = "Admins";
 				[3] = "Owners";
 				[4] = "Creators";
+				[5] = "Place Owner";
 			})[lvl]
 		end;
 


### PR DESCRIPTION
If future commands or plugins use the LevelToListName function, it may break if run by or on the place owner, the level 5 which is given to the player with the isPlaceOwner() boolean true, is now converted to "Place Owner" in the LevelToListName function

Added :broadcast, which is essentially :chatnotify, but for admins, utilizing the System Title, and automatically running the command on everyone