### PR TITLE
Remove Agents

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -125,7 +125,6 @@ local descs = {};			--// Contains settings descriptions
 				Admins				- Card Format: Same as settings.Admins
 				HeadAdmins				- Card Format: Same as settings.HeadAdmins
 				Creators			- Card Format: Same as settings.Creators
-				Agents				- Card Format: Same as settings.Admins
 				Banlist				- Card Format: Same as settings.Banned
 				Mutelist			- Card Format: Same as settings.Muted
 				Blacklist			- Card Format: Same as settings.Blacklist

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1332,7 +1332,6 @@ return function(Vargs, env)
 			Hidden = false;
 			Description = "Shows you a list of items currently in the target player(s) backpack";
 			Fun = false;
-			Agents = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				for i,v in pairs(service.GetPlayers(plr,args[1])) do
@@ -1361,7 +1360,6 @@ return function(Vargs, env)
 			Hidden = false;
 			Description = "Shows you all players currently in-game, including nil ones";
 			Fun = false;
-			Agents = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				local plrs = {}
@@ -1551,7 +1549,6 @@ return function(Vargs, env)
 			Commands = {"view";"watch";"nsa";"viewplayer";};
 			Args = {"player";};
 			Description = "Makes you view the target player";
-			Agents = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				for i,v in pairs(service.GetPlayers(plr, args[1])) do
@@ -1567,7 +1564,6 @@ return function(Vargs, env)
 			Commands = {"viewport", "cctv"};
 			Args = {"player";};
 			Description = "Makes a viewport of the target player<s>";
-			Agents = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				for i,v in pairs(service.GetPlayers(plr, args[1])) do
@@ -1583,7 +1579,6 @@ return function(Vargs, env)
 			Commands = {"resetview";"rv";"fixview";"fixcam";"unwatch";"unview"};
 			Args = {"optional player"};
 			Description = "Resets your view";
-			Agents = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				if args[1] then
@@ -2990,7 +2985,6 @@ return function(Vargs, env)
 			Hidden = false;
 			Description = "Shows you where the target player(s) is/are";
 			Fun = false;
-			Agents = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				for i,v in next,service.GetPlayers(plr,args[1]) do
@@ -3040,7 +3034,6 @@ return function(Vargs, env)
 			Hidden = false;
 			Description = "Stops tracking the target player(s)";
 			Fun = false;
-			Agents = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				if args[1]:lower() == Settings.SpecialPrefix.."all" then
@@ -5711,7 +5704,6 @@ return function(Vargs, env)
 			Description = "View server log";
 			AdminLevel = "Moderators";
 			NoFilter = true;
-			Agents = true;
 			Function = function(plr,args)
 				local temp = {}
 				local auto
@@ -5749,7 +5741,6 @@ return function(Vargs, env)
 			Description = "View local log";
 			AdminLevel = "Moderators";
 			NoFilter = true;
-			Agents = true;
 			Function = function(plr,args)
 				local auto
 				if args[2] and type(args[2]) == "string" and (args[2]:lower() == "yes" or args[2]:lower() == "true") then
@@ -5807,7 +5798,6 @@ return function(Vargs, env)
 			Hidden = false;
 			Description = "View the exploit logs for the server OR a specific player";
 			Fun = false;
-			Agents = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				local auto
@@ -5833,7 +5823,6 @@ return function(Vargs, env)
 			Hidden = false;
 			Description = "Displays the current join logs for the server";
 			Fun = false;
-			Agents = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				local auto
@@ -5855,7 +5844,6 @@ return function(Vargs, env)
 			Commands = {"chatlogs","chats","chathistory"};
 			Args = {"autoupdate"};
 			Description = "Displays the current chat logs for the server";
-			Agents = true;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
 				local auto
@@ -5882,7 +5870,6 @@ return function(Vargs, env)
 			Args = {"autoupdate"};
 			Description = "View the admin logs for the server";
 			AdminLevel = "Moderators";
-			Agents = true;
 			Function = function(plr,args)
 				local auto
 				if args[1] and type(args[1]) == "string" and (args[1]:lower() == "yes" or args[1]:lower() == "true") then

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -799,23 +799,6 @@ return function(Vargs, env)
 			end
 		};
 
-		Agents = {
-			Prefix = Settings.PlayerPrefix;
-			Commands = {"agents";"trelloagents";"showagents";};
-			Args = {};
-			Hidden = true;
-			Description = "Shows a list of Trello agents pulled from the configured boards";
-			Fun = false;
-			AdminLevel = "Players";
-			Function = function(plr,args)
-				local temp={}
-				for i,v in pairs(HTTP.Trello.Agents) do
-					table.insert(temp,{Text = v,Desc = "A Trello agent"})
-				end
-				Remote.MakeGui(plr,"List",{Title = "Agents", Tab = temp})
-			end
-		};
-
 		Credits = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"credit";"credits";};

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -718,7 +718,6 @@ return function(Vargs)
 				local ran, error = service.TrackTask(tostring(plr) ..": ".. coma, com.Function, plr, args, {PlayerData = {
 					Player = plr;
 					Level = adminLvl;
-					isAgent = HTTP.Trello.CheckAgent(plr) or false;
 					isDonor = (Admin.CheckDonor(plr) and (Settings.DonorCommands or com.AllowDonors)) or false;
 				}})
 				--local task,ran,error = service.Threads.TimeoutRunTask("COMMAND:"..tostring(plr)..": "..coma,com.Function,60*5,plr,args)
