### PR TITLE
Fixes/Updates to Inspect

### DIFF
--- a/MainModule/Client/UI/Default/Inspect.lua
+++ b/MainModule/Client/UI/Default/Inspect.lua
@@ -1,12 +1,9 @@
 client = nil
 service = nil
+Routine = nil
 
 local function boolToStr(bool)
-	if bool then
-		return "Yes"
-	else
-		return "No"
-	end
+	return bool and "Yes" or "No"
 end
 
 local function assetTypeToStr(int)
@@ -50,6 +47,11 @@ local function formatColor3(color)
 end
 
 return function(data)
+	local client = client
+	local service = client.Service
+
+	local Routine = Routine
+
 	local player = data.Target
 
 	local window = client.UI.Make("Window", {
@@ -116,7 +118,7 @@ return function(data)
 		addGeneralEntry("Account Age:", player.AccountAge .. " days ("..string.format("%.2f", player.AccountAge/365).." years)", "How long the player has been registered on Roblox")
 		addGeneralEntry("Membership:", player.MembershipType.Name, "The player's Roblox membership type")
 		i = i + 1
-		addGeneralEntry("Safe Chat Enabled:", boolToStr(data.SafeChat), "Does the player have safe chat enabled?")
+		addGeneralEntry("Safe Chat Enabled:", (data.SafeChat), "Does the player have safe chat enabled?")
 		addGeneralEntry("Can Chat:", boolToStr(data.CanChat), "Does the player's account settings allow them to chat?")
 		addGeneralEntry("Country/Region Code:", data.Code, "The player's country or region code based on geolocation")
 		addGeneralEntry("Is Roblox Staff:", boolToStr(player:IsInGroup(1200769) or player:IsInGroup(2868472)), "Is the player an official Roblox employee?")
@@ -137,16 +139,23 @@ return function(data)
 				Position = UDim2.new(0, 5, 0, (30*(i-1))+5);
 				TextXAlignment = "Left";
 			})
+			
+			if value["Image"] then
+				Routine(service.ContentProvider.PreloadAsync, service.ContentProvider, {
+					value["Image"]
+				})
+			end
+
 			entry:Add(valueType, value)
 
 			i = i + 1
 		end
 
-		local humDesc = game:GetService("Players"):GetHumanoidDescriptionFromUserId(player.UserId)
+		local humDesc = service.Players:GetHumanoidDescriptionFromUserId(player.UserId)
 
