### PR TITLE
Update Process.lua | oldLogs Fix

### DIFF
--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -254,9 +254,8 @@ return function(Vargs)
 
 								if opts.CrossServer or (not isSystem and not opts.DontLog) then
 									AddLog("Commands",{
-										Text = ((opts.CrossServer and "[CRS_SERVER] ") or "").. p.Name,
-										Desc = matched.. Settings.SplitKey.. table.concat(args, Settings.SplitKey),
-										Player = p;
+										Text = string.format("%s%s", (opts.CrossServer and "[CRS_SERVER] ") or "", p.Name),
+										Desc = matched .. Settings.SplitKey.. table.concat(args, Settings.SplitKey),
 									})
 
 									if Settings.ConfirmCommands then


### PR DESCRIPTION
`Process`:
Error from oldLogs, "Error: DataStore UpdateAsync Failed: 104: Cannot store Array in data store. Data stores can only accept valid UTF-8 characters.: nil". Fixed by removing `Player = p` inside the dictionary as it seemed to put the players full Instance inside if it wasn't a Non-CRS command. I have checked and was unable to find `Player` being used, If there is parts where it is being used please comment, Thanks.