### PR TITLE
Timeban Fixes/Updates, new Usage.

### DIFF
--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -14,12 +14,13 @@ return function(Vargs, env)
 			Commands = {"tban";"timedban";"timeban";};
 			Args = {"player";"number<s/m/h/d>";};
 			Hidden = false;
-			Description = "Bans the target player(s) for the supplied amount of time; Data Persistent; Undone using :undataban";
+			Description = "Bans the target player(s) for the supplied amount of time; Data Persistent; Undone using :untimeban";
 			Fun = false;
 			AdminLevel = "HeadAdmins";
 			Function = function(plr,args,data)
-				local time = args[2] or '60'
 				assert(args[1] and args[2], "Argument missing or nil")
+				local time = args[2]
+
 				if time:lower():sub(#time)=='s' then
 					time = time:sub(1,#time-1)
 					time = tonumber(time)
@@ -35,10 +36,12 @@ return function(Vargs, env)
 				end
 
 				local level = data.PlayerData.Level;
+				local timebans = Core.Variables.TimeBans
+
 				for i,v in next,service.GetPlayers(plr, args[1], false, false, true) do
 					if level > Admin.GetLevel(v) then
-						local endTime = tonumber(os.time())+tonumber(time)
-						local timebans = Core.Variables.TimeBans
+						local endTime = os.time() + tonumber(time)
+
 						local data = {
 							Name = v.Name;
 							UserId = v.UserId;
@@ -64,22 +67,22 @@ return function(Vargs, env)
 
 		UnTimeBan = {
 			Prefix = Settings.Prefix;
-			Commands = {"untimeban";};
+			Commands = {"untimeban";"untimedban";"untban";};
 			Args = {"player";};
 			Hidden = false;
-			Description = "UnBan";
+			Description = "Removes specified player from Timebans list";
 			Fun = false;
 			AdminLevel = "HeadAdmins";
 			Function = function(plr,args)
 				assert(args[1], "Argument missing or nil")
 				local timebans = Core.Variables.TimeBans or {}
+
 				for i, data in next, timebans do
 					if data.Name:lower():sub(1,#args[1]) == args[1]:lower() then
 						table.remove(timebans, i)
 						Core.DoSave({
 							Type = "TableRemove";
-							Table = "TimeBans";
-							Parent = "Variables";
+							Table = {"Core", "Variables", "TimeBans"};
 							Value = data;
 						})
 

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -35,6 +35,8 @@ return function(Vargs, env)
 					time = ((tonumber(time)*60)*60)*24
 				end
 
+				assert(tonumber(time), "Unable to cast time, check "..Settings.PlayerPrefix.."usage for more infomation on timeban.")
+
 				local level = data.PlayerData.Level;
 				local timebans = Core.Variables.TimeBans
 

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -111,15 +111,18 @@ return function(Vargs, env)
 				local tab = {}
 				local variables = Core.Variables
 				local timeBans = Core.Variables.TimeBans or {}
-				for _, v in ipairs(timeBans) do
+
+				for ind, v in pairs(timeBans) do
 					local timeLeft = v.EndTime - os.time()
 					local minutes = Functions.RoundToPlace(timeLeft / 60, 2)
+
 					if timeLeft <= 0 then
-						table.remove(Core.Variables.TimeBans, i)
+						table.remove(Core.Variables.TimeBans, ind)
 					else
 						table.insert(tab, {Text = tostring(v.Name)..":"..tostring(v.UserId), Desc = "Minutes Left: "..tostring(minutes)})
 					end
 				end
+
 				Remote.MakeGui(plr, "List", {Title = 'Time Bans', Tab = tab})
 			end
 		};
@@ -133,6 +136,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
 				assert(args[1] and args[2], "Argument missing or nil")
+
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
 					Remote.MakeGui(v ,"Notification", {
 						Title = "Notification";

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -874,6 +874,8 @@ return function(Vargs, env)
 			Function = function(plr,args)
 				local usage={
 					'Mouse over things in lists to expand them';
+					'Commands: ';
+					'Timeban, Works with non-ingame players, '.. Settings.Prefix ..'tban Player time(d/h/m/s) | Example Usage: '.. Settings.Prefix ..'timeban Sceleratis 10h (10 hours ban), d = days, h = hour, m = minutes, s = seconds';
 					'Special Functions: ';
 					'Ex: '..Settings.Prefix..'kill FUNCTION, so like '..Settings.Prefix..'kill '..Settings.SpecialPrefix..'all';
 					'Put /e in front to make it silent (/e '..Settings.Prefix..'kill scel)';

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -1066,7 +1066,7 @@ return function(Vargs)
 									table.remove(Core.Variables.TimeBans, i)
 									Core.DoSave({
 										Type = "TableRemove";
-										Table = {"Variables", "TimeBans"};
+										Table = {"Core", "Variables", "TimeBans"};
 										Value = v;
 									})
 								end


### PR DESCRIPTION
`Commands.UnTimeBan`:

added `untban`/`untimedban` alias.

`Commands.TimeBanList`:
Fixed bug with removing users possibly preventing the whole command being broken (apparently someones change changed i to _, causing an unknown variable)

`Core` (line:1069):
Added persistent `Table` table for untimeban related removals.

`Commands.Usage`:
Add new usage `Timeban` to let people understand what timebans (d/h/m/s) does.
