### PR TITLE
Modified behaviour of kill command

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -3498,6 +3498,10 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				for i,v in pairs(service.GetPlayers(plr,args[1])) do
+					local hum = v.Character:FindFirstChildWhichIsA("Humanoid")
+					if hum then
+						hum.Health = 0
+					end
 					v.Character:BreakJoints()
 				end
 			end


### PR DESCRIPTION
Sometimes due to ragdolls (like EchoReaper's R15 ragdoll), commands like kill and smite don't work correctly. This change retains the old behaviour of kill, but manually sets the player's health to 0 as well if they have a humanoid under their character (which they should in most cases), rectifying any issues related to the usage of constraints serving as joints.