### PR TITLE
Player-Related Utility Commands

### DIFF
--- a/MainModule/Client/UI/Default/Friends.lua
+++ b/MainModule/Client/UI/Default/Friends.lua
@@ -1,0 +1,88 @@
+-- Expertcoder2
+-- 26/03/2021
+
+
+client = nil
+service = nil
+
+return function(data)
+
+	local window = client.UI.Make("Window",{
+		Name  = "OnlineFriends";
+		Title = "Online Friends";
+		Size  = {390, 320};
+		MinSize = {180, 120};
+		AllowMultiple = false;
+	})
+
+	do
+		local function locationTypeToStr(int)
+			return ({
+				[0] = "Mobile Website";
+				[1] = "Mobile InGame";
+				[2] = "Webpage";
+				[3] = "Studio";
+				[4] = "InGame";
+				[5] = "Xbox";
+				[6] = "Team Create";
+			})[int]
+		end;
+
+		local friendDictionary = game:GetService("Players").LocalPlayer:GetFriendsOnline()
+		local sortedFriends = {}
+		local friendInfo = {}
+
+		for _, item in pairs(friendDictionary) do
+			table.insert(sortedFriends, item.UserName)
+			friendInfo[item.UserName] = {id=item.VisitorId;displayName=item.DisplayName;lastLocation=item.LastLocation;locationType=item.LocationType;}
+		end
+
+		table.sort(sortedFriends)
+		
+		local i = 2
+		local friendCount = 0
+		for _, friendName in ipairs(sortedFriends) do
+			friendCount = friendCount + 1
+			local entryText = ""
+			if friendName == friendInfo[friendName].displayName then
+				entryText = friendName
+			else
+				entryText = friendName.." ("..friendInfo[friendName].displayName..")"
+			end
+			local entry = window:Add("TextLabel", {
+				Text = "             "..entryText;
+				ToolTip = "Location: "..friendInfo[friendName].lastLocation;
+				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
+				Size = UDim2.new(1, -10, 0, 30);
+				Position = UDim2.new(0, 5, 0, (30*(i-1))+5);
+				TextXAlignment = "Left";
+			})
+			entry:Add("TextLabel", {
+				Text = " "..locationTypeToStr(friendInfo[friendName].locationType).."  ";
+				BackgroundTransparency = 1;
+				Size = UDim2.new(0, 120, 1, 0);
+				Position = UDim2.new(1, -120, 0, 0);
+				TextXAlignment = "Right";
+			})
+			spawn(function()
+				entry:Add("ImageLabel", {
+					Image = game:GetService("Players"):GetUserThumbnailAsync(friendInfo[friendName].id, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size420x420);
+					BackgroundTransparency = 1;
+					Size = UDim2.new(0, 30, 0, 30);
+					Position = UDim2.new(0, 0, 0, 0);
+				})
+			end)
+			i = i + 1
+		end
+		
+		window:Add("TextLabel", {
+			Size = UDim2.new(1, -10, 0, 25);
+			Position = UDim2.new(0, 5, 0, 5);
+			BackgroundTransparency = 0.5;
+			Text = friendCount.." friends are currently online.";
+		})
+	end
+
+	window:ResizeCanvas(false, true, false, false, 5, 5)
+	window:Ready()
+end

--- a/MainModule/Client/UI/Default/Friends.lua
+++ b/MainModule/Client/UI/Default/Friends.lua
@@ -1,5 +1,6 @@
 -- Expertcoder2
--- 26/03/2021
+-- Created: 26/03/2021
+-- Updated: 28/03/2021
 
 
 client = nil
@@ -39,7 +40,7 @@ return function(data)
 
 		table.sort(sortedFriends)
 		
-		local i = 2
+		local i = 1
 		local friendCount = 0
 		for _, friendName in ipairs(sortedFriends) do
 			friendCount = friendCount + 1
@@ -74,13 +75,7 @@ return function(data)
 			end)
 			i = i + 1
 		end
-		
-		window:Add("TextLabel", {
-			Size = UDim2.new(1, -10, 0, 25);
-			Position = UDim2.new(0, 5, 0, 5);
-			BackgroundTransparency = 0.5;
-			Text = friendCount.." friends are currently online.";
-		})
+		window:SetTitle("Online Friends ("..friendCount..")")
 	end
 
 	window:ResizeCanvas(false, true, false, false, 5, 5)

--- a/MainModule/Client/UI/Default/Inspect.lua
+++ b/MainModule/Client/UI/Default/Inspect.lua
@@ -1,5 +1,6 @@
 -- Expertcoder2
--- 20/03/2021
+-- Created 20/03/2021
+-- Updated 28/03/2021
 
 
 client = nil
@@ -23,13 +24,53 @@ local function msTypeToStr(enum)
 	end
 end
 
