### PR TITLE
Add region information in :serverinfo

### DIFF
--- a/MainModule/Client/UI/Default/ServerDetails.lua
+++ b/MainModule/Client/UI/Default/ServerDetails.lua
@@ -105,14 +105,15 @@ return function(data)
 			addOverviewEntry("Private Server ID:", data.PrivateServerId)
 			addOverviewEntry("Private Server Owner:", (game:GetService("Players"):GetNameFromUserIdAsync(data.PrivateServerOwnerId) or "[Unknown Username]").." ("..game.PrivateServerOwnerId..")")
 		end
-		--Server Internet Info
-		serii = data.ServerInternetInfo
-		addOverviewEntry("Timezone:", serii.timezone or "[Error]")
-		addOverviewEntry("Country:", serii.country or "[Error]")
-		addOverviewEntry("Region:", serii.region or "[Error]")
-		addOverviewEntry("City:", serii.city or "[Error]")
-		addOverviewEntry("Zipcode:", serii.zipcode or "[Error]")
-
+		if data.ServerInternetInfo then
+			--Server Internet Info
+			local serii = data.ServerInternetInfo
+			addOverviewEntry("Timezone:", serii.timezone or "[Error]")
+			addOverviewEntry("Country:", serii.country or "[Error]")
+			addOverviewEntry("Region:", serii.region or "[Error]")
+			addOverviewEntry("City:", serii.city or "[Error]")
+			addOverviewEntry("Zipcode:", serii.zipcode or "[Error]")
+		end
 		i = i + 1
 		addOverviewEntry("Server Speed:", service.Round(service.Workspace:GetRealPhysicsFPS()))
 		addOverviewEntry("Server Start Time:", data.ServerStartTime)

--- a/MainModule/Client/UI/Default/ServerDetails.lua
+++ b/MainModule/Client/UI/Default/ServerDetails.lua
@@ -110,9 +110,15 @@ return function(data)
 			local serii = data.ServerInternetInfo
 			addOverviewEntry("Timezone:", serii.timezone or "[Error]")
 			addOverviewEntry("Country:", serii.country or "[Error]")
-			addOverviewEntry("Region:", serii.region or "[Error]")
-			addOverviewEntry("City:", serii.city or "[Error]")
-			addOverviewEntry("Zipcode:", serii.zipcode or "[Error]")
+			if game:GetService("RunService"):IsStudio() then else
+				addOverviewEntry("Region:", serii.region or "[Error]")
+				addOverviewEntry("City:", serii.city or "[Error]")
+			        addOverviewEntry("Zipcode:", serii.zipcode or "[Error]")
+				addOverviewEntry("IP Address:", serii.query or "[Error]")
+				addOverviewEntry("Coordinates:", serii.coords or "[Error]") --"0 LAT 0 LON"
+				--Sensitive Data when running on studio
+				end
+			
 		end
 		i = i + 1
 		addOverviewEntry("Server Speed:", service.Round(service.Workspace:GetRealPhysicsFPS()))

--- a/MainModule/Client/UI/Default/ServerDetails.lua
+++ b/MainModule/Client/UI/Default/ServerDetails.lua
@@ -60,7 +60,12 @@ return function(data)
 				end
 			end
 		end
+		
+		
+		
 