@@ -738,7 +737,6 @@ return function(Vargs)
 				local ran, error = service.TrackTask(tostring(plr) ..": ".. coma, com.Function, plr, args, {PlayerData = {
 					Player = plr;
 					Level = 0;
-					isAgent = false;
 					isDonor = false;
 				}})
 				if error then
@@ -923,7 +921,6 @@ return function(Vargs)
 			local allowed = false
 			local p = pDat.Player
 			local adminLevel = pDat.Level
-			local isAgent = pDat.isAgent
 			local isDonor = (pDat.isDonor and (Settings.DonorCommands or cmd.AllowDonors))
 			local comLevel = cmd.AdminLevel
 			local funAllowed = Settings.FunCommands
@@ -933,8 +930,6 @@ return function(Vargs)
 			elseif cmd.Fun and not funAllowed then
 				return false
 			elseif cmd.Donors and isDonor then
-				return true
-			elseif cmd.Agents and isAgent then
 				return true
 			elseif comLevel == 0 and Settings.PlayerCommands then
 				return true
@@ -951,7 +946,6 @@ return function(Vargs)
 			local pDat = {
 				Player = p;
 				Level = Admin.GetLevel(p);
-				isAgent = HTTP.Trello.CheckAgent(p);
 				isDonor = Admin.CheckDonor(p);
 			}
 

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -1226,8 +1226,6 @@ return function(Vargs)
 
 				GetLevel = service.MetaFunc(Admin.GetLevel);
 
-				CheckAgent = service.MetaFunc(HTTP.Trello.CheckAgent);
-
 				SetLighting = service.MetaFunc(Functions.SetLighting);
 
 				SetPlayerLighting = service.MetaFunc(Remote.SetLighting);

--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -66,7 +66,6 @@ return function(Vargs)
 			Bans = {};
 			Music = {};
 			InsertList = {};
-			Agents = {};
 			Blacklist = {};
 			Whitelist = {};
 			PerformedCommands = {};
@@ -85,7 +84,6 @@ return function(Vargs)
 					local HeadAdmins = {}
 					local helpers = {}
 					local creators = {}
-					local agents = {}
 					local music = {}
 					local insertlist = {}
 					local mutes = {}
@@ -115,7 +113,6 @@ return function(Vargs)
 						local insertList = trello.getListObj(lists,{"InsertList","Insert List","Insertlist","Inserts","ModelList","Model List","Modellist","Models"})
 						local permList = trello.getListObj(lists,{"Permissions","Permission List","Permlist"})
 						local muteList = trello.getListObj(lists,{"Mutelist","Mute List"})
-						local agentList = trello.getListObj(lists,{"Agents","Agent List","Agentlist"})
 						local bList = trello.getListObj(lists,{"Blacklist"})
 						local wList = trello.getListObj(lists,{"Whitelist"})
 
@@ -133,7 +130,6 @@ return function(Vargs)
 						getNames(modList, mods);
 						getNames(adminList, admins)
 						getNames(ownerList, HeadAdmins);
-						getNames(agentList, agents);
 						getNames(muteList, mutes);
 						getNames(bList, blacklist);
 						getNames(wList, whitelist);
@@ -211,7 +207,6 @@ return function(Vargs)
 					if #music>0 then HTTP.Trello.Music = music end
 					if #insertlist>0 then HTTP.Trello.InsertList = insertlist end
 					if #mutes>0 then HTTP.Trello.Mutes = mutes end
-					if #agents>0 then HTTP.Trello.Agents = agents end
 					if #blacklist>0 then HTTP.Trello.Blacklist = blacklist end
 					if #whitelist>0 then HTTP.Trello.Whitelist = whitelist end
 
@@ -258,14 +253,6 @@ return function(Vargs)
 						Text = "Updated Trello Data";
 						Desc = "Data was retreived from Trello";
 					})
-				end
-			end;
-
-			CheckAgent = function(p)
-				for ind,v in pairs(HTTP.Trello.Agents) do
-					if Admin.DoCheck(p,v) then
-						return true
-					end
 				end
 			end;
 		};

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -415,7 +415,7 @@ return function(Vargs)
 			end;
 
 			RemoteLogs = function(p)
-				if Admin.CheckAdmin(p) or HTTP.Trello.CheckAgent(p) then
+				if Admin.CheckAdmin(p) then
 					return Logs.RemoteFires
 				end
 			end;

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -208,7 +208,6 @@ return function(Vargs)
 						local pDat = {
 							Player = opts.Player or p;
 							Level = opts.AdminLevel or Admin.GetLevel(p);
-							isAgent = opts.IsAgent or HTTP.Trello.CheckAgent(p);
 							isDonor = opts.IsDonor or (Admin.CheckDonor(p) and (Settings.DonorCommands or command.AllowDonors));
 						}
 

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -125,7 +125,6 @@ local descs = {};			--// Contains settings descriptions
 				Admins				- Card Format: Same as settings.Admins
 				HeadAdmins				- Card Format: Same as settings.HeadAdmins
 				Creators			- Card Format: Same as settings.Creators
-				Agents				- Card Format: Same as settings.Admins
 				Banlist				- Card Format: Same as settings.Banned
 				Mutelist			- Card Format: Same as settings.Muted
 				Blacklist			- Card Format: Same as settings.Blacklist


### PR DESCRIPTION
Agents have more or less been deprecated since the Adonis Trello board included in the loader by default became defunct, so it may be time to remove them entirely. With the introduction of more customizable custom ranks, the need for agents as a feature has decreased significantly, also.

Although I don't think removing them entirely now would cause too many issues, if people feel that it will cause issues then we could also add a notification of some sort that appears to place owners alerting them that agents will be removed soon before merging this.