### PR TITLE
ESP Error fix [Nametag removal]

### DIFF
--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -176,7 +176,7 @@ return function()
 
 			for obj in pairs(Variables.ESPObjects) do
 				if not mode or not target or (target and obj:IsDescendantOf(target)) then
-					local __ADONIS_NAMETAG = obj.Parent:FindFirstChild("__ADONIS_NAMETAG")
+					local __ADONIS_NAMETAG = obj.Parent and obj.Parent:FindFirstChild("__ADONIS_NAMETAG")
 					if __ADONIS_NAMETAG then
 						__ADONIS_NAMETAG:Destroy()
 					end


### PR DESCRIPTION
`Nametag l: 179`:
Fix error while removing ESPObjects, seemed like an ESPObject was in nil and the parent thus was going to nil which was no parent so it was unable to `FindFirstChild` a child as it was nil.
![RobloxPlayerBeta_RN6AckGZix](https://user-images.githubusercontent.com/64731916/127525011-ba6e7dbc-6b11-464a-a216-bd880cf4f780.png)
