### PR TITLE
Update Core/Moderators/Creators

### DIFF
--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -19,15 +19,15 @@ return function(Vargs, env)
 				local reason = args[2] or "No reason provided";
 
 				for i in string.gmatch(args[1], "[^,]+") do
-					local userid = service.Players:GetUserIdFromNameAsync(i)
+					local UserId = service.Players:GetUserIdFromNameAsync(i)
 
-					if userid == plr.UserId then
+					if UserId == plr.UserId then
 						error("You cannot ban yourself or the creator of the game", 2)
 						return
 					end
 
-					if userid then
-						Admin.AddBan({UserId = userId, Name = i}, reason, true)
+					if UserId then
+						Admin.AddBan({UserId = UserId, Name = i}, reason, true)
 						Functions.Hint("Direct banned "..i, {plr})
 					end
 				end
@@ -42,6 +42,7 @@ return function(Vargs, env)
 			AdminLevel = "Creators";
 			Function = function(plr,args,data)
 				for i in string.gmatch(args[1], "[^,]+") do
+
 					local userid = service.Players:GetUserIdFromNameAsync(i)
 
 					if userid then
@@ -61,7 +62,7 @@ return function(Vargs, env)
 			Prefix = Settings.Prefix;
 			Commands = {"globalplace","gplace"};
 			Args = {"placeid"};
-			Description = "Sends a global message to all servers";
+			Description = "Force all game-players to teleport to a desired place";
 			AdminLevel = "Creators";
 			CrossServerDenied = true;
 			Function = function(plr,args)

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1546,6 +1546,7 @@ return function(Vargs, env)
 			Function = function(plr,args)
 				if args[1] then
 					for i,v in pairs(service.GetPlayers(plr,args[1])) do
+						Remote.Send(v,'Function','SetView','reset')
 					end
 				else
 					Remote.Send(plr,'Function','SetView','reset')
@@ -3558,7 +3559,7 @@ return function(Vargs, env)
 			Commands = {"trip";};
 			Args = {"player";"angle";};
 			Hidden = false;
-			Description = "Rotates the target player(s) by 180 degrees or the angle you server";
+			Description = "Rotates the target player(s) by 180 degrees or a custom angle";
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -652,10 +652,13 @@ return function(Vargs)
 					end
 				]])
 			end
