### PR TITLE
Update HeadAdmins.lua / Service.lua

### DIFF
--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -225,6 +225,10 @@ return function(Vargs, env)
 				assert(args[1], "Argument #1 must be supplied")
 
 				local globalMessage = string.format([[
+					local server = server
+					local service = server.Service
+					local Remote = server.Remote
+
 					for i,v in pairs(service.Players:GetPlayers()) do
 						Remote.RemoveGui(v, "Message")
 						Remote.MakeGui(v, "Message", {

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -224,7 +224,19 @@ return function(Vargs, env)
 			Function = function(plr,args)
 				assert(args[1], "Argument #1 must be supplied")
 
-				if not Core.CrossServer("NewRunCommand", {Name = plr.Name; UserId = plr.UserId, AdminLevel = Admin.GetLevel(plr)}, Settings.Prefix.."m "..args[1]) then
+				local globalMessage = string.format([[
+					for i,v in pairs(service.Players:GetPlayers()) do
+						Remote.RemoveGui(v, "Message")
+						Remote.MakeGui(v, "Message", {
+							Title = "Global Message from %s";
+							Message = "%s";
+							Scroll = true;
+							Time = (#("%s") / 19) + 2.5;
+						})
+					end
+				]], plr.Name, args[1], args[1])
+
+				if not Core.CrossServer("Loadstring", globalMessage) then
 					error("CrossServer Handler Not Ready");
 				end
 			end;

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -1168,11 +1168,11 @@ return function(errorHandler, eventChecker, fenceSpecific)
 		EventService = EventService;
 		ThreadService = ThreadService;
 		HelperService = HelperService;
-		MarketPlace = game:service("MarketplaceService");
-		GamepassService = game:service("GamePassService");
-		ChatService = game:service("Chat");
-		Gamepasses = game:service("GamePassService");
-		Delete = function(obj,num) game:service("Debris"):AddItem(obj,(num or 0)) pcall(obj.Destroy, obj) end;
+		MarketPlace = game:GetService("MarketplaceService");
+		GamepassService = game:GetService("GamePassService");
+		ChatService = game:GetService("Chat");
+		Gamepasses = game:GetService("GamePassService");
+		Delete = function(obj,num) game:GetService("Debris"):AddItem(obj,(num or 0)) pcall(obj.Destroy, obj) end;
 		RbxEvent = function(signal, func) local event = signal:connect(func) table.insert(RbxEvents, event) return event end;
 		SelfEvent = function(signal, func) local rbxevent = service.RbxEvent(signal, function(...) func(...) end) end;
 		DelRbxEvent = function(signal) for i,v in next,RbxEvents do if v == signal then v:Disconnect() table.remove(RbxEvents, i) end end end;
@@ -1184,14 +1184,19 @@ return function(errorHandler, eventChecker, fenceSpecific)
 		CheckProperty = function(obj,prop) return pcall(function() return obj[prop] end) end;
 		NewWaiter = function() local event = service.New("BindableEvent") return {Wait = event.wait; Finish = event.Fire} end;
 	},{
-		__index = function(tab,index)
+		__index = function(tab, index)
 			local found = (fenceSpecific and fenceSpecific[index]) or Wrapper[index] or Events[index] or Helpers[index]
-			if found ~= nil then
+
+			if found then
 				return found
 			else
-				local ran,serv = pcall(function() return (client ~= nil and service.Wrap(game:GetService(index), true)) or game:GetService(index) end)
+				local ran, serv = pcall(function()
+					local gameservice = game:GetService(index)
+					return (client ~= nil and service.Wrap(gameservice, true)) or gameservice
+				end)
+
 				if ran and serv then
-					service[tostring(serv)] = serv
+					service[index] = serv
 					return serv
 				end
 			end


### PR DESCRIPTION
`HeadAdmins`:
`GlobalMessage`: Command now displays the title as "Global message from (PlayerName)".

`Service`:
service.__index: Caching the service now uses the `index` argument instead of using `tostring` on the gotten Service as Instances such as `UserInputService` just give `Instance` when `tostring` is used. (services also like `ScriptContext` will give `Script Context` as its their original service)