### PR TITLE
Explorer improvements + permission fix (serverinfo UI)

### DIFF
--- a/MainModule/Client/UI/Default/Explorer.lua
+++ b/MainModule/Client/UI/Default/Explorer.lua
@@ -8,7 +8,7 @@ return function(data)
 	local lastObject = game
 	local curObject = game
 	local scroller, search
-	
+
 	local window = client.UI.Make("Window",{
 		Name  = "Explorer";
 		Title = "Game Explorer";
@@ -19,31 +19,19 @@ return function(data)
 			getList(curObject)
 		end
 	})
-	
+
 	function newEntry(obj, name, numPos, isBack)
 		local new = scroller:Add("TextLabel", {
 			Text = "  "..tostring(name);
-			ToolTip = obj.ClassName;
+			ToolTip = ("Class: %s | Children: %d | Descendants: %d"):format(obj.ClassName, #obj:GetChildren(), #obj:GetDescendants());
 			TextXAlignment = "Left";
-			Size = UDim2.new(1, 0, 0, 30);
-			Position = UDim2.new(0, 0, 0, 30*numPos);
-		})
-		
-		local del = new:Add("TextButton",{
-			Text = "Delete";
-			Size = UDim2.new(0, 80, 0, 30);
-			Position = UDim2.new(1, -160, 0, 0);
-			Visible = not isBack;
-			OnClick = function()
-				curObject = curObject.Parent or game
-				client.Remote.Send("HandleExplore", obj, "Delete")
-				getList(curObject)
-			end;
+			Size = UDim2.new(1, 0, 0, 26);
+			Position = UDim2.new(0, 0, 0, 26*numPos);
 		})
 		
 		local open = new:Add("TextButton", {
 			Text = "Open";
-			Size = UDim2.new(0, 80, 0, 30);
+			Size = UDim2.new(0, 80, 1, 0);
 			Position = UDim2.new(1, -80, 0, 0);
 			OnClick = function()
 				lastObject = curObject
@@ -51,8 +39,27 @@ return function(data)
 				getList(obj)
 			end;
 		})
+
+		if not (obj.Parent == game and obj.Name:sub(1,1):upper() == obj.Name:sub(1,1)) then
+			local del = new:Add("TextButton",{
+				Text = "Delete";
+				Size = UDim2.new(0, 80, 1, 0);
+				Position = UDim2.new(1, -160, 0, 0);
+				Visible = not isBack;
+				OnClick = function(self)
+					curObject = curObject.Parent or game
+					client.Remote.Send("HandleExplore", obj, "Delete")
+					if pcall(function() obj:Destroy() end) then
+						new.TextColor3 = Color3.fromRGB(255, 48, 48)
+						new.Text = new.Text.." [Deleted]"
+						open:Destroy()
+						self:Destroy()
+					end
+				end;
+			})
+		end
 	end
-	
+
 	function getList(obj)
 		local filter = search.Text
 		local num = 1
@@ -68,7 +75,7 @@ return function(data)
 		end
 		scroller:ResizeCanvas(false, true, false, false, 5, 5)
 	end
-	
+
 	if window then
 		scroller = window:Add("ScrollingFrame",{
 			List = {};
@@ -77,7 +84,7 @@ return function(data)
 			Position = UDim2.new(0, 5, 0, 30);
 			Size = UDim2.new(1,-10,1,-30);
 		})	
-		
+
 		search = window:Add("TextBox", {
 			Size = UDim2.new(1, -10, 0, 20);
 			Position = UDim2.new(0, 5, 0, 5);
@@ -88,11 +95,11 @@ return function(data)
 			PlaceholderText = "Search";
 			TextStrokeTransparency = 0.8;
 		})
-		
+
 		search.FocusLost:Connect(function(enter)
 			getList(curObject, search.Text)
 		end)
-		
+
 		getList(game)
 		gTable = window.gTable
 		window:Ready()

--- a/MainModule/Client/UI/Default/ServerDetails.lua
+++ b/MainModule/Client/UI/Default/ServerDetails.lua
@@ -152,7 +152,7 @@ return function(data)
 		addWorkspaceEntry("Cameras:", "TextLabel", {Text = " "..data.CameraCount.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";})
 		addWorkspaceEntry("Nil Players:", "TextLabel", {Text = " "..data.NilPlayerCount.."  ";BackgroundTransparency = 1;Size = UDim2.new(0, 120, 1, 0);Position = UDim2.new(1, -120, 0, 0);TextXAlignment = "Right";})
 
-		if client.Remote.Get("AdminLevel") > 2 then
+		if client.Remote.Get("AdminLevel") >= 300 then
 			workspacetab:Add("TextButton", {
 				Text = "Open Game Explorer";
 				BackgroundTransparency = (i%2 == 0 and 0) or 0.2;

--- a/MainModule/Server/Core/Remote.lua
+++ b/MainModule/Server/Core/Remote.lua
@@ -699,7 +699,15 @@ return function(Vargs)
 
 					if obj then
 						if com == "Delete" then
-							obj:Destroy()
+							if not pcall(function()
+									obj:Destroy()
+								end) then
+								Remote.MakeGui(p ,"Notification", {
+									Title = "Error";
+									Message = "Cannot delete object.";
+									Time = 2;
+								})
+							end
 						end
 					end
 				end


### PR DESCRIPTION
- Slight enhancements to the game explorer window, including better deletion handling
- Fixed permission checking issue for the server details window 'Open Game Explorer' button @GalacticInspired  (originally allowed for Level < 300 admins to access the game explorer via :serverinfo without proper perms to use :explorer)

Random fact: this is my first time ever using `self` in Lua code.