### PR TITLE
Different License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,26 @@
-MIT License
+Copyright (c),(©) 2021 Sceleratis (Davey_Bones)
 
-Copyright (c) 2018 Sceleratis (Davey_Bones)
+This Software covered by Creative Commons license, available at
+"https://creativecommons.org/licenses/by/4.0/legalcode". 
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This is a human-readable summary of the license, and not
+a substitute for the license.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+You are free to:
+- Share, copy, and redistribute the material in any format or medium.
+- Adapt — remix, transform, and build upon the material 
+for any purpose, even commercially.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Under the following terms:
+- Attribution — You must give appropriate credit, provide a link to the 
+license, and indicate if changes were made. You may do so in any reasonable manner,
+but not in any way that suggests the licensor endorses you or your use.
+- No additional restrictions — You may not apply legal terms or technological measures 
+that legally restrict others from doing anything the license permits.
+
+Notices:
+- You do not have to comply with the license for elements of the material in the public 
+domain or where your use is permitted by an applicable exception or limitation.
+- No warranties are given. The license may not give you all of the permissions necessary
+for your intended use. For example, other rights such as publicity, privacy, or moral 
+rights may limit how you use the material.


### PR DESCRIPTION
Change license from MIT to Creative Commons. Why? Adds a more human-readable description of it with the more complex one linked