+local function assetTypeToStr(int)
+	return ({
+		[2] = "T-Shirt";
+		[8] = "Hat";
+		[11] = "Shirt";
+		[12] = "Pants";
+		[17] = "Head";
+		[18] = "Face";
+		[19] = "Gear";
+		[27] = "Torso";
+		[28] = "Right Arm";
+		[29] = "Left Arm";
+		[30] = "Left Leg";
+		[31] = "Right Leg";
+		[41] = "Hair";
+		[42] = "Face Accessory";
+		[42] = "Face Accessory";
+		[43] = "Neck Accessory";
+		[44] = "Shoulder Accessory";
+		[45] = "Front Accessory";
+		[46] = "Back Accessory";
+		[47] = "Waist Accessory";
+		[48] = "Climb Animation";
+		[49] = "Death Animation";
+		[50] = "Fall Animation";
+		[51] = "Idle Animation";
+		[52] = "Jump Animation";
+		[53] = "Run Animation";
+		[54] = "Swim Animation";
+		[55] = "Walk Animation";
+		[56] = "Pose Animation";
+		[61] = "Emote Animation";
+
+	})[int] or "Unknown"
+end
+
+local function formatColor3(color)
+	return "RGB "..math.floor(color.r*255)..", "..math.floor(color.g*255)..", "..math.floor(color.b*255)
+end
+
 return function(data)
 	local player = data.Target
 
 	local window = client.UI.Make("Window", {
 		Name  = "Inspect_"..player.UserId;
 		Title = "Inspect ("..player.Name..")";
-		Size  = {400, 350};
+		Size  = {400, 360};
 		AllowMultiple = false;
 	})
 
@@ -42,8 +83,8 @@ return function(data)
 		Text = "General"
 	})
 
