### PR TITLE
Added fix to prevent GP Events from deleting or rotating

### DIFF
--- a/MainModule/Server/Dependencies/Assets/ClickTeleport.rbxmx
+++ b/MainModule/Server/Dependencies/Assets/ClickTeleport.rbxmx
@@ -68,8 +68,8 @@ function onEquipped(mouse)
   mouse.Button1Down:connect(function() onButton1Down(mouse) end)
 end
 
-game:service("UserInputService").InputBegan:connect(function(InputObject)
-if  InputObject.UserInputType == Enum.UserInputType.Keyboard then
+game:service("UserInputService").InputBegan:connect(function(InputObject,gpe)
+if  InputObject.UserInputType == Enum.UserInputType.Keyboard and not gpe then
   if InputObject.KeyCode == Enum.KeyCode.R then
     holding = true
     rotate()


### PR DESCRIPTION
Fixes things such as the chat causing the tool to be deleted or triggering a rotate.