### PR TITLE
add github build action

### DIFF
--- a/.github/build.project.json
+++ b/.github/build.project.json
@@ -1,0 +1,13 @@
+{
+    "name": "Adonis_Rojo",
+    "tree": {
+        "$className": "Folder",
+        "MainModule": {
+            "$path": "../MainModule"
+        },
+        "Adonis_Loader": {
+            "$className": "Model",
+            "$path": "../Loader"
+        }
+    }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        run: rojo build .github/build.project.json -o Adonis_Nightly_$(date +"%Y_%m_%d_%H_%M").rbxm
+        run: rojo build .github/build.project.json -o Adonis_Nightly_$(date +"%Y_%m_%d_%H_%M").rbxmx
 
       - name: Upload model as artifact
         uses: actions/upload-artifact@v2
         with:
-          path: Adonis_Nightly_*.rbxm
+          path: Adonis_Nightly_*.rbxmx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: rojo
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: Roblox/setup-foreman@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        run: rojo build .github/build.project.json -o Adonis_Nightly_$(date +"%Y_%m_%d_%H_%M").rbxm
+
+      - name: Upload model as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: Adonis_Nightly_*.rbxm

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-
-README.md
-README.md

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,0 +1,2 @@
+[tools]
+rojo = { source="rojo-rbx/rojo", version="6.2.0" }


### PR DESCRIPTION
This PR adds a GitHub action that automatically builds PRs and commits and allows the generated model file to be downloaded. 

Useful so people can quickly test PRs and changes without needing Rojo, and any build errors where the build works on one machine but not another can be quickly spotted