-	local backgroundtab = tabFrame:NewTab("Background", {
-		Text = "Background"
+	local avatartab = tabFrame:NewTab("Avatar", {
+		Text = "Avatar"
 	})
 
 	local friendstab = tabFrame:NewTab("Friends", {
@@ -84,38 +125,21 @@ return function(data)
 		addGeneralEntry("User ID:", player.UserId, "The player's unique Roblox user ID")
 		addGeneralEntry("Account Age:", player.AccountAge, "How long (in days) the player has been registered on Roblox")
 		addGeneralEntry("Membership:", msTypeToStr(player.MembershipType), "The player's Roblox membership type")
-
-		spawn(function()
-			generaltab:Add("ImageLabel", {
-				Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size420x420);
-				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
-				Size = UDim2.new(0, 90, 0, 90);
-				Position = UDim2.new(0, 5, 0, (30*(i-1))+10);
-			})
-			generaltab:Add("ImageLabel", {
-				Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.AvatarBust, Enum.ThumbnailSize.Size420x420);
-				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
-				Size = UDim2.new(0, 90, 0, 90);
-				Position = UDim2.new(0, 100, 0, (30*(i-1))+10);
-			})
-			generaltab:Add("ImageLabel", {
-				Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.AvatarThumbnail, Enum.ThumbnailSize.Size420x420);
-				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
-				Size = UDim2.new(0, 90, 0, 90);
-				Position = UDim2.new(0, 195, 0, (30*(i-1))+10);
-			})
-		end)
-
+		addGeneralEntry("Safe Chat Enabled:", boolToStr(data.SafeChat), "Does the player have safe chat enabled?")
+		addGeneralEntry("Can Chat:", boolToStr(data.CanChat), "Does the player's account settings allow them to chat?")
+		addGeneralEntry("Locale ID:", player.LocaleId, "The player's locale ID")
+		addGeneralEntry("Country/Region Code:", data.Code, "The player's country or region code based on geolocation")
+		addGeneralEntry("Is Roblox Staff:", boolToStr(player:IsInGroup(1200769) or player:IsInGroup(2868472)), "Is the player an official Roblox employee?")
 
 		generaltab:ResizeCanvas(false, true, false, false, 5, 5)
 	end
-	
+
 	window:Ready()
 
 	do
 		local i = 1
-		local function addBackgroundEntry(name, value, toolTip)
-			local entry = backgroundtab:Add("TextLabel", {
+		local function addAvatarEntry(name, valueType, value, toolTip)
+			local entry = avatartab:Add("TextLabel", {
 				Text = "  "..name.." ";
 				ToolTip = toolTip;
 				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
@@ -123,22 +147,46 @@ return function(data)
 				Position = UDim2.new(0, 5, 0, (30*(i-1))+5);
 				TextXAlignment = "Left";
 			})
-			entry:Add("TextLabel", {
-				Text = " "..value.."  ";
-				BackgroundTransparency = 1;
-				Size = UDim2.new(0, 120, 1, 0);
-				Position = UDim2.new(1, -120, 0, 0);
-				TextXAlignment = "Right";
-			})
+			entry:Add(valueType, value)
+
 			i = i + 1
 		end
+		
+		local humDesc = game:GetService("Players"):GetHumanoidDescriptionFromUserId(player.UserId)
+		
+		addAvatarEntry("Head Shot Thumbnail:", "ImageLabel", {BackgroundTransparency = 1;Size = UDim2.new(0, 30, 1, 0);Position = UDim2.new(1, -30, 0, 0);Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size48x48);})
+		addAvatarEntry("Avatar Bust Thumbnail:", "ImageLabel", {BackgroundTransparency = 1;Size = UDim2.new(0, 30, 1, 0);Position = UDim2.new(1, -30, 0, 0);Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.AvatarBust, Enum.ThumbnailSize.Size48x48);})
+		addAvatarEntry("Avatar Thumbnail:", "ImageLabel", {BackgroundTransparency = 1;Size = UDim2.new(0, 30, 1, 0);Position = UDim2.new(1, -30, 0, 0);Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.AvatarThumbnail, Enum.ThumbnailSize.Size48x48);})
+		addAvatarEntry("Body Type Scale:", "TextLabel", {Text = " "..humDesc.BodyTypeScale.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "The factor by which the shape of the Humanoid rig is interpolated from the standard R15 body shape shape (0) to a taller and more slender body type (1)")
+		addAvatarEntry("Depth Scale:", "TextLabel", {Text = " "..humDesc.DepthScale.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "The factor by which the depth (back-to-front distance) of the Humanoid rig is scaled")
+		addAvatarEntry("Height Scale:", "TextLabel", {Text = " "..humDesc.HeightScale.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "The factor by which the height (top-to-bottom distance) of the Humanoid rig is scaled")
+		addAvatarEntry("Width Scale:", "TextLabel", {Text = " "..humDesc.WidthScale.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "The factor by which the width (left-to-right distance) of the Humanoid is scaled")
+		addAvatarEntry("Head Scale:", "TextLabel", {Text = " "..humDesc.HeadScale.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "The factor the Head of the Humanoid is scaled")
+		addAvatarEntry("Proportion Scale:", "TextLabel", {Text = " "..humDesc.ProportionScale.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "How wide (0) or narrow (1) the Humanoid rig is")
+		addAvatarEntry("Head Color:", "TextLabel", {Text = " "..formatColor3(humDesc.HeadColor).."  ";TextColor3=humDesc.HeadColor;BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";})
+		addAvatarEntry("Torso Color:", "TextLabel", {Text = " "..formatColor3(humDesc.TorsoColor).."  ";TextColor3=humDesc.TorsoColor;BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";})
+		addAvatarEntry("Left Arm Color:", "TextLabel", {Text = " "..formatColor3(humDesc.LeftArmColor).."  ";TextColor3=humDesc.LeftArmColor;BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";})
+		addAvatarEntry("Right Arm Color:", "TextLabel", {Text = " "..formatColor3(humDesc.RightArmColor).."  ";TextColor3=humDesc.RightArmColor;BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";})
+		addAvatarEntry("Left Leg Color:", "TextLabel", {Text = " "..formatColor3(humDesc.LeftLegColor).."  ";TextColor3=humDesc.LeftLegColor;BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";})
+		addAvatarEntry("Right Leg Color:", "TextLabel", {Text = " "..formatColor3(humDesc.RightLegColor).."  ";TextColor3=humDesc.RightLegColor;BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";})
 
-		addBackgroundEntry("Safe Chat Enabled:", boolToStr(data.SafeChat), "Does the player have safe chat enabled?")
-		addBackgroundEntry("Locale ID:", player.LocaleId, "The player's locale ID")
-		addBackgroundEntry("Country/Region Code:", data.Code, "The player's country or region code based on geolocation")
-		addBackgroundEntry("Is Roblox Staff:", boolToStr(player:IsInGroup(1200769) or player:IsInGroup(2868472)), "Is the player an official Roblox employee?")
+		avatartab:ResizeCanvas(false, true, false, false, 5, 5)
 
-		backgroundtab:ResizeCanvas(false, true, false, false, 5, 5)
+		i = i + 1
+
+		spawn(function()
+			for _, category in ipairs({{humDesc.ClimbAnimation,humDesc.Face,humDesc.FallAnimation,humDesc.Head,humDesc.IdleAnimation,humDesc.JumpAnimation,humDesc.LeftArm,humDesc.LeftLeg,humDesc.Pants,humDesc.RightArm,humDesc.RightLeg,humDesc.RunAnimation,humDesc.Shirt,humDesc.SwimAnimation,humDesc.Torso,humDesc.WalkAnimation},string.split(humDesc.BackAccessory),string.split(humDesc.FaceAccessory),string.split(humDesc.FrontAccessory),string.split(humDesc.HairAccessory),string.split(humDesc.HatAccessory),string.split(humDesc.ShouldersAccessory),string.split(humDesc.WaistAccessory),string.split(humDesc.NeckAccessory)}) do
+				for _, itemId in ipairs(category) do
+					if itemId and itemId ~= 0 and tonumber(itemId) ~= nil then
+						local info = game:GetService("MarketplaceService"):GetProductInfo(itemId)
+						addAvatarEntry(info.Name, "TextLabel", {Text = " "..assetTypeToStr(info.AssetTypeId).."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "ID: "..itemId.." | Creator: "..(info.Creator.Name or ("[None]")).." | Price: "..(info.PriceInRobux or "0").." Robux")
+					end
+				end
+			end
+
+			avatartab:ResizeCanvas(false, true, false, false, 5, 5)
+		end)
+
 	end
 
 	do
@@ -269,10 +317,12 @@ return function(data)
 			i = i + 1
 		end
 
+		addGameEntry("Source Place ID:", data.SourcePlace, "The ID of the place from which the player was teleported to this game, if applicable")
 		addGameEntry("Character Appearance ID:", player.CharacterAppearanceId, "The player's character appearance ID")
 		addGameEntry("Auto Jump Enabled:", boolToStr(player.AutoJumpEnabled), "Does the player have auto jump enabled?")
 		addGameEntry("Camera Max Zoom Distance:", tostring(player.CameraMaxZoomDistance), "How far in studs the player can zoom their camera")
 		addGameEntry("Camera Min Zoom Distance:", tostring(player.CameraMinZoomDistance), "How close in studs the player can zoom their camera")
+		addGameEntry("Character Appearance ID:", player.CharacterAppearanceId, "The player's character appearance ID")
 		addGameEntry("Gameplay Paused:", boolToStr(player.GameplayPaused), "Is the player's gameplay paused?")
 		addGameEntry("Character Exists:", boolToStr(player.Character), "Does the player have a character?")
 

--- a/MainModule/Client/UI/Default/Inspect.lua
+++ b/MainModule/Client/UI/Default/Inspect.lua
@@ -1,0 +1,306 @@
+-- Expertcoder2
+-- 20/03/2021
+
+
+client = nil
+service = nil
+
+local function boolToStr(bool)
+	if bool then
+		return "Yes"
+	else
+		return "No"
+	end
+end
+
+local function msTypeToStr(enum)
+	if enum == Enum.MembershipType.None then
+		return "None"
+	elseif enum == Enum.MembershipType.Premium then
+		return "Premium"
+	else
+		return "?"
+	end
+end
+
+return function(data)
+	local player = data.Target
+
+	local window = client.UI.Make("Window", {
+		Name  = "Inspect_"..player.UserId;
+		Title = "Inspect ("..player.Name..")";
+		Size  = {400, 350};
+		AllowMultiple = false;
+	})
+
+	local tabFrame = window:Add("TabFrame", {
+		Size = UDim2.new(1, -10, 1, -10);
+		Position = UDim2.new(0, 5, 0, 5);
+	})
+
+	local generaltab = tabFrame:NewTab("General", {
+		Text = "General"
+	})
+
+	local backgroundtab = tabFrame:NewTab("Background", {
+		Text = "Background"
+	})
+
+	local friendstab = tabFrame:NewTab("Friends", {
+		Text = "Friends"
+	})
+
+	local adonistab = tabFrame:NewTab("Adonis", {
+		Text = "Adonis"
+	})
+
+	local gametab = tabFrame:NewTab("Game", {
+		Text = "Game"
+	})
+
+	do
+		local i = 1
+		local function addGeneralEntry(name, value, toolTip)
+			local entry = generaltab:Add("TextLabel", {
+				Text = "  "..name.." ";
+				ToolTip = toolTip;
+				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
+				Size = UDim2.new(1, -10, 0, 30);
+				Position = UDim2.new(0, 5, 0, (30*(i-1))+5);
+				TextXAlignment = "Left";
+			})
+			entry:Add("TextLabel", {
+				Text = " "..value.."  ";
+				BackgroundTransparency = 1;
+				Size = UDim2.new(0, 120, 1, 0);
+				Position = UDim2.new(1, -120, 0, 0);
+				TextXAlignment = "Right";
+			})
+
+			i = i + 1
+		end
+
+		addGeneralEntry("Username:", player.Name, "The player's Roblox username")
+		addGeneralEntry("User ID:", player.UserId, "The player's unique Roblox user ID")
+		addGeneralEntry("Account Age:", player.AccountAge, "How long (in days) the player has been registered on Roblox")
+		addGeneralEntry("Membership:", msTypeToStr(player.MembershipType), "The player's Roblox membership type")
+
+		spawn(function()
+			generaltab:Add("ImageLabel", {
+				Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size420x420);
+				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
+				Size = UDim2.new(0, 90, 0, 90);
+				Position = UDim2.new(0, 5, 0, (30*(i-1))+10);
+			})
+			generaltab:Add("ImageLabel", {
+				Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.AvatarBust, Enum.ThumbnailSize.Size420x420);
+				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
+				Size = UDim2.new(0, 90, 0, 90);
+				Position = UDim2.new(0, 100, 0, (30*(i-1))+10);
+			})
+			generaltab:Add("ImageLabel", {
+				Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.AvatarThumbnail, Enum.ThumbnailSize.Size420x420);
+				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
+				Size = UDim2.new(0, 90, 0, 90);
+				Position = UDim2.new(0, 195, 0, (30*(i-1))+10);
+			})
+		end)
+
+
+		generaltab:ResizeCanvas(false, true, false, false, 5, 5)
+	end
+	
+	window:Ready()
+
+	do
+		local i = 1
+		local function addBackgroundEntry(name, value, toolTip)
+			local entry = backgroundtab:Add("TextLabel", {
+				Text = "  "..name.." ";
+				ToolTip = toolTip;
+				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
+				Size = UDim2.new(1, -10, 0, 30);
+				Position = UDim2.new(0, 5, 0, (30*(i-1))+5);
+				TextXAlignment = "Left";
+			})
+			entry:Add("TextLabel", {
+				Text = " "..value.."  ";
+				BackgroundTransparency = 1;
+				Size = UDim2.new(0, 120, 1, 0);
+				Position = UDim2.new(1, -120, 0, 0);
+				TextXAlignment = "Right";
+			})
+			i = i + 1
+		end
+
+		addBackgroundEntry("Safe Chat Enabled:", boolToStr(data.SafeChat), "Does the player have safe chat enabled?")
+		addBackgroundEntry("Locale ID:", player.LocaleId, "The player's locale ID")
+		addBackgroundEntry("Country/Region Code:", data.Code, "The player's country or region code based on geolocation")
+		addBackgroundEntry("Is Roblox Staff:", boolToStr(player:IsInGroup(1200769) or player:IsInGroup(2868472)), "Is the player an official Roblox employee?")
+
+		backgroundtab:ResizeCanvas(false, true, false, false, 5, 5)
+	end
+
+	do
+		local function iterPageItems(pages)
+			return coroutine.wrap(function()
+				local pagenum = 1
+				while true do
+					for _, item in ipairs(pages:GetCurrentPage()) do
+						coroutine.yield(item, pagenum)
+					end
+					if pages.IsFinished then
+						break
+					end
+					pages:AdvanceToNextPageAsync()
+					pagenum = pagenum + 1
+				end
+			end)
+		end
+
+		local friendPages = service.Players:GetFriendsAsync(player.UserId)
+		local sortedFriends = {}
+		local friendInfo = {}
+
+		for item, pageNo in iterPageItems(friendPages) do
+			table.insert(sortedFriends, item.Username)
+			friendInfo[item.Username] = {id=item.Id;displayName=item.DisplayName;isOnline=item.IsOnline;}
+		end
+
+		table.sort(sortedFriends)
+
+		local i = 2
+		local friendCount = 0
+		local onlineCount = 0
+		for _, friendName in ipairs(sortedFriends) do
+			friendCount = friendCount + 1
+			local entryText = ""
+			if friendName == friendInfo[friendName].displayName then
+				entryText = friendName
+			else
+				entryText = friendName.." ("..friendInfo[friendName].displayName..")"
+			end
+			local entry = friendstab:Add("TextLabel", {
+				Text = "             "..entryText;
+				ToolTip = "ID: "..friendInfo[friendName].id;
+				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
+				Size = UDim2.new(1, -10, 0, 30);
+				Position = UDim2.new(0, 5, 0, (30*(i-1))+5);
+				TextXAlignment = "Left";
+			})
+			if friendInfo[friendName].isOnline then
+				onlineCount = onlineCount + 1
+				entry:Add("TextLabel", {
+					Text = " Online  ";
+					BackgroundTransparency = 1;
+					Size = UDim2.new(0, 120, 1, 0);
+					Position = UDim2.new(1, -120, 0, 0);
+					TextXAlignment = "Right";
+				})
+			end
+			spawn(function()
+				entry:Add("ImageLabel", {
+					Image = game:GetService("Players"):GetUserThumbnailAsync(friendInfo[friendName].id, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size48x48);
+					BackgroundTransparency = 1;
+					Size = UDim2.new(0, 30, 0, 30);
+					Position = UDim2.new(0, 0, 0, 0);
+				})
+			end)
+			i = i + 1
+		end
+
+		friendstab:Add("TextLabel", {
+			Size = UDim2.new(1, -10, 0, 25);
+			Position = UDim2.new(0, 5, 0, 5);
+			BackgroundTransparency = 0.5;
+			Text = friendCount.." Friends | "..onlineCount.." Online";
+		})
+
+		friendstab:ResizeCanvas(false, true, false, false, 5, 5)
+	end
+
+	do
+		local i = 1
+		local function addAdonisEntry(name, value, toolTip)
+			local entry = adonistab:Add("TextLabel", {
+				Text = "  "..name.." ";
+				ToolTip = toolTip;
+				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
+				Size = UDim2.new(1, -10, 0, 30);
+				Position = UDim2.new(0, 5, 0, (30*(i-1))+5);
+				TextXAlignment = "Left";
+			})
+			entry:Add("TextLabel", {
+				Text = " "..value.."  ";
+				BackgroundTransparency = 1;
+				Size = UDim2.new(0, 120, 1, 0);
+				Position = UDim2.new(1, -120, 0, 0);
+				TextXAlignment = "Right";
+			})
+			i = i + 1
+		end
+
+		addAdonisEntry("Admin Level:", data.AdminLevel, "The player's Adonis rank")
+		addAdonisEntry("Donor:", boolToStr(data.IsDonor), "Is the player an Adonis donor?")
+		addAdonisEntry("Muted:", boolToStr(data.IsMuted), "Is the player muted? (IGNORES TRELLO MUTELIST)")
+		addAdonisEntry("Banned:", boolToStr(data.IsBanned), "Is the player banned? (IGNORES TRELLO BANLIST)")
+
+		adonistab:ResizeCanvas(false, true, false, false, 5, 5)
+	end
+
+	do
+		local i = 1
+		local function addGameEntry(name, value, toolTip)
+			local entry = gametab:Add("TextLabel", {
+				Text = "  "..name.." ";
+				ToolTip = toolTip;
+				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
+				Size = UDim2.new(1, -10, 0, 30);
+				Position = UDim2.new(0, 5, 0, (30*(i-1))+5);
+				TextXAlignment = "Left";
+			})
+			entry:Add("TextLabel", {
+				Text = " "..value.."  ";
+				BackgroundTransparency = 1;
+				Size = UDim2.new(0, 120, 1, 0);
+				Position = UDim2.new(1, -120, 0, 0);
+				TextXAlignment = "Right";
+			})
+			i = i + 1
+		end
+
+		addGameEntry("Character Appearance ID:", player.CharacterAppearanceId, "The player's character appearance ID")
+		addGameEntry("Auto Jump Enabled:", boolToStr(player.AutoJumpEnabled), "Does the player have auto jump enabled?")
+		addGameEntry("Camera Max Zoom Distance:", tostring(player.CameraMaxZoomDistance), "How far in studs the player can zoom their camera")
+		addGameEntry("Camera Min Zoom Distance:", tostring(player.CameraMinZoomDistance), "How close in studs the player can zoom their camera")
+		addGameEntry("Gameplay Paused:", boolToStr(player.GameplayPaused), "Is the player's gameplay paused?")
+		addGameEntry("Character Exists:", boolToStr(player.Character), "Does the player have a character?")
+
+		local tools = {}
+		table.insert(tools,{Text="==== "..player.Name.."'s Tools ====",Desc=player.Name:lower()})
+		for k,t in pairs(player.Backpack:children()) do
+			if t:IsA("Tool") then
+				table.insert(tools,{Text=t.Name,Desc="Class: "..t.ClassName.." | ToolTip: "..t.ToolTip.." | Name: "..t.Name})
+			elseif t:IsA("HopperBin") then
+				table.insert(tools,{Text=t.Name,Desc="Class: "..t.ClassName.." | BinType: "..tostring(t.BinType).." | Name: "..t.Name})
+			else
+				table.insert(tools,{Text=t.Name,Desc="Class: "..t.ClassName.." | Name: "..t.Name})
+			end
+		end
+
+		gametab:Add("TextButton", {
+			Text = "View Tools";
+			BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
+			Size = UDim2.new(1, -10, 0, 35);
+			Position = UDim2.new(0, 5, 0, (30*(i-1))+10);
+			OnClicked = function()
+				client.UI.Make("List", {
+					Title = player.Name;
+					Table = tools;
+				})
+			end
+		})
+
+		gametab:ResizeCanvas(false, true, false, false, 5, 5)
+	end
+end

--- a/MainModule/Client/UI/Default/Inspect.lua
+++ b/MainModule/Client/UI/Default/Inspect.lua
@@ -125,6 +125,7 @@ return function(data)
 		addGeneralEntry("User ID:", player.UserId, "The player's unique Roblox user ID")
 		addGeneralEntry("Account Age:", player.AccountAge, "How long (in days) the player has been registered on Roblox")
 		addGeneralEntry("Membership:", msTypeToStr(player.MembershipType), "The player's Roblox membership type")
+		i = i + 1
 		addGeneralEntry("Safe Chat Enabled:", boolToStr(data.SafeChat), "Does the player have safe chat enabled?")
 		addGeneralEntry("Can Chat:", boolToStr(data.CanChat), "Does the player's account settings allow them to chat?")
 		addGeneralEntry("Locale ID:", player.LocaleId, "The player's locale ID")

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1268,5 +1268,20 @@ return function(Vargs, env)
 				end
 			end
 		};
+		
+		PromptPremiumPurchase = {
+			Prefix = Settings.Prefix;
+			Commands = {"promptpremiumpurchase";"premiumpurchaseprompt";};
+			Args = {"player"};
+			Description = "Opens the Roblox Premium purchase prompt for the target player(s)";
+			Hidden = false;
+			Fun = false;
+			AdminLevel = "Admins";
+			Function = function(plr,args)
+				for i,v in pairs(service.GetPlayers(plr,args[1])) do
+					game:GetService("MarketplaceService"):PromptPremiumPurchase(v)
+				end
+			end
+		}
 	}
 end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6244,5 +6244,41 @@ return function(Vargs, env)
 				end
 			end
 		};
+		
+		Inspect = {
+			Prefix = Settings.Prefix;
+			Commands = {"inspect";"playerinfo"};
+			Args = {"player"};
+			Description = "Shows comphrehensive information about a player";
+			Hidden = false;
+			Fun = false;
+			AdminLevel = "Moderator";
+			Function = function(plr,args)
+				local function checkSafeChat(player)
+					local textToFilter = "1234"
+					if game:GetService("TextService"):FilterStringAsync(textToFilter, player.UserId):GetNonChatStringForUserAsync(player.UserId) == textToFilter then
+						return false
+					else
+						return true
+					end
+				end
+				for i,v in pairs(service.GetPlayers(plr,args[1])) do
+					local isMuted = false
+					if table.find(Settings.Muted, v.Name..":"..v.UserId) then
+						isMuted = true
+					else
+						isMuted = false
+					end
+					local isBanned = false
+					if table.find(Settings.Banned, v.Name..":"..v.UserId) then
+						isBanned = true
+					else
+						isBanned = false
+					end
+					Remote.MakeGui(plr,"Inspect",{Target=v;SafeChat=checkSafeChat(v);AdminLevel="["..server.Admin.GetLevel(v).."] "..Admin.LevelToListName(Admin.GetLevel(v));IsDonor=service.MarketPlace:UserOwnsGamePassAsync(v.UserId, server.Variables.DonorPass[1]);IsMuted=isMuted;IsBanned=isBanned;Code=game:GetService("LocalizationService"):GetCountryRegionForPlayerAsync(v) or "[Error]";})
+				end
+			end
+		};
+	
 	}
 end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6275,7 +6275,7 @@ return function(Vargs, env)
 					else
 						isBanned = false
 					end
-					Remote.MakeGui(plr,"Inspect",{Target=v;SafeChat=checkSafeChat(v);AdminLevel="["..server.Admin.GetLevel(v).."] "..Admin.LevelToListName(Admin.GetLevel(v));IsDonor=service.MarketPlace:UserOwnsGamePassAsync(v.UserId, server.Variables.DonorPass[1]);IsMuted=isMuted;IsBanned=isBanned;Code=game:GetService("LocalizationService"):GetCountryRegionForPlayerAsync(v) or "[Error]";})
+					server.Remote.MakeGui(plr,"Inspect",{Target=v;SafeChat=checkSafeChat(v);CanChat=game:GetService("Chat"):CanUserChatAsync(v.UserId) or "[Error]";AdminLevel="["..server.Admin.GetLevel(v).."] "..server.Admin.LevelToListName(server.Admin.GetLevel(v));IsDonor=service.MarketPlace:UserOwnsGamePassAsync(v.UserId, server.Variables.DonorPass[1]);IsMuted=isMuted;IsBanned=isBanned;Code=game:GetService("LocalizationService"):GetCountryRegionForPlayerAsync(v) or "[Error]";SourcePlace=v:GetJoinData().SourcePlaceId or "N/A";})
 				end
 			end
 		};

--- a/MainModule/Server/Commands/Owners.lua
+++ b/MainModule/Server/Commands/Owners.lua
@@ -379,6 +379,21 @@ return function(Vargs, env)
 				Remote.MakeLocal(plr,Deps.Assets.Dex_Explorer:Clone(),"PlayerGui")
 			end
 		};
+																		
+		PromptInvite = {
+			Prefix = Settings.Prefix;
+			Commands = {"promptinvite";"inviteprompt";"forceinvite"};
+			Args = {"player"};
+			Description = "Opens the friend invitation popup for the target player(s), same as them running !invite";
+			Hidden = false;
+			Fun = false;
+			AdminLevel = "Owners";
+			Function = function(plr,args)
+				for i,v in pairs(service.GetPlayers(plr,args[1])) do
+					game:GetService("SocialService"):PromptGameInvite(v)
+				end
+			end
+		};
 
 		--[[FullShutdown = {
 			Prefix = Settings.Prefix;

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -917,5 +917,31 @@ return function(Vargs, env)
 				Remote.MakeGui(plr,"UserPanel",{Tab = "Aliases"})
 			end
 		};
+		
+		Invite = {
+			Prefix = Settings.PlayerPrefix;
+			Commands = {"invite";"invitefriends"};
+			Args = {};
+			Description = "Invite your friends into the game";
+			Hidden = false;
+			Fun = false;
+			AdminLevel = "Player";
+			Function = function(plr,args)
+				game:GetService("SocialService"):PromptGameInvite(plr)
+			end
+		};
+	
+		OnlineFriends = {
+			Prefix = Settings.PlayerPrefix;
+			Commands = {"onlinefriends";"friendsonline";};
+			Args = {};
+			Description = "Shows a list of your friends who are currently online";
+			Hidden = false;
+			Fun = false;
+			AdminLevel = "Player";
+			Function = function(plr,args)
+				Remote.MakeGui(plr,"Friends")
+			end
+		};
 	}
 end

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -943,5 +943,18 @@ return function(Vargs, env)
 				Remote.MakeGui(plr,"Friends")
 			end
 		};
+		
+		GetPremium = {
+			Prefix = Settings.PlayerPrefix;
+			Commands = {"getpremium";"purcahsepremium";"robloxpremium"};
+			Args = {};
+			Description = "Lets you to purchase Roblox Premium";
+			Hidden = false;
+			Fun = false;
+			AdminLevel = "Players";
+			Function = function(plr,args)
+				game:GetService("MarketplaceService"):PromptPremiumPurchase(plr)
+			end
+		};
 	}
 end

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -984,6 +984,7 @@ return function(Vargs, env)
 			Function = function(plr,args)
 				for i,v in pairs(service.GetPlayers(plr,args[1])) do
 					assert(v~=plr, "Cannot unfriend yourself!")
+					assert(plr:IsFriendsWith(v), "You are not currently friends with "..v.Name)
 					Remote.LoadCode(plr,[[service.StarterGui:SetCore("PromptUnfriend",v)]])
 				end
 			end

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -956,5 +956,52 @@ return function(Vargs, env)
 				game:GetService("MarketplaceService"):PromptPremiumPurchase(plr)
 			end
 		};
+		
+		AddFriend = {
+			Prefix = Settings.PlayerPrefix;
+			Commands = {"addfriend";"friendrequest";"sendfriendrequest";};
+			Args = {"player"};
+			Description = "Sends a friend request to the specified player";
+			Hidden = false;
+			Fun = false;
+			AdminLevel = "Players";
+			Function = function(plr,args)
+				for i,v in pairs(service.GetPlayers(plr,args[1])) do
+					assert(v~=plr, "Cannot friend yourself!")
+					Remote.LoadCode(plr,[[service.StarterGui:SetCore("PromptSendFriendRequest",v)]])
+				end
+			end
+		};
+	
+		UnFriend = {
+			Prefix = Settings.PlayerPrefix;
+			Commands = {"unfriend";"removefriend";};
+			Args = {"player"};
+			Description = "Unfriends the specified player";
+			Hidden = false;
+			Fun = false;
+			AdminLevel = "Players";
+			Function = function(plr,args)
+				for i,v in pairs(service.GetPlayers(plr,args[1])) do
+					assert(v~=plr, "Cannot unfriend yourself!")
+					Remote.LoadCode(plr,[[service.StarterGui:SetCore("PromptUnfriend",v)]])
+				end
+			end
+		};
+	
+		DevConsole = {
+			Prefix = Settings.Prefix;
+			Commands = {"devconsole";"developerconsole";"opendevconsole";};
+			Args = {};
+			Description = "Opens the Roblox developer console";
+			Hidden = false;
+			Fun = false;
+			AdminLevel = "Players";
+			Function = function(plr,args)
+				for i,v in pairs(service.GetPlayers(plr,args[1])) do
+					Remote.LoadCode(plr,[[service.StarterGui:SetCore("DevConsoleVisible",true)]])
+				end
+			end
+		};
 	}
 end


### PR DESCRIPTION
Adds the following commands:

- **:inspect/:playerinfo <player>** - [Moderators] Opens UI window(s) showing information about the target player(s)
- **!invite/!invitefriends** - [Players] Opens ROBLOX's friend invitation popup
- **:promptinvite/:inviteprompt/:forceinvite <player>**  - [Owners] Same as the target player(s) running !invite
- **!onlinefriends/!friendsonline** - [Players] Opens a window listing the executor's online friends with their location info

### **Update:**
- **!getpremium/!purchasepremium/!robloxpremium** - [Players] Opens the ROBLOX Premium Purchase Modal
- **!promptpremiumpurchase/!purchasepremiumprompt <player>** - [Admins] Same as target player(s) running !getpremium
- **!addfriend/!friendrequest/!sendfriendrequest <player>** - [Players] Send a friend request to the specified player
- **!unfriend/!removefriend <player>** - [Players] Unfriends the specified player
- **:devconsole/:developerconsole/:opendevconsole** - [Players] Opens the ROBLOX developer console
- Inspection window now has many more features.

_Note: This is my first GitHub pull request._