-			if not service.Players:FindFirstChild(p.Name) then
-				Remote.Send(p,'Function','KillClient')
-			else
-				if p then pcall(function() p:Kick(Variables.BanMessage .. " | Reason: "..(value.Reason or "No reason provided")) end) end
+			
+			if type(p) ~= "table" then
+				if not service.Players:FindFirstChild(p.Name) then
+					Remote.Send(p,'Function','KillClient')
+				else
+					if p then pcall(function() p:Kick(Variables.BanMessage .. " | Reason: "..(value.Reason or "No reason provided")) end) end
+				end
 			end
 		end;
 

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -152,14 +152,14 @@ return function(Vargs)
 					func.OnServerInvoke = Process.Remote
 
 					service.RbxEvent(decoy1.OnServerEvent, function(p,modu,com,sub)
-						local keys = Remote.Clients[tostring(p.userId)]
+						local keys = Remote.Clients[tostring(p.UserId)]
 						if keys and com == "TrustCheck" and modu == keys.Module then
 							decoy1:FireClient(p,"TrustCheck",keys.Decoy1)
 						end
 					end)
 
 					service.RbxEvent(decoy2.OnServerEvent, function(p,modu,com,sub)
-						local keys = Remote.Clients[tostring(p.userId)]
+						local keys = Remote.Clients[tostring(p.UserId)]
 						if keys and com == "TrustCheck" and modu == keys.Module then
 							decoy1:FireClient(p,"TrustCheck",keys.Decoy2)
 						end
@@ -196,7 +196,7 @@ return function(Vargs)
 						if Anti.ObjRLocked(p) then
 							Anti.Detected(p, "Log", "RobloxLocked")
 						else
-							local client = Remote.Clients[tostring(p.userId)]
+							local client = Remote.Clients[tostring(p.UserId)]
 							if client and client.LoadingStatus == "READY" then
 								local lastTime = client.LastUpdate
 								if lastTime and tick()-lastTime > 60*5 then
@@ -238,18 +238,18 @@ return function(Vargs)
 		end;
 
 		SetupEvent = function(p)
-			local key = tostring(p.userId)
+			local key = tostring(p.UserId)
 			local keys = Remote.Clients[key]
 			if keys and keys.EventName and p and not Anti.ObjRLocked(p) then
 				local event = Instance.new("RemoteEvent")
 				event.Name = keys.EventName
-				event.Changed:connect(function()
+				event.Changed:Connect(function()
 					if Anti.RLocked(event) or not event or event.Parent ~= p then
 						service.Delete(event)
 						Core.SetupEvent(p)
 					end
 				end)
-				event.OnServerEvent:connect(function(np,...)
+				event.OnServerEvent:Connect(function(np,...)
 					if np == p then
 						Process.Remote(np,...)
 					end
@@ -274,7 +274,7 @@ return function(Vargs)
 
 					loader.Parent = service.ReplicatedFirst
 					Core.ClientLoader = loader
-					Core.ClientLoaderEvent = loader.Changed:connect(function()
+					Core.ClientLoaderEvent = loader.Changed:Connect(function()
 						Core.PrepareClient()
 					end)
 				end)
@@ -286,7 +286,7 @@ return function(Vargs)
 		end;
 
 		HookClient = function(p)
-			local key = tostring(p.userId)
+			local key = tostring(p.UserId)
 			local keys = Remote.Clients[key]
 			if keys then
 				local depsName = Functions:GetRandom()
@@ -371,7 +371,7 @@ return function(Vargs)
 					if not starterScripts then
 						starterScripts = service.New("StarterPlayerScripts", service.StarterPlayer)
 						starterScripts.Name = Core.Name
-						starterScripts.Changed:connect(function(p)
+						starterScripts.Changed:Connect(function(p)
 							if p=="Parent" then
 								Core.MakeClient()
 							elseif p=="Name" then
@@ -381,7 +381,7 @@ return function(Vargs)
 							end
 						end)
 
-						starterScripts.ChildAdded:connect(function(c)
+						starterScripts.ChildAdded:Connect(function(c)
 							if c.Name ~= Core.Name then
 								wait(0.5)
 								c:Destroy()
@@ -398,7 +398,7 @@ return function(Vargs)
 							if Anti.ObjRLocked(cli.Object) then
 								Core.Panic("Client RobloxLocked")
 							else
-								Core.Client.Security:disconnect()
+								Core.Client.Security:Disconnect()
 								pcall(function() Core.Client.Object:Destroy() end)
 							end
 						end
@@ -409,7 +409,7 @@ return function(Vargs)
 						client.Parent = starterScripts
 						client.Disabled = false
 						Core.Client.Object = client
-						Core.Client.Security = client.Changed:connect(function(p)
+						Core.Client.Security = client.Changed:Connect(function(p)
 							if p == "Parent" or p == "RobloxLocked" then
 								Core.MakeClient()
 							end
@@ -591,7 +591,7 @@ return function(Vargs)
 		end;
 
 		SavePlayer = function(p,data)
-			local key = tostring(p.userId)
+			local key = tostring(p.UserId)
 			Remote.PlayerData[key] = data
 		end;
 
@@ -617,7 +617,7 @@ return function(Vargs)
 		end;
 
 		GetPlayer = function(p)
-			local key = tostring(p.userId)
+			local key = tostring(p.UserId)
 			local PlayerData = Core.DefaultData(p)
 
 			if not Remote.PlayerData[key] then
@@ -641,11 +641,11 @@ return function(Vargs)
 		end;
 
 		ClearPlayer = function(p)
-			Remote.PlayerData[tostring(p.userId)] = Core.DefaultData(p);
+			Remote.PlayerData[tostring(p.UserId)] = Core.DefaultData(p);
 		end;
 
 		SavePlayerData = function(p)
-			local key = tostring(p.userId)
+			local key = tostring(p.UserId)
 			local data = Remote.PlayerData[key]
 			if data and Core.DataStore then
 				data.LastChat = nil


### PR DESCRIPTION
`Core`:
Changed deprecated userId and connect with the undeprecated version.

`Moderators`:
Fixed resetview if a player argument was provided. (for some reason it was empty)
Fixed a typo on the trip command.

`Core/Admin`:
Added check if the player isn't a table to kick in-game. (DirectBan fix)

`Creators`:
DirectBan used a unknown variable for the UserId inside the table (variable typo) was fixed.
Fixed globalplace Description typo.