### PR TITLE
don't upload to webhook if event is a pr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
       
       - name: Send file nightly build to Discord channel
         uses: tsickert/discord-webhook@v3.0.0
+        if: github.event_name != 'pull_request'
         with:
           webhook-url: ${{ secrets.NIGHTLY_WEBHOOK }}
           filename: Adonis_Nightly_${{ steps.date.outputs.date }}.rbxm


### PR DESCRIPTION
pretty sure it wouldn't work anyway as secrets aren't provided to prs, but the workflow would appear like it failed so might as well