### PR TITLE
Local timezones display in logs

### DIFF
--- a/MainModule/Client/UI/Default/List.lua
+++ b/MainModule/Client/UI/Default/List.lua
@@ -98,7 +98,7 @@ return function(data)
 			end
 
 			if v.Time then
-				v.Text = "["..v.Time.."] "..v.Text
+				v.Text = "["..service.FormatTime(v.Time).."] "..v.Text
 			end
 		end
 

--- a/MainModule/Client/UI/Hydris.rbxmx
+++ b/MainModule/Client/UI/Hydris.rbxmx
@@ -12237,7 +12237,7 @@ return function(data)
 								text.Text = "(x"..v.Duplicates..") "..text.Text
 							end
 							if v.Time then 
-								text.Text = "["..v.Time.."] "..text.Text
+								text.Text = "["..service.FormatTime(v.Time).."] "..text.Text
 							end
 							if v.Color then
 								text.TextColor3 = v.Color

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1664,8 +1664,8 @@ return function(Vargs, env)
 					CreatorId = game.CreatorId;
 					PrivateServerId = game.PrivateServerId;
 					PrivateServerOwnerId = game.PrivateServerOwnerId;
-					ServerStartTime = service.GetTime(server.ServerStartTime);
-					ServerAge = service.GetTime(os.time()-server.ServerStartTime);
+					ServerStartTime = service.FormatTime(server.ServerStartTime);
+					ServerAge = service.FormatTime(os.time()-server.ServerStartTime);
 					HttpEnabled = HTTP.CheckHttp();
 					LoadstringEnabled = HTTP.LoadstringEnabled;
 					Admins = adminDictionary;

--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -187,7 +187,7 @@ return function(Vargs)
 										Desc = cmd;
 									})
 									if Settings.Trello_Token ~= "" then
-										pcall(trello.makeComment,k.id,"Ran Command: "..cmd.."\nPlace ID: "..game.PlaceId.."\nServer Job Id: "..game.JobId.."\nServer Players: "..#service.GetPlayers().."\nServer Time: "..service.GetTime())
+										pcall(trello.makeComment,k.id,"Ran Command: "..cmd.."\nPlace ID: "..game.PlaceId.."\nServer Job Id: "..game.JobId.."\nServer Players: "..#service.GetPlayers().."\nServer Time: "..service.FormatTime())
 									end
 								end
 							end

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -360,8 +360,8 @@ return function(Vargs)
 					table.insert(tab,{Text = "Place Owner: "..service.MarketPlace:GetProductInfo(game.PlaceId).Creator.Name})
 					table.insert(tab,{Text = "―――――――――――――――――――――――"})
 					table.insert(tab,{Text = "Server Speed: "..service.Round(service.Workspace:GetRealPhysicsFPS())})
-					table.insert(tab,{Text = "Server Start Time: "..service.GetTime(server.ServerStartTime)})
-					table.insert(tab,{Text = "Server Age: "..service.GetTime(os.time()-server.ServerStartTime)})
+					table.insert(tab,{Text = "Server Start Time: "..service.FormatTime(server.ServerStartTime)})
+					table.insert(tab,{Text = "Server Age: "..service.FormatTime(os.time()-server.ServerStartTime)})
 					table.insert(tab,{Text = "―――――――――――――――――――――――"})
 
 					--[[

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -407,7 +407,6 @@ return function(Vargs)
 					AddLog(Logs.Chats,{
 						Text = p.Name..": "..tostring(filtered);
 						Desc = tostring(filtered);
-						NoTime = true;
 						Player = p;
 					})
 
@@ -436,7 +435,6 @@ return function(Vargs)
 					AddLog(Logs.Chats,{
 						Text = "[MUTED] ".. p.Name ..": "..tostring(filtered);
 						Desc = tostring(filtered);
-						NoTime = true;
 						Player = p;
 					})
 				end
@@ -588,18 +586,15 @@ return function(Vargs)
 
 		NetworkAdded = function(cli)
 			wait(0.25)
-			local tim = service.GetTime()
 			local p = cli:GetPlayer()
 			if p then
-				Logs.AddLog(Logs.Script,{
-					Time = tim;
+				Logs.AddLog(Logs.Script, {
 					Text = tostring(p).." connected";
 					Desc = tostring(p).." successfully established a connection with the server";
 					Player = p;
 				})
 			else
-				Logs.AddLog(Logs.Script,{
-					Time = tim;
+				Logs.AddLog(Logs.Script, {
 					Text = "<UNKNOWN> connected";
 					Desc = "An unknown user successfully established a connection with the server";
 				})
@@ -608,21 +603,19 @@ return function(Vargs)
 		end;
 
 		NetworkRemoved = function(cli)
-			local tim = service.GetTime()
 			local p = cli:GetPlayer() or Core.Connections[cli]
 			Core.Connections[cli] = nil
 			if p then
 				local key = tostring(p.userId)
 				Core.SavePlayerData(p)
 				Remote.Clients[key] = nil
-				Logs.AddLog(Logs.Script,{
+				Logs.AddLog(Logs.Script, {
 					Text = tostring(p).." disconnected";
 					Desc = tostring(p).." disconnected from the server";
 					Player = p;
 				})
 			else
-				Logs.AddLog(Logs.Script,{
-					Time = tim;
+				Logs.AddLog(Logs.Script, {
 					Text = "<UNKNOWN> disconnected";
 					Desc = "An unknown user disconnected from the server";
 				})

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -930,13 +930,19 @@ return function(errorHandler, eventChecker, fenceSpecific)
 			end
 		end;
 
-		GetTime = function(optTime)
-			local tim=optTime or os.time()
-			local hour = math.floor((tim%86400)/60/60)
-			local min = math.floor(((tim%86400)/60/60-hour)*60)
-			if min < 10 then min = "0"..min end
-			if hour < 10 then hour = "0"..hour end
-			return hour..":"..min
+		GetTime = function()
+			return os.time();
+		end;
+
+		FormatTime = function(optTime, withDate)
+			local formatString = withDate and "L LT" or "LT"
+			local tim = DateTime.fromUnixTimestamp(optTime or service.GetTime())
+			if service.RunService:IsServer() then
+				return tim:FormatUniversalTime(formatString, "en-gb") -- Always show UTC in 24 hour format
+			else
+				local locale = service.Players.LocalPlayer.LocaleId
+				return tim:FormatLocalTime(formatString, locale) -- Show in player's local timezone and format
+			end
 		end;
 
 		OwnsAsset = function(p,id)


### PR DESCRIPTION
Displays times for log commands (`:logs`, `:chats`, etc) in the user's local timezone along with the preferred time format for their locale. Also enables timestamps for chat logs since they were disabled before.