### PR TITLE
Donor Neon Command Fix

### DIFF
--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -263,14 +263,14 @@ return function(Vargs, env)
 			Function = function(plr,args)
 				if plr.Character then
 					for k,p in pairs(plr.Character:children()) do
-						if p:IsA("Part") then
+						if p:IsA("BasePart") then
 							if args[1] then
 								local str = BrickColor.new('Institutional white').Color
 								local teststr = args[1]
 								if BrickColor.new(teststr) ~= nil then str = BrickColor.new(teststr) end
 								p.BrickColor = str
 							end
-							p.Material = "Neon"
+							p.Material = Enum.Material.Neon
 						end
 					end
 				end


### PR DESCRIPTION
Fixed donor neon command to modify all BaseParts instead of just Parts

I am aware that neon does not correctly create a neon effect in most instances because of meshes, but there isn't much that can be done about this ig