-		addAvatarEntry("Head Shot Thumbnail:", "ImageLabel", {BackgroundTransparency = 1;Size = UDim2.new(0, 30, 1, 0);Position = UDim2.new(1, -30, 0, 0);Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size48x48);})
-		addAvatarEntry("Avatar Bust Thumbnail:", "ImageLabel", {BackgroundTransparency = 1;Size = UDim2.new(0, 30, 1, 0);Position = UDim2.new(1, -30, 0, 0);Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.AvatarBust, Enum.ThumbnailSize.Size48x48);})
-		addAvatarEntry("Avatar Thumbnail:", "ImageLabel", {BackgroundTransparency = 1;Size = UDim2.new(0, 30, 1, 0);Position = UDim2.new(1, -30, 0, 0);Image = game:GetService("Players"):GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.AvatarThumbnail, Enum.ThumbnailSize.Size48x48);})
+		addAvatarEntry("Head Shot Thumbnail:", "ImageLabel", {BackgroundTransparency = 1;Size = UDim2.new(0, 30, 1, 0);Position = UDim2.new(1, -30, 0, 0);Image = service.Players:GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size48x48);})
+		addAvatarEntry("Avatar Bust Thumbnail:", "ImageLabel", {BackgroundTransparency = 1;Size = UDim2.new(0, 30, 1, 0);Position = UDim2.new(1, -30, 0, 0);Image = service.Players:GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.AvatarBust, Enum.ThumbnailSize.Size48x48);})
+		addAvatarEntry("Avatar Thumbnail:", "ImageLabel", {BackgroundTransparency = 1;Size = UDim2.new(0, 30, 1, 0);Position = UDim2.new(1, -30, 0, 0);Image = service.Players:GetUserThumbnailAsync(player.UserId, Enum.ThumbnailType.AvatarThumbnail, Enum.ThumbnailSize.Size48x48);})
 		addAvatarEntry("Body Type Scale:", "TextLabel", {Text = " "..humDesc.BodyTypeScale.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "The factor by which the shape of the Humanoid rig is interpolated from the standard R15 body shape shape (0) to a taller and more slender body type (1)")
 		addAvatarEntry("Depth Scale:", "TextLabel", {Text = " "..humDesc.DepthScale.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "The factor by which the depth (back-to-front distance) of the Humanoid rig is scaled")
 		addAvatarEntry("Height Scale:", "TextLabel", {Text = " "..humDesc.HeightScale.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "The factor by which the height (top-to-bottom distance) of the Humanoid rig is scaled")
@@ -164,11 +173,11 @@ return function(data)
 
 		i = i + 1
 
-		spawn(function()
+		Routine(function()
 			for _, category in ipairs({{humDesc.ClimbAnimation,humDesc.Face,humDesc.FallAnimation,humDesc.Head,humDesc.IdleAnimation,humDesc.JumpAnimation,humDesc.LeftArm,humDesc.LeftLeg,humDesc.Pants,humDesc.RightArm,humDesc.RightLeg,humDesc.RunAnimation,humDesc.Shirt,humDesc.SwimAnimation,humDesc.Torso,humDesc.WalkAnimation},string.split(humDesc.BackAccessory),string.split(humDesc.FaceAccessory),string.split(humDesc.FrontAccessory),string.split(humDesc.HairAccessory),string.split(humDesc.HatAccessory),string.split(humDesc.ShouldersAccessory),string.split(humDesc.WaistAccessory),string.split(humDesc.NeckAccessory)}) do
 				for _, itemId in ipairs(category) do
 					if itemId and itemId ~= 0 and tonumber(itemId) ~= nil then
-						local info = game:GetService("MarketplaceService"):GetProductInfo(itemId)
+						local info = service.MarketplaceService:GetProductInfo(itemId)
 						addAvatarEntry(info.Name, "TextLabel", {Text = " "..assetTypeToStr(info.AssetTypeId).."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";}, "ID: "..itemId.." | Creator: "..(info.Creator.Name or ("[None]")).." | Price: "..(info.PriceInRobux or "0").." Robux")
 					end
 				end
@@ -202,9 +211,12 @@ return function(data)
 
 		for item, pageNo in iterPageItems(friendPages) do
 			table.insert(sortedFriends, item.Username)
-			friendInfo[item.Username] = {id=item.Id;displayName=item.DisplayName;isOnline=item.IsOnline;}
+			friendInfo[item.Username] = {
+				id=item.Id;
+				displayName=item.DisplayName;
+				isOnline=item.IsOnline;
+			}
 		end
-
 		table.sort(sortedFriends)
 
 		local i = 2
@@ -236,12 +248,17 @@ return function(data)
 					TextXAlignment = "Right";
 				})
 			end
-			spawn(function()
+			Routine(function()
+				local friendHeadshot = service.Players:GetUserThumbnailAsync(friendInfo[friendName].id, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size48x48)
 				entry:Add("ImageLabel", {
-					Image = game:GetService("Players"):GetUserThumbnailAsync(friendInfo[friendName].id, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size48x48);
+					Image = friendHeadshot;
 					BackgroundTransparency = 1;
 					Size = UDim2.new(0, 30, 0, 30);
 					Position = UDim2.new(0, 0, 0, 0);
+				})
+
+				service.ContentProvider:PreloadAsync({
+					friendHeadshot
 				})
 			end)
 			i = i + 1
@@ -256,16 +273,28 @@ return function(data)
 
 		friendstab:ResizeCanvas(false, true, false, false, 5, 5)
 	end
-	
+
 
 	local sortedGroups = {}           -- Putting this code outside the DO for groupstab
 	local groupInfoRef = {}           -- because it'll be used by adonistab later to
 	for _, groupInfo in pairs(service.GroupService:GetGroupsAsync(player.UserId) or {}) do -- get the Epix Incorporated group logo.
+		
+		-- Preloading Group EmblemUrl(s) before player gets to not cause downloading of it when on the page
+		Routine(service.ContentProvider.PreloadAsync, service.ContentProvider, {
+			groupInfo.EmblemUrl
+		})
+
 		table.insert(sortedGroups, groupInfo.Name)
-		groupInfoRef[groupInfo.Name] = {Id=groupInfo.Id;Rank=groupInfo.Rank;Role=groupInfo.Role;IsPrimary=groupInfo.IsPrimary;EmblemUrl=groupInfo.EmblemUrl}
+		groupInfoRef[groupInfo.Name] = {
+			Id = groupInfo.Id;
+			Rank = groupInfo.Rank;
+			Role = groupInfo.Role;
+			IsPrimary = groupInfo.IsPrimary;
+			EmblemUrl = groupInfo.EmblemUrl
+		}
 	end
 	table.sort(sortedGroups)
-	
+
 	do
 		local i = 2
 		local groupCount = 0
@@ -291,7 +320,7 @@ return function(data)
 				Position = UDim2.new(1, -120, 0, 0);
 				TextXAlignment = "Right";
 			})
-			spawn(function()
+			Routine(function()
 				entry:Add("ImageLabel", {
 					Image = groupInfo.EmblemUrl;
 					BackgroundTransparency = 1;
@@ -366,6 +395,7 @@ return function(data)
 	do
 		local i = 1
 		local function addGameEntry(name, value, toolTip)
+			print(name.value,toolTip)
 			local entry = gametab:Add("TextLabel", {
 				Text = "  "..name.." ";
 				ToolTip = toolTip;

--- a/MainModule/Client/UI/Default/Inspect.lua
+++ b/MainModule/Client/UI/Default/Inspect.lua
@@ -395,7 +395,6 @@ return function(data)
 	do
 		local i = 1
 		local function addGameEntry(name, value, toolTip)
-			print(name.value,toolTip)
 			local entry = gametab:Add("TextLabel", {
 				Text = "  "..name.." ";
 				ToolTip = toolTip;

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6345,7 +6345,7 @@ return function(Vargs, env)
 
 					do
 						local policyResult, policyInfo = pcall(service.PolicyService.GetPolicyInfoForPlayerAsync, service.PolicyService, v)
-						hasSafeChat = policyResult and table.find(policyInfo.AllowedExternalLinkReferences, "Discord") and "Yes" or "No" or not policyResult and "Unable to be fetched"
+						hasSafeChat = policyResult and table.find(policyInfo.AllowedExternalLinkReferences, "Discord") and "No" or "Yes" or not policyResult and "Unable to be fetched"
 					end
 
 					Remote.MakeGui(plr, "Inspect", {

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -4311,7 +4311,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-		
+
 		JumpHeight = {
 			Prefix = Settings.Prefix;
 			Commands = {"jheight";"jumpheight";};
@@ -4439,8 +4439,7 @@ return function(Vargs, env)
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
-				for _,player in ipairs(server.Functions.GetPlayers(plr, args[1])) do
-
+				for _,player in ipairs(Functions.GetPlayers(plr, args[1])) do
 					player.Neutral = true
 					player.Team = nil
 					player.TeamColor = BrickColor.new(194) -- Neutral Team
@@ -5562,7 +5561,7 @@ return function(Vargs, env)
 									end
 								end
 							elseif rigType == Enum.HumanoidRigType.R15 then
-								local rig = server.Deps.Assets.RigR15
+								local rig = Deps.Assets.RigR15
 								local rigHumanoid = rig.Humanoid
 								local validParts = {}
 								for _,x in pairs(Enum.BodyPartR15:GetEnumItems()) do
@@ -6280,7 +6279,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-		
+
 		Reverb = {
 			Prefix = Settings.Prefix;
 			Commands = {"reverb","ambientreverb";};
@@ -6289,43 +6288,43 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr,args,data)
 				local rev = args[1]
-		
+
 				local reverbs = {"NoReverb","GenericReverb","PaddedCell","Room","Bathroom","LivingRoom",
-				"StoneRoom","Auditorium","ConcertHall","Cave","Arena","Hangar","CarpettedHallway",
-				"Hallway","StoneCorridor","Alley","Forest","City","Mountains","Quarry","Plain",
-				"ParkingLot","SewerPipe","UnderWater"}
-			
+					"StoneRoom","Auditorium","ConcertHall","Cave","Arena","Hangar","CarpettedHallway",
+					"Hallway","StoneCorridor","Alley","Forest","City","Mountains","Quarry","Plain",
+					"ParkingLot","SewerPipe","UnderWater"}
+
 				if not rev or not Enum.ReverbType[rev] then
-				
+
 					Functions.Hint("Argument 1 missing or nil. Opening Reverb List",{plr})
-				
+
 					local tab = {}
-				
+
 					table.insert(tab,{Text = "Note: Argument is CASE SENSITIVE"})
-				
+
 					for _,v in pairs(reverbs) do
-					table.insert(tab,{Text = v})
+						table.insert(tab,{Text = v})
 					end
-				
+
 					Remote.MakeGui(plr,"List",{Title = "Reverbs";Table = tab})
 
 					return
 				end
-			
+
 				if args[2] then
-				
+
 					for i,v in pairs(service.GetPlayers(plr,args[2])) do
-					Remote.LoadCode(v,"game:GetService(\"SoundService\").AmbientReverb = Enum.ReverbType["..rev.."]")
+						Remote.LoadCode(v,"game:GetService(\"SoundService\").AmbientReverb = Enum.ReverbType["..rev.."]")
 
 					end
-				
+
 					Functions.Hint("Changed Ambient Reverb of specified player(s)",{plr})
-			
+
 				else
-				
+
 					service.SoundService.AmbientReverb = Enum.ReverbType[rev]
 					Functions.Hint("Successfully changed the Ambient Reverb to "..rev,{plr})
-			
+
 				end
 			end
 		};
@@ -6339,35 +6338,24 @@ return function(Vargs, env)
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
-				local function checkSafeChat(player)
-					return service.TextService:FilterStringAsync("1234", player.UserId):GetNonChatStringForUserAsync(player.UserId) == "1234" and false or true
-				end
-
 				for i,v in pairs(service.GetPlayers(plr,args[1])) do
-					local _isMuted = false
-					local _isBanned = false
+					local hasSafeChat
+					local isMuted = table.find(Settings.Muted, v.Name..":"..v.UserId) and true or false
+					local isBanned = table.find(Settings.Banned, v.Name..":"..v.UserId) and true or false
 
-					if table.find(Settings.Muted, v.Name..":"..v.UserId) then
-						_isMuted = true
-					else
-						_isMuted = false
+					do
+						local policyResult, policyInfo = pcall(service.PolicyService.GetPolicyInfoForPlayerAsync, service.PolicyService, v)
+						hasSafeChat = policyResult and table.find(policyInfo.AllowedExternalLinkReferences, "Discord") and "Yes" or "No" or not policyResult and "Unable to be fetched"
 					end
 
-					local isBanned = false
-					if table.find(Settings.Banned, v.Name..":"..v.UserId) then
-						_isBanned = true
-					else
-						_isBanned = false
-					end
-
-					server.Remote.MakeGui(plr,"Inspect",{
+					Remote.MakeGui(plr, "Inspect", {
 						Target = v;
-						SafeChat = checkSafeChat(v);
+						SafeChat = hasSafeChat;
 						CanChat = service.Chat:CanUserChatAsync(v.UserId) or "[Error]";
-						AdminLevel = "["..server.Admin.GetLevel(v).."] "..server.Admin.LevelToListName(server.Admin.GetLevel(v));
-						IsDonor = service.MarketPlace:UserOwnsGamePassAsync(v.UserId, server.Variables.DonorPass[1]);
-						IsMuted = _isMuted;
-						IsBanned = _isBanned;
+						AdminLevel = "["..Admin.GetLevel(v).."] "..Admin.LevelToListName(Admin.GetLevel(v));
+						IsDonor = service.MarketPlace:UserOwnsGamePassAsync(v.UserId, Variables.DonorPass[1]);
+						IsMuted = isMuted;
+						IsBanned = isBanned;
 						Code = service.LocalizationService:GetCountryRegionForPlayerAsync(v) or "[Error]";
 						SourcePlace = v:GetJoinData().SourcePlaceId or "N/A";
 						Groups = service.GroupService:GetGroupsAsync(v.UserId);


### PR DESCRIPTION
`Inspect`:
SafeChat checking fix. (uses PolicyService and checks if `Discord` social link is able to be seen by the player, indicating that they are <13 and are unable to see social links)
Micro-optimization to improve some performance. (atleast)
Preloading to some thumbnails Inspect adds.
Switched from `spawn` global to Adonis's `Routine` as `spawn` has a delay in some timing of execution and `Routine` uses `coroutines`, which should make it faster.