### PR TITLE
Fix for sp00ky and k1tty on MeshPart head places

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -2629,8 +2629,20 @@ return function(Vargs, env)
 					Admin.RunCommand(Settings.Prefix.."removehats",v.Name)
 					Admin.RunCommand(Settings.Prefix.."invisible",v.Name)
 
-					v.Character.Head.Transparency = 0.9
-					v.Character.Head.Mesh.Scale = Vector3.new(0.01,0.01,0.01)
+					local headMesh = v.Character.Head:FindFirstChild("Mesh")
+					if headMesh then
+						v.Character.Head.Transparency = 0.9
+						headMesh.Scale = Vector3.new(0.01,0.01,0.01)
+					else
+						v.Character.Head.Transparency = 1
+						for _,c in ipairs(v.Character.Head:GetChildren()) do
+							if c:IsA("Decal") then
+								c.Transparency = 1
+							elseif c:IsA("LayerCollector") then
+								c.Enabled = false
+							end
+						end
+					end
 
 					cl:Clone().Parent = decal1
 					cl:Clone().Parent = decal2
@@ -2688,9 +2700,21 @@ return function(Vargs, env)
 
 					Admin.RunCommand(Settings.Prefix.."removehats",v.Name)
 					Admin.RunCommand(Settings.Prefix.."invisible",v.Name)
-
-					v.Character.Head.Transparency = 0.9
-					v.Character.Head.Mesh.Scale = Vector3.new(0.01,0.01,0.01)
+					
+					local headMesh = v.Character.Head:FindFirstChild("Mesh")
+					if headMesh then
+						v.Character.Head.Transparency = 0.9
+						headMesh.Scale = Vector3.new(0.01,0.01,0.01)
+					else
+						v.Character.Head.Transparency = 1
+						for _,c in ipairs(v.Character.Head:GetChildren()) do
+							if c:IsA("Decal") then
+								c.Transparency = 1
+							elseif c:IsA("LayerCollector") then
+								c.Enabled = false
+							end
+						end
+					end
 
 					cl:Clone().Parent = decal1
 					cl:Clone().Parent = decal2


### PR DESCRIPTION
Sp00ky and k1tty currently error used in a place where `workspace.MeshPartHeadsAndAccessories` is enabled.

This edit fixes that issue, while trying to retain old behaviour (decals and guis are not visible).
In places where MeshPart heads/accessories are not enabled, the current behaviour is maintained.