### PR TITLE
Validate cape material enum + bug fix

### DIFF
--- a/MainModule/Client/UI/Default/List.lua
+++ b/MainModule/Client/UI/Default/List.lua
@@ -98,7 +98,7 @@ return function(data)
 			end
 
 			if v.Time then
-				v.Text = "["..service.FormatTime(v.Time).."] "..v.Text
+				v.Text = "["..(typeof(v.Time) == "number" and service.FormatTime(v.Time) or v.Time).."] "..v.Text
 			end
 		end
 

--- a/MainModule/Client/UI/Hydris.rbxmx
+++ b/MainModule/Client/UI/Hydris.rbxmx
@@ -12237,7 +12237,7 @@ return function(data)
 								text.Text = "(x"..v.Duplicates..") "..text.Text
 							end
 							if v.Time then 
-								text.Text = "["..service.FormatTime(v.Time).."] "..text.Text
+								text.Text = "["..(typeof(v.Time) == "number" and service.FormatTime(v.Time) or v.Time).."] "..text.Text
 							end
 							if v.Color then
 								text.TextColor3 = v.Color

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -678,6 +678,11 @@ return function(Vargs)
 		end;
 
 		Cape = function(player,isdon,material,color,decal,reflect)
+			material = material or "Neon"
+			if not Functions.GetEnumValue(Enum.Material, material) then
+				error("Invalid material value")
+			end
+
 			Functions.UnCape(player)
 			local torso = player.Character:FindFirstChild("HumanoidRootPart")
 			if torso then
@@ -720,6 +725,17 @@ return function(Vargs)
 			end
 		end;
 
+		GetEnumValue = function(enum, item)
+			local valid = false
+			for _,v in ipairs(enum:GetEnumItems()) do
+				if v.Name == item then
+					valid = v.Value
+					break
+				end
+			end
+			return valid
+		end;
+
 		ApplyBodyPart = function(character, model)
 			local humanoid = character:FindFirstChildOfClass("Humanoid")
 			if humanoid then
@@ -742,13 +758,10 @@ return function(Vargs)
 							v:Clone().Parent = character
 						end
 					elseif rigType == "R15" then
-						local validParts = {}
-						for _,x in pairs(Enum.BodyPartR15:GetEnumItems()) do
-							validParts[x.Name] = x.Value
-						end
 						for _,v in pairs(part:GetChildren()) do
-							if validParts[v.Name] then
-								humanoid:ReplaceBodyPartR15(validParts[v.Name], v:Clone())
+							local value = Functions.GetEnumValue(Enum.BodyPartR15, v.Name)
+							if value then
+								humanoid:ReplaceBodyPartR15(value, v:Clone())
 							end
 						end
 					end


### PR DESCRIPTION
Closes #2 and also fixes a backwards compatibility bug that was introduced with #395.