### PR TITLE
Rename owner rank mentions in loader to headadmins + typo fixes

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -218,7 +218,7 @@ local descs = {};			--// Contains settings descriptions
 	settings.OnJoin = {};		-- List of commands ran as player on join (ignores adminlevel)		Format: {":cmds"}
 	settings.OnSpawn = {};		-- List off commands ran as player on spawn (ignores adminlevel)	Format: {"!fire Really red",":ff me"}
 
-	settings.SaveAdmins = true		  -- If true anyone you :admin or :owner in-game will save
+	settings.SaveAdmins = true		  -- If true anyone you :admin or :headadmin in-game will save
 	settings.WhitelistEnabled = false -- If true enables the whitelist/server lock; Only lets admins & whitelisted users join
 
 	settings.Prefix = ":"				-- The : in :kill me
@@ -358,7 +358,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.OnJoin = [[ List of commands ran as player on join (ignores adminlevel)		Format: {":cmds"} ]]
 	descs.OnSpawn = [[ List off commands ran as player on spawn (ignores adminlevel)	Format: {"!fire Really red",":ff me"} ]]
 
-	descs.SaveAdmins = [[ If true anyone you :mod, :admin, or :owner in-game will save; This does not apply to helpers as they are considered temporary ]]
+	descs.SaveAdmins = [[ If true anyone you :mod, :admin, or :headadmin in-game will save]]
 	descs.WhitelistEnabled = [[ If true enables the whitelist/server lock; Only lets admins & whitelisted users join ]]
 
 	descs.Prefix = [[ The : in :kill me ]]

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -140,7 +140,7 @@ return function(Vargs, env)
 
 		UnAdmin = {
 			Prefix = Settings.Prefix;
-			Commands = {"unadmin";"unmod","unowner","unhelper","unpadmin","unpa";"unoa";"unta";};
+			Commands = {"unadmin";"unmod","unowner","unhelper","unpadmin","unheadadmin","unpa";"unoa";"unta";};
 			Args = {"player", "temp (true/false)"};
 			Hidden = false;
 			Description = "Removes the target players' admin powers; Saves unless <temp> is 'true'";

--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -158,7 +158,7 @@ return function(Vargs, env)
 							Time = 10;
 							OnClick = Core.Bytecode("client.Remote.Send('ProcessCommand','"..Settings.Prefix.."cmds')");
 						})
-						Functions.Hint(v.Name..' is now an owner',{plr})
+						Functions.Hint(v.Name..' is now a head admin',{plr})
 					else
 						Functions.Hint(v.Name.." is the same admin level as you or higher",{plr})
 					end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2216,7 +2216,7 @@ return function(Vargs, env)
 		Vote = {
 			Prefix = Settings.Prefix;
 			Commands = {"vote";"makevote";"startvote";"question";"survey";};
-			Args = {"player";"anwser1,answer2,etc (NO SPACES)";"question";};
+			Args = {"player";"answer1,answer2,etc (NO SPACES)";"question";};
 			Filter = true;
 			Description = "Lets you ask players a question with a list of answers and get the results";
 			AdminLevel = "Moderators";

--- a/MainModule/Server/Plugins/Cross_Server.lua
+++ b/MainModule/Server/Plugins/Cross_Server.lua
@@ -210,7 +210,7 @@ return function(Vargs)
 	Commands.CrossServerVote = {
 		Prefix = Settings.Prefix;
 		Commands = {"crossservervote", "crsvote"};
-		Args = {"anwser1,answer2,etc (NO SPACES)";"question";};
+		Args = {"answer1,answer2,etc (NO SPACES)";"question";};
 		Filter = true;
 		Description = "Lets you ask players in all servers a question with a list of answers and get the results";
 		AdminLevel = "Moderators";


### PR DESCRIPTION
plus some other things
1.  The `:headadmin` command now properly says that the person is now a head admin instead of an owner

2. Change the mention of the owner rank in the loader config to HeadAdmin (also removed the helper bit from `descs.SaveAdmins` as this would confuse people as helpers aren't a thing anymore)

3. Fix typo in the args for `:vote` and `:crosservervote` (anwser1)

4. The `:unadmin` command now has `:unheadadmin` as an alias