### PR TITLE
Remove PlayerData.Groups

### DIFF
--- a/MainModule/Client/UI/Default/Inspect.lua
+++ b/MainModule/Client/UI/Default/Inspect.lua
@@ -269,7 +269,7 @@ return function(data)
 	
 	do
 
-		local rawGroups = data.Groups
+		local rawGroups = service.GroupService:GetGroupsAsync(p.UserId) or {}
 		local sortedGroups = {}
 		local groupInfoRef = {}
 		for _, groupInfo in pairs(rawGroups) do

--- a/MainModule/Client/UI/Default/Inspect.lua
+++ b/MainModule/Client/UI/Default/Inspect.lua
@@ -269,7 +269,7 @@ return function(data)
 	
 	do
 
-		local rawGroups = service.GroupService:GetGroupsAsync(p.UserId) or {}
+		local rawGroups = service.GroupService:GetGroupsAsync(player.UserId) or {}
 		local sortedGroups = {}
 		local groupInfoRef = {}
 		for _, groupInfo in pairs(rawGroups) do

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -193,7 +193,7 @@ return function(Vargs)
 
 		GetPlayerGroup = function(p, group)
 			local data = Core.GetPlayer(p)
-			local groups = data.Groups
+			local groups = service.GroupService:GetGroupsAsync(p.UserId) or {}
 			local isID = type(group) == "number"
 			if groups then
 				for i,v in next,groups do
@@ -322,7 +322,7 @@ return function(Vargs)
 
 		UpdateCachedLevel = function(p)
 			local data = Core.GetPlayer(p)
-			data.Groups = service.GroupService:GetGroupsAsync(p.UserId) or {}
+			--data.Groups = service.GroupService:GetGroupsAsync(p.UserId) or {}
 			data.AdminLevel = Admin.GetUpdatedLevel(p)
 			data.LastLevelUpdate = tick()
 			Logs.AddLog("Script", {


### PR DESCRIPTION
Users can have up to 100 groups, and service.GroupService:GetGroupsAsync(p.UserId) or {} returns all the information about a group, including a full URL to the groups image, a group description, and so on.

This takes up megabytes of space and is a poor use of the DataStore since it's only used in 1 command, which runs for 1 person. Caching this before opening up the UI makes no sense either as it just takes up more time creating a cache for each user.

It does not cause any realistic change whatsoever to the speed of commands

![image](https://user-images.githubusercontent.com/31691973/123429085-6fbb9900-d5be-11eb-8d90-a37d02076779.png)