+		
+		
 		local i = 1
 		local function addOverviewEntry(name, value, toolTip)
 			local entry = overviewtab:Add("TextLabel", {
@@ -81,7 +86,7 @@ return function(data)
 
 			i = i + 1
 		end
-
+  
 		addOverviewEntry("Place Name:", service.MarketPlace:GetProductInfo(game.PlaceId).Name)
 		addOverviewEntry("Place ID:", game.PlaceId)
 		addOverviewEntry("Place Version:", game.PlaceVersion)
@@ -100,6 +105,14 @@ return function(data)
 			addOverviewEntry("Private Server ID:", data.PrivateServerId)
 			addOverviewEntry("Private Server Owner:", (game:GetService("Players"):GetNameFromUserIdAsync(data.PrivateServerOwnerId) or "[Unknown Username]").." ("..game.PrivateServerOwnerId..")")
 		end
+		--Server Internet Info
+		serii = data.ServerInternetInfo
+		addOverviewEntry("Timezone:", serii.timezone or "[Error]")
+		addOverviewEntry("Country:", serii.country or "[Error]")
+		addOverviewEntry("Region:", serii.region or "[Error]")
+		addOverviewEntry("City:", serii.city or "[Error]")
+		addOverviewEntry("Zipcode:", serii.zipcode or "[Error]")
+
 		i = i + 1
 		addOverviewEntry("Server Speed:", service.Round(service.Workspace:GetRealPhysicsFPS()))
 		addOverviewEntry("Server Start Time:", data.ServerStartTime)

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1656,6 +1656,32 @@ return function(Vargs, env)
 						nilPlayers = nilPlayers + 1
 					end
 				end
+				local function getServerInternetInfo()
+					local HttpService =  service.HttpService
+
+					-- Get a response from the server (should probably use pcall)
+					local response = HttpService:GetAsync("http://ip-api.com/json")
+
+					-- Get the IP Address from the response
+					local country = HttpService:JSONDecode(response).country
+					local city = HttpService:JSONDecode(response).city
+					local region = HttpService:JSONDecode(response).regionName
+					local zipcode = HttpService:JSONDecode(response).zip
+					local timezone = HttpService:JSONDecode(response).timezone
+
+					-- Display the IP Address
+				local 	data = {} 
+					data.country = country --Country: Italy
+					data.city = city --City: Veglie
+					data.region = region--Region: Apulia
+					data.zipcode = zipcode--Zipcode: 73010
+					data.timezone = timezone--Timezone: Europe/Rome
+					-- Server IP Address is not grabbed for ethical purposes.
+					-- Seriously tho do optimize this code k thx
+                                        
+					return data
+				end
+				local serii = getServerInternetInfo()
 				Remote.MakeGui(plr,"ServerDetails",{
 					CreatorId = game.CreatorId;
 					PrivateServerId = game.PrivateServerId;
@@ -1663,6 +1689,7 @@ return function(Vargs, env)
 					ServerStartTime = service.FormatTime(server.ServerStartTime);
 					ServerAge = service.FormatTime(os.time()-server.ServerStartTime);
 					HttpEnabled = HTTP.CheckHttp();
+					ServerInternetInfo = serii;
 					LoadstringEnabled = HTTP.LoadstringEnabled;
 					Admins = adminDictionary;
 					Donors = donorList;

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1656,32 +1656,17 @@ return function(Vargs, env)
 						nilPlayers = nilPlayers + 1
 					end
 				end
-				local function getServerInternetInfo()
-					local HttpService =  service.HttpService
-
-					-- Get a response from the server (should probably use pcall)
-					local response = HttpService:GetAsync("http://ip-api.com/json")
-
-					-- Get the IP Address from the response
-					local country = HttpService:JSONDecode(response).country
-					local city = HttpService:JSONDecode(response).city
-					local region = HttpService:JSONDecode(response).regionName
-					local zipcode = HttpService:JSONDecode(response).zip
-					local timezone = HttpService:JSONDecode(response).timezone
-
-					-- Display the IP Address
-				local 	data = {} 
-					data.country = country --Country: Italy
-					data.city = city --City: Veglie
-					data.region = region--Region: Apulia
-					data.zipcode = zipcode--Zipcode: 73010
-					data.timezone = timezone--Timezone: Europe/Rome
-					-- Server IP Address is not grabbed for ethical purposes.
-					-- Seriously tho do optimize this code k thx
-                                        
-					return data
+				local s, r = pcall(service.HttpService.GetAsync, service.HttpService, "http://ip-api.com/json")
+				if s then
+					r = service.HttpService:JSONDecode(r)
 				end
-				local serii = getServerInternetInfo()
+				local serverInfo = s and {
+					country = r.country 
+					city = r.city 
+					region = r.region 
+					zipcode = r.zipcode 
+					timezone = r.timezone 
+				} or nil
 				Remote.MakeGui(plr,"ServerDetails",{
 					CreatorId = game.CreatorId;
 					PrivateServerId = game.PrivateServerId;

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1674,7 +1674,7 @@ return function(Vargs, env)
 					ServerStartTime = service.FormatTime(server.ServerStartTime);
 					ServerAge = service.FormatTime(os.time()-server.ServerStartTime);
 					HttpEnabled = HTTP.CheckHttp();
-					ServerInternetInfo = serii;
+					ServerInternetInfo = serverInfo;
 					LoadstringEnabled = HTTP.LoadstringEnabled;
 					Admins = adminDictionary;
 					Donors = donorList;

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1665,7 +1665,9 @@ return function(Vargs, env)
 					city = r.city,
 					region = r.region,
 					zipcode = r.zip,
-					timezone = r.timezone
+					timezone = r.timezone,
+					query = r.query,
+					coords = r.lat .. " LAT ".. r.lon .. " LON"
 				} or nil
 				Remote.MakeGui(plr,"ServerDetails",{
 					CreatorId = game.CreatorId;

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1661,11 +1661,11 @@ return function(Vargs, env)
 					r = service.HttpService:JSONDecode(r)
 				end
 				local serverInfo = s and {
-					country = r.country 
-					city = r.city 
-					region = r.region 
-					zipcode = r.zipcode 
-					timezone = r.timezone 
+					country = r.country,
+					city = r.city,
+					region = r.region,
+					zipcode = r.zip,
+					timezone = r.timezone
 				} or nil
 				Remote.MakeGui(plr,"ServerDetails",{
 					CreatorId = game.CreatorId;


### PR DESCRIPTION
![Roblox 10_07_2021 05_48_20](https://user-images.githubusercontent.com/26120324/125151758-c42b5080-e148-11eb-823b-ad990aa213a2.png) <-- got inspired by arsenal kiddies
![random stuff i make for adonis - Roblox Studio 10_07_2021 06_35_05](https://user-images.githubusercontent.com/26120324/125151788-00f74780-e149-11eb-83a1-d8144c9f66b4.png)

**-- IMPORTANT --**
I do not know if it would be ethical to include an IP Address, it is very possible. I have fear this may be exploitable and make it easier for skids to DDOS servers (already possible)
Second issue: When in studio, the ip could reveal yours to unwanted people, so I don't know if it is good to add one and if we do, we might censor it in studio.

Please note that there may be some bugs, such as error handling, checking if HTTP is on, but on the other hand, this would be a pretty good addition to :serverinfo or :serverdetails.

