### PR TITLE
Fix error locale Timezone unavailable

### DIFF
--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -941,7 +941,12 @@ return function(errorHandler, eventChecker, fenceSpecific)
 				return tim:FormatUniversalTime(formatString, "en-gb") -- Always show UTC in 24 hour format
 			else
 				local locale = service.Players.LocalPlayer.LocaleId
-				return tim:FormatLocalTime(formatString, locale) -- Show in player's local timezone and format
+				local succes,err = pcall(function()
+					return tim:FormatLocalTime(formatString, locale) -- Show in player's local timezone and format
+				end)
+				if err then
+					return tim:FormatLocalTime(formatString, "en-gb") -- show UTC in 24 hour format because player's local timezone is not available in DateTimeLocaleConfigs
+				end
 			end
 		end;
 


### PR DESCRIPTION
When the DateTimeLocaleConfig file of the player's LocaleId is not available, it throws an error.
![image](https://user-images.githubusercontent.com/87205936/125175083-1eb8c100-e1ca-11eb-89d2-30eff4535c9f.png)

Because of this error all the logs are broken and wont show up. To fix this, i added a try-catch statement to check for this. If the DateTimeLocaleConfig is not available, it will default to "en-gb".

In my case "nl-nl" (which is my LocaleId) is not a DatetimeLocaleConfig and the logs are broken because of that.
