### PR TITLE
Help button for command list + Notepad update

### DIFF
--- a/MainModule/Client/UI/Default/List.lua
+++ b/MainModule/Client/UI/Default/List.lua
@@ -4,6 +4,7 @@ service = nil
 
 return function(data)
 	local Title = data.Title
+	local TitleButtons = data.TitleButtons or {}
 	local Tabs = data.Tabs
 	local Tab = data.Table or data.Tab
 	local Update = data.Update
@@ -158,7 +159,7 @@ return function(data)
 	window = client.UI.Make("Window",{
 		Name  = "List";
 		Title = Title;
-		Size  = Size or {225, 200};
+		Size  = Size or {240, 225};
 		MinSize = {150, 100};
 		OnRefresh = Update and function()
 			Tab = client.Remote.Get("UpdateList", Update, unpack(UpdateArgs or {UpdateArg}))
@@ -295,6 +296,10 @@ return function(data)
 			end
 		end
 	})
+
+	for i, v in ipairs(TitleButtons) do
+		window:AddTitleButton(v)
+	end
 
 	search = window:Add("TextBox", {
 		Size = UDim2.new(1, -10, 0, 20);

--- a/MainModule/Client/UI/Default/Notepad.lua
+++ b/MainModule/Client/UI/Default/Notepad.lua
@@ -78,7 +78,7 @@ return function(data)
 				TextXAlignment = "Right";
 				ClipsDescendants = true;
 				TextChanged = function(text, enter, new)
-					if enter and tonumber(text) and #text < 1000 then
+					if enter and tonumber(text) and text < 1000 then
 						content.TextSize = text;
 					end
 				end

--- a/MainModule/Client/UI/Default/Notepad.lua
+++ b/MainModule/Client/UI/Default/Notepad.lua
@@ -48,7 +48,7 @@ return function(data)
 	
 	local fonts = {}
 	for _, font in ipairs(Enum.Font:GetEnumItems()) do
-		table.insert(fonts, tostring(font):sub(11))
+		table.insert(fonts, font.Name)
 	end
 	local fontSelector = topbar:Add("Dropdown", {
 		Size = UDim2.new(0, 140, 1, -8);
@@ -60,6 +60,30 @@ return function(data)
 		OnSelect = function(selection)
 			content.Font = selection
 		end;
+	})
+	
+	local sizeControl = topbar:Add("TextLabel", {
+		Text = "  Size: ";
+		BackgroundTransparency = 0;
+		Size = UDim2.new(0, 80, 1, -8);
+		Position = UDim2.new(0, 155, 0, 4);
+		TextXAlignment = "Left";
+		Children = {
+			TextBox = {
+				Text = "";
+				PlaceholderText = "18";
+				Size = UDim2.new(0, 26, 1, 0);
+				Position = UDim2.new(1, -31, 0, 0);
+				BackgroundTransparency = 1;
+				TextXAlignment = "Right";
+				ClipsDescendants = true;
+				TextChanged = function(text, enter, new)
+					if enter and tonumber(text) and #text < 1000 then
+						content.TextSize = text;
+					end
+				end
+			}
+		}
 	})
 
 	window:Ready()

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -66,6 +66,12 @@ return function(Vargs, env)
 					{
 						Title = "Commands ("..cmdCount..")";
 						Table = tab;
+						TitleButtons = {
+							{
+								Text = "?";
+								OnClick = Core.Bytecode("client.Remote.Send('ProcessCommand','"..Settings.PlayerPrefix.."usage')")
+							}
+						};
 					}
 				)
 			end


### PR DESCRIPTION
- List UIs can now have window title buttons.
- Added a 'help' title button to cmd list that shows usage info.
- Increased the default window size of lists.
- Text size customization for notepad UI.

![Screenshot_20210727-112959_Roblox.jpg](https://user-images.githubusercontent.com/81153405/127091052-553f1297-632d-40e8-8227-04997bae84bd.jpg)

![Screenshot_20210727-113124_Roblox.jpg](https://user-images.githubusercontent.com/81153405/127091062-fe874ec6-d2ec-45e4-a708-0a99bca8a9d4.jpg)