### PR TITLE
Fixed Refresh, Logs typo fixed.

### DIFF
--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -98,7 +98,7 @@ return function(Vargs)
 				local temp = {}
 
 				for i,m in ipairs(Logs.Commands) do
-					local newTab = (type(m) == "table" and service.CLoneTable(m)) or m;
+					local newTab = (type(m) == "table" and service.CloneTable(m)) or m;
 					if type(m) == "table" and newTab.Player then
 						local p = newTab.Player;
 						newTab.Player = {


### PR DESCRIPTION
`Moderators`:
Just rewrote all of the previous refresh command.

`Logs`:
Fix typo of `CLoneTable` with `CloneTable`.