### PR TITLE
Fix filtering/Chat limit kick.

### DIFF
--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -399,13 +399,9 @@ return function(Vargs)
 		end;
 
 		Chat = function(p, msg)
-			if Settings.Detection and p.userId < 0 and tostring(p):match("^Guest") then
-				Anti.Detected(p, "kick", "Talking guest")
-			end
-
 			if RateLimit(p, "Chat") then
 				local isMuted = Admin.IsMuted(p);
-				if #msg > Process.MaxChatCharacterLimit and not Admin.CheckAdmin(p) then
+				if utf8.len(utf8.nfcnormalize(msg)) > Process.MaxChatCharacterLimit and not Admin.CheckAdmin(p) then
 					Anti.Detected(p, "Kick", "Chatted message over the maximum character limit")
 				elseif not isMuted then
 					local msg = string.sub(msg, 1, Process.MsgStringLimit);

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -651,10 +651,16 @@ return function(errorHandler, eventChecker, fenceSpecific)
 		end;
 
 		Filter = function(str,from,to)
+			if not utf8.len(str) then
+				return "Filter Error"
+			end
+
 			local new = ""
 			local lines = service.ExtractLines(str)
 			for i = 1,#lines do
-				local ran,newl = pcall(function() return service.TextService:FilterStringAsync(lines[i],from.UserId):GetChatForUserAsync(to.UserId) end)
+				local ran,newl = pcall(function()
+					return service.TextService:FilterStringAsync(lines[i],from.UserId):GetChatForUserAsync(to.UserId)
+				end)
 				newl = (ran and newl) or lines[i] or ""
 				if i > 1 then
 					new = new.."\n"..newl
@@ -669,6 +675,10 @@ return function(errorHandler, eventChecker, fenceSpecific)
 			if tonumber(str) then				-- to avoid major filter related problems (like commands becoming unusable due to numbers or names being filtered)
 				return str						-- Please consider dropping the filter rules down a notch or improving on the existing filtering methods
 			elseif type(str) == "string" then	-- Also always feel free to message me with any concerns you have :)!
+				if not utf8.len(str) then
+					return "Filter Error"
+				end
+
 				if cmd and #service.GetPlayers(from, str, true) > 0 then
 					return str
 				else
@@ -680,6 +690,10 @@ return function(errorHandler, eventChecker, fenceSpecific)
 		end;
 
 		BroadcastFilter = function(str,from)
+			if not utf8.len(str) then
+				return "Filter Error"
+			end
+
 			local new = ""
 			local lines = service.ExtractLines(str)
 			for i = 1,#lines do


### PR DESCRIPTION
`Service`:
Add `ccuser44`'s old pull from a few months ago into this as they haven't ever resolved the conflict (https://github.com/Sceleratis/Adonis/pull/333)

`Server/Process`:
Removed guest checks.
Switch from # (len) to utf8.len+utf8.nfcnormalize (what Roblox does to check chat lengths in ChatModules), many chinese/other unicodes actually exceed this limit with #/string.len and utf8 is a way to fix it so switching should fix many false kicks.