### PR TITLE
Admin/Remote/Process/Service/CRS Updates

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -936,8 +936,9 @@ return function(Vargs)
 		end;
 
 		StringToComLevel = function(str)
-			if type(str) == "number" then return str end;
-			if string.lower(str) == "players" then return 0 end;
+			local strType = type(str)
+			if strType == "string" and string.lower(str) == "players" then return 0 end;
+			if strType == "number" then return str end;
 
 			local lvl = Settings.Ranks[str];
 			return (lvl and lvl.Level) or tonumber(str);
@@ -951,7 +952,7 @@ return function(Vargs)
 			if type(comLevel) == "number" and plrAdminLevel >= comLevel then
 				return true;
 			elseif type(comLevel) == "table" then
-				for i,level in next, comLevel do
+				for i,level in pairs(comLevel) do
 					if plrAdminLevel == level then
 						return true;
 					end
@@ -968,8 +969,6 @@ return function(Vargs)
 		end;
 
 		CheckPermission = function(pDat, cmd)
-			local allowed = false
-			local p = pDat.Player
 			local adminLevel = pDat.Level
 			local isDonor = (pDat.isDonor and (Settings.DonorCommands or cmd.AllowDonors))
 			local comLevel = cmd.AdminLevel

--- a/MainModule/Server/Core/Remote.lua
+++ b/MainModule/Server/Core/Remote.lua
@@ -852,7 +852,9 @@ return function(Vargs)
 
 			ProcessCommand = function(p,args)
 				if Process.RateLimit(p, "Command") then
-					Process.Command(p,args[1],{Check=true})
+					Process.Command(p, args[1], {
+						Check = true
+					})
 				elseif Process.RateLimit(p, "RateLog") then
 					Anti.Detected(p, "Log", string.format("Running commands too quickly (>Rate: %s/sec)", 1/Process.RateLimits.Chat));
 					warn(string.format("%s is running commands too quickly (>Rate: %s/sec)", p.Name, 1/Process.RateLimits.Chat));

--- a/MainModule/Server/Plugins/Cross_Server.lua
+++ b/MainModule/Server/Plugins/Cross_Server.lua
@@ -81,7 +81,9 @@ return function(Vargs)
 		end;
 
 		DataStoreUpdate = function(jobId, type, data)
-			server.Process.DataStoreUpdated(type, data)
+			if type and data then
+				Routine(Core.LoadData, type, data)
+			end
 		end;
 
 		UpdateSetting = function(jobId, setting, newValue)

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -60,34 +60,38 @@ return function(errorHandler, eventChecker, fenceSpecific)
 
 	main = server or client
 	ErrorHandler = errorHandler
+
 	server = nil
 	client = nil
 
-	local Kill = main.Kill
 	local service;
+
 	local WaitingEvents = {}
 	local HookedEvents = {}
 	local Debounces = {}
 	local Queues = {}
 	local RbxEvents = {}
 	local LoopQueue = {}
-	local FilterCache = {}
 	local TrackedTasks = {}
 	local RunningLoops = {}
 	local TaskSchedulers = {}
 	local ServiceVariables = {}
-	local CreatedItems = setmetatable({},{__mode = "v"});
-	local Wrappers = setmetatable({},{__mode = "kv"});
+
+	local CreatedItems = setmetatable({}, {__mode = "v"})
+	local Wrappers = setmetatable({}, {__mode = "kv"})
+
 	local oldInstNew = Instance.new
 	local WrapService = Instance.new("Folder")
 	local ThreadService = Instance.new("Folder")
 	local HelperService = Instance.new("Folder")
 	local EventService = Instance.new("Folder")
+
 	local Instance = {new = function(obj, parent) return service and client and service.Wrap(oldInstNew(obj, service.UnWrap(parent)), true) or oldInstNew(obj, parent) end}
 	local Events, Threads, Wrapper, Helpers = {
 		TrackTask = function(name, func, ...)
-			local index = math.random()
+			local index = (main and main.Functions and main.Functions:GetRandom()) or math.random();
 			local isThread = string.sub(name, 1, 7) == "Thread:"
+
 			local data = {
 				Name = name;
 				Status = "Waiting";


### PR DESCRIPTION
This is quite a long one.

`Admin`:
cached `type` check and checked for string first instead of number.
Changed from `next` to `pairs`.
Removed useless variables.

`Process`:
Changed from using `tostring` on the `player` instance to indexing the `Name` property. (Most likely some sort of RBXLocked/Non-fe trace)
Changed to some `cached functions` Init sets that weren't being used in some parts of the code of Process.
Removed `DataStoreUpdated` as its used only once inside `CrossServer`.

`Process/Command`:
Removed variables that were never used.
Changed from `string metamethods` to `string library` functions for some optimiations.
Spaced out table contents for more readability.
Spaced out `Tracktask` for more readability inside Command.

`Remote`:
Spaced out table in `ProcessCommand` for more readability.

`Service`:
Spaced out some tables and removed one useless table.
Checks for `Functions.GetRandom` instead of using `math.random` as a solution, and if not found it will use `math.random` instead.

`Plugins/CrossServer`:
Did the Routine inside CrossServer as its only used once and thats inside the Plugin.