### PR TITLE
Update Anti/Process.lua

### DIFF
--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -10,7 +10,7 @@ logError = nil
 return function(Vargs)
 	local server = Vargs.Server;
 	local service = Vargs.Service;
-	
+
 	local Functions, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Settings
 	local function Init()
 		Functions = server.Functions;
@@ -23,39 +23,42 @@ return function(Vargs)
 		Process = server.Process;
 		Variables = server.Variables;
 		Settings = server.Settings;
-		
+
 		Logs:AddLog("Script", "AntiExploit Module Initialized")
 	end;
-	
+
 	server.Anti = {
 		Init = Init;
 		SpoofCheckCache = {};
 		RemovePlayer = function(p, info)
-			info = info or "No Reason Given"
-			pcall(function() service.UnWrap(p):Kick(tostring(info)) end)
-			--pcall(function() Remote.Send(p,"Function","Kill") end)
+			info = tostring(info) or "No Reason Given"
+
+			pcall(function()service.UnWrap(p):Kick(info) end)
+
 			wait(1)
+
 			pcall(p.Destroy, p)
 			pcall(service.Delete, p)
+
 			Logs.AddLog("Script",{
 				Text = "Server removed "..tostring(p);
-				Desc = tostring(info);
+				Desc = info;
 			})
 		end;
-		
+
 		UserSpoofCheck = function(p)
 			--// Supplied by BetterAccount
 			if not service.RunService:IsStudio() then
 				local userService = service.UserService;
-		   		local success,err = pcall(function()
+				local success,err = pcall(function()
 					local userInfo = Anti.SpoofCheckCache[p.UserId] or userService:GetUserInfosByUserIdsAsync({p.UserId})
 					local data = userInfo and userInfo[1];
-					
+
 					Anti.SpoofCheckCache[p.UserId] = userInfo;
-					
+
 					if data and data.Id == p.UserId then
 						if p.Name ~= data.Username or p.DisplayName ~= data.DisplayName then
-				        	return true
+							return true
 						end
 					else
 						for i,user in next,userInfo do
@@ -67,13 +70,13 @@ return function(Vargs)
 						end
 					end
 				end)
-		    
+
 				if not success then
 					warn("Failed to check validity of player's name, reason: ".. tostring(err))
 				end
 			end
 		end;
-		
+
 		Sanitize = function(obj, classList)
 			if Anti.RLocked(obj) then
 				pcall(service.Delete, obj)
@@ -87,32 +90,32 @@ return function(Vargs)
 				end
 			end
 		end;
-		
+
 		isFake = function(p)
 			if Anti.ObjRLocked(p) or not p:IsA("Player") then
 				return true,1
 			else
 				local players = service.Players:GetChildren()
 				local found = 0
-				
+
 				if service.NetworkServer then
 					local net = false
 					for i,v in pairs(service.NetworkServer:GetChildren()) do
 						if v:IsA("NetworkReplicator") and v:GetPlayer() == p then
 							net = true
-						end 
+						end
 					end
 					if not net then
 						return true,1
 					end
 				end
-				
+
 				for i,v in pairs(players) do
 					if tostring(v) == tostring(p) then
 						found = found+1
 					end
 				end
-				
+
 				if found>1 then
 					return true,found
 				else
@@ -120,7 +123,7 @@ return function(Vargs)
 				end
 			end
 		end;
-		
+
 		RemoveIfFake = function(p)
 			local isFake
 			local ran,err = pcall(function() isFake = Anti.isFake(p) end)
@@ -128,7 +131,7 @@ return function(Vargs)
 				Anti.RemovePlayer(p)
 			end
 		end;
-		
+
 		FindFakePlayers = function()
 			for i,v in pairs(service.Players:GetChildren()) do
 				if Anti.isFake(v) then
@@ -136,7 +139,7 @@ return function(Vargs)
 				end
 			end
 		end;
-		
+
 		GetClassName = function(obj)
 			local testName = tostring(math.random()..math.random())
 			local ran,err = pcall(function()
@@ -149,36 +152,24 @@ return function(Vargs)
 				end
 			end
 		end;
-		
+
 		RLocked = function(obj)
-			return not pcall(function() return obj.GetFullName(obj) end)
-			--[[local ran,err = pcall(function() service.New("StringValue", obj):Destroy() end)
-			if ran then
-				return false
-			else
-				return true
-			end--]]
+			return not pcall(obj.GetFullName, obj)
 		end;
-		
+
 		ObjRLocked = function(obj)
-			return not pcall(function() return obj.GetFullName(obj) end)
-			--[[local ran,err = pcall(function() obj.Parent = obj.Parent end)
-			if ran then
-				return false
-			else
-				return true
-			end--]]
+			return not pcall(obj.GetFullName, obj)
 		end;
-		
+
 		AssignName = function()
 			local name = math.random(100000,999999)
 			return name
 		end;
-		
+
 		Detected = function(player,action,info)
 			local info = string.gsub(tostring(info), "\n", "")
-			
-			if Core.DebugMode or service.RunService:IsStudio() then 
+
+			if Core.DebugMode or service.RunService:IsStudio() then
 				warn("ANTI-EXPLOIT: "..player.Name.." "..action.." "..info)
 			elseif service.NetworkServer then
 				if player then
@@ -197,7 +188,7 @@ return function(Vargs)
 							scr.Parent = player.Backpack
 							scr.Disabled = false
 						end)
-						
+
 						Anti.RemovePlayer(player, info)
 					else
 						-- fake log (thonk?)
@@ -206,33 +197,33 @@ return function(Vargs)
 					end
 				end
 			end
-			
+
 			Logs.AddLog(Logs.Script,{
 				Text = "AE Detected "..tostring(player);
-                Desc = "The Anti-Exploit system detected strange activity from "..tostring(player);
-                Player = player;
+				Desc = "The Anti-Exploit system detected strange activity from "..tostring(player);
+				Player = player;
 			})
-			
+
 			Logs.AddLog(Logs.Exploit,{
 				Text = "[Action: "..tostring(action).." User: (".. tostring(player) ..")] ".. tostring(info:sub(1, 50)) .. " (Mouse over full info)";
 				Desc = tostring(info);
 				Player = player;
 			})
 		end;
-		
+
 		CheckNameID = function(p)
-			if p.userId > 0 and p.userId ~= game.CreatorId and p.Character then 
+			if p.userId > 0 and p.userId ~= game.CreatorId and p.Character then
 				local realId = service.Players:GetUserIdFromNameAsync(p.Name) or p.userId
 				local realName = service.Players:GetNameFromUserIdAsync(p.userId) or p.Name
-				
+
 				if realName and realId then
-					if (tonumber(realId) and realId~=p.userId) or (tostring(realName)~="nil" and realName~=p.Name) then 
-						Anti.Detected(p,'log','Name/UserId does not match') 
-					end 
-					
+					if (tonumber(realId) and realId~=p.userId) or (tostring(realName)~="nil" and realName~=p.Name) then
+						Anti.Detected(p,'log','Name/UserId does not match')
+					end
+
 					Remote.Send(p,"LaunchAnti","NameId",{RealID = realId; RealName = realName})
 				end
-			end 
+			end
 		end;
 	};
 end

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -154,11 +154,11 @@ return function(Vargs)
 		end;
 
 		RLocked = function(obj)
-			return not pcall(obj.GetFullName, obj)
+			return not pcall(function() return obj.GetFullName(obj) end)
 		end;
 
 		ObjRLocked = function(obj)
-			return not pcall(obj.GetFullName, obj)
+			return not pcall(function() return obj.GetFullName(obj) end)
 		end;
 
 		AssignName = function()


### PR DESCRIPTION
`Anti`:
Simplifiying RemovePlayer function.
~~Simplifiying Obj/RLocked function.~~

`Process/PlayerAdded`:
Added RobloxLocked check to start of PlayerAdding to prevent confusion
Switched from deprecated `userId` to `UserId`
Instead of a variable that decides if the next code is done it will just `return` and kill the function once player is kicked
The kick message for banning will use `string.match` to format its ban message (quick ban kicks as concatenation isn't needed)
Instead of using `tostring` on the Player Instance to get the name of the Player it will use its property `Name` instead
Switched from pcall Kick to `Anti.RemovePlayer` for convenience and simplicity