### PR TITLE
Update Teleport to CFrame

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -4796,7 +4796,7 @@ return function(Vargs, env)
 								v.Character.Humanoid.Jump = true
 							end
 							wait()
-							v.Character:MoveTo(point)
+							v.Character.HumanoidRootPart.CFrame = CFrame.new(point)
 						end
 					end
 
@@ -4812,7 +4812,7 @@ return function(Vargs, env)
 							v.Character.Humanoid.Jump = true
 						end
 						wait()
-						v.Character:MoveTo(Vector3.new(tonumber(x),tonumber(y),tonumber(z)))
+						v.Character.HumanoidRootPart.CFrame = CFrame.new(Vector3.new(tonumber(x),tonumber(y),tonumber(z))))
 					end
 				else
 					local target = service.GetPlayers(plr,args[2])[1]


### PR DESCRIPTION
This change updates the teleport command to edit the character's HumanoidRootPart's CFrame, instead of using :MoveTo(). This fixes server-sided anti-exploits flagging players for being teleported, as they use CFrame to calculate this.