### PR TITLE
Service/Moderators Updates.

### DIFF
--- a/MainModule/Client/UI/Default/PrivateMessage.lua
+++ b/MainModule/Client/UI/Default/PrivateMessage.lua
@@ -60,7 +60,7 @@ return function(data)
 	gTable = window.gTable
 	client.UI.Make("Notification",{
 		Title = "New Message";
-		Message = "Message from "..player.Name;
+		Message = string.format("Message from %s (@%s)", player.DisplayName, player.Name);
 		Time = false;
 		OnClick = function() window:Ready() end;
 		OnClose = function() window:Destroy() end;

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -140,11 +140,7 @@ return function(Vargs, env)
 
 		UnAdmin = {
 			Prefix = Settings.Prefix;
-<<<<<<< HEAD
-			Commands = {"unadmin";"unmod","unowner","unhelper","unpadmin","unpa";"unoa";"unta";};
-=======
 			Commands = {"unadmin";"unmod","unowner","unhelper","unpadmin","unheadadmin","unrank","unpa";"unoa";"unta";};
->>>>>>> upstream/master
 			Args = {"player", "temp (true/false)"};
 			Hidden = false;
 			Description = "Removes the target players' admin powers; Saves unless <temp> is 'true'";

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -140,7 +140,7 @@ return function(Vargs, env)
 
 		UnAdmin = {
 			Prefix = Settings.Prefix;
-			Commands = {"unadmin";"unmod","unowner","unhelper","unpadmin","unheadadmin","unpa";"unoa";"unta";};
+			Commands = {"unadmin";"unmod","unowner","unhelper","unpadmin","unpa";"unoa";"unta";};
 			Args = {"player", "temp (true/false)"};
 			Hidden = false;
 			Description = "Removes the target players' admin powers; Saves unless <temp> is 'true'";
@@ -309,8 +309,8 @@ return function(Vargs, env)
 			Description = "Makes a message in the chat window";
 			AdminLevel = "Admins";
 			Function = function(plr,args)
-				for i,v in pairs(service.GetPlayers())do
-					Remote.Send(v,"Function","ChatMessage","["..Settings.SystemTitle.."] "..service.Filter(args[1],plr,v),Color3.new(1,64/255,77/255))
+				for i,v in pairs(service.GetPlayers()) do
+					Remote.Send(v, "Function", "ChatMessage", string.format("[%s] %s", Settings.SystemTitle, service.Filter(args[1], plr, v)), Color3.new(1,64/255,77/255))
 				end
 			end
 		};
@@ -399,6 +399,25 @@ return function(Vargs, env)
 					end
 				else
 					error("Invalid action; (on/off/add/remove)")
+				end
+			end
+		};
+
+		SystemNotify = {
+			Prefix = Settings.Prefix;
+			Commands = {"sn","systemsmallmessage","snmessage","snmsg","ssmsg","ssmessage"};
+			Args = {"message";};
+			Filter = true;
+			Description = "Makes a system small message,";
+			AdminLevel = "Admins";
+			Function = function(plr, args)
+				assert(args[1], "Argument missing or nil")
+				for _, v in ipairs(service.GetPlayers()) do
+					Remote.RemoveGui(v, "Notify")
+					Remote.MakeGui(v, "Notify", {
+						Title = Settings.SystemTitle;
+						Message = service.Filter(args[1], plr, v);
+					})
 				end
 			end
 		};

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -297,10 +297,11 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
 				assert(args[1] and args[2] and tonumber(args[1]), "Argument missing or invalid")
+				local messageRecipient = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name)
 				for _, v in ipairs(service.GetPlayers()) do
 					Remote.RemoveGui(v, "Message")
 					Remote.MakeGui(v, "Message", {
-						Title = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name);
+						Title = messageRecipient;
 						Message = args[2];
 						Time = tonumber(args[1]);
 					})
@@ -317,11 +318,12 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
 				assert(args[1], "Argument missing or nil")
+				local messageRecipient = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name)
 				for _, v in ipairs(service.GetPlayers()) do
 					Remote.RemoveGui(v, "Message")
 					Remote.MakeGui(v, "Message", {
-						Title = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name);
-						Message = args[1]; --service.Filter(args[1],plr,v);
+						Title = messageRecipient;
+						Message = args[1]; --service.Filter(args[1], plr, v);
 						Time = (#tostring(args[1]) / 19) + 2.5;
 						Scroll = true;
 					})
@@ -338,8 +340,9 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
 				assert(args[1] and args[2], "Argument missing or nil")
+				local messageRecipient = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name)
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
-					Functions.Message(string.format("Message from %s (@%s)", plr.DisplayName, plr.Name), service.Filter(args[2], plr, v), {v})
+					Functions.Message(messageRecipient, service.Filter(args[2], plr, v), {v})
 				end
 			end
 		};
@@ -353,10 +356,11 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
 				assert(args[1], "Argument missing or nil")
+				local messageRecipient = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name)
 				for _, v in ipairs(service.GetPlayers()) do
 					Remote.RemoveGui(v, "Notify")
 					Remote.MakeGui(v, "Notify", {
-						Title = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name);
+						Title = messageRecipient;
 						Message = service.Filter(args[1], plr, v);
 					})
 				end
@@ -372,10 +376,11 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
 				assert(args[1] and args[2], "Argument missing or nil")
+				local messageRecipient = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name)
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
 					Remote.RemoveGui(v, "Notify")
 					Remote.MakeGui(v, "Notify", {
-						Title = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name);
+						Title = messageRecipient;
 						Message = service.Filter(args[2], plr, v);
 					})
 				end
@@ -391,9 +396,10 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
 				assert(args[1], "Argument missing or nil")
+				local HintFormat = string.format("%s (@%s): %s", plr.DisplayName, plr.Name, args[1])
 				for _, v in ipairs(service.GetPlayers()) do
 					Remote.MakeGui(v, "Hint", {
-						Message = string.format("%s (@%s): %s", plr.DisplayName, plr.Name, service.Filter(args[1], plr, v));
+						Message = HintFormat; --service.Filter(args[1], plr, v)
 					})
 				end
 			end
@@ -1161,11 +1167,13 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
 				assert(args[1] and args[2], "Argument missing")
+				local messageRecipient = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name)
+
 				if Admin.CheckAdmin(plr) then
 					for _, v in ipairs(service.GetPlayers(plr, args[1])) do
 						Variables.AuthorizedToReply[v] = true;
 						Remote.MakeGui(v, "PrivateMessage", {
-							Title = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name);
+							Title = messageRecipient;
 							Player = plr;
 							Message = service.Filter(args[2], plr, v);
 						})

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -44,12 +44,14 @@ return function(Vargs, env)
 				})) do
 					local targLevel = Admin.GetLevel(v)
 					if plrLevel > targLevel then
+						local PlayerName = v.Name
 						if not service.Players:FindFirstChild(v.Name) then
 							Remote.Send(v, "Function", "Kill")
 						else
 							v:Kick(args[2])
 						end
-						Functions.Hint("Kicked "..tostring(v), {plr})
+
+						Functions.Hint("Kicked ".. PlayerName, {plr})
 					end
 				end
 			end
@@ -185,7 +187,7 @@ return function(Vargs, env)
 				assert(args[1] and args[2], "Argument missing or nil")
 
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
-					Remote.MakeGui(v ,"Notification", {
+					Remote.MakeGui(v, "Notification", {
 						Title = "Notification";
 						Message = service.Filter(args[2], plr, v);
 					})
@@ -298,7 +300,7 @@ return function(Vargs, env)
 				for _, v in ipairs(service.GetPlayers()) do
 					Remote.RemoveGui(v, "Message")
 					Remote.MakeGui(v, "Message", {
-						Title = "Message from " .. plr.Name;
+						Title = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name);
 						Message = args[2];
 						Time = tonumber(args[1]);
 					})
@@ -318,10 +320,10 @@ return function(Vargs, env)
 				for _, v in ipairs(service.GetPlayers()) do
 					Remote.RemoveGui(v, "Message")
 					Remote.MakeGui(v, "Message", {
-						Title = "Message from " .. plr.Name;
-						Message = args[1];--service.Filter(args[1],plr,v);
-						Scroll = true;
+						Title = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name);
+						Message = args[1]; --service.Filter(args[1],plr,v);
 						Time = (#tostring(args[1]) / 19) + 2.5;
+						Scroll = true;
 					})
 				end
 			end
@@ -337,7 +339,7 @@ return function(Vargs, env)
 			Function = function(plr, args)
 				assert(args[1] and args[2], "Argument missing or nil")
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
-					Functions.Message("Message from "..plr.Name, service.Filter(args[2], plr, v), {v})
+					Functions.Message(string.format("Message from %s (@%s)", plr.DisplayName, plr.Name), service.Filter(args[2], plr, v), {v})
 				end
 			end
 		};
@@ -354,27 +356,7 @@ return function(Vargs, env)
 				for _, v in ipairs(service.GetPlayers()) do
 					Remote.RemoveGui(v, "Notify")
 					Remote.MakeGui(v, "Notify", {
-						Title = "Message from " .. plr.Name;
-						Message = service.Filter(args[1], plr, v);
-					})
-				end
-			end
-		};
-
-
-		SystemNotify = {
-			Prefix = Settings.Prefix;
-			Commands = {"sn","systemsmallmessage","snmessage","snmsg","ssmsg","ssmessage"};
-			Args = {"message";};
-			Filter = true;
-			Description = "Makes a system small message,";
-			AdminLevel = "Moderators";
-			Function = function(plr, args)
-				assert(args[1], "Argument missing or nil")
-				for _, v in ipairs(service.GetPlayers()) do
-					Remote.RemoveGui(v, "Notify")
-					Remote.MakeGui(v, "Notify", {
-						Title = Settings.SystemTitle;
+						Title = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name);
 						Message = service.Filter(args[1], plr, v);
 					})
 				end
@@ -393,7 +375,7 @@ return function(Vargs, env)
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
 					Remote.RemoveGui(v, "Notify")
 					Remote.MakeGui(v, "Notify", {
-						Title = "Message from " .. plr.Name;
+						Title = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name);
 						Message = service.Filter(args[2], plr, v);
 					})
 				end
@@ -411,7 +393,7 @@ return function(Vargs, env)
 				assert(args[1], "Argument missing or nil")
 				for _, v in ipairs(service.GetPlayers()) do
 					Remote.MakeGui(v, "Hint", {
-						Message = tostring(plr or "")..": "..service.Filter(args[1], plr, v);
+						Message = string.format("%s (@%s): %s", plr.DisplayName, plr.Name, service.Filter(args[1], plr, v));
 					})
 				end
 			end
@@ -438,11 +420,9 @@ return function(Vargs, env)
 							Message = args[2];
 						})
 
-						if plr and type(plr) == "userdata" then
-							Remote.MakeGui(plr, "Hint", {
-								Message = "Warned "..tostring(v);
-							})
-						end
+						Remote.MakeGui(plr, "Hint", {
+							Message = "Warned ".. v.Name;
+						})
 					end
 				end
 			end
@@ -464,13 +444,12 @@ return function(Vargs, env)
 						local data = Core.GetPlayer(v)
 
 						table.insert(data.Warnings, {From = tostring(plr), Message = args[2], Time = os.time()})
+						local PlayerName = v.Name
 						v:Kick(tostring("\n[Warning from "..tostring(plr).."]\n"..args[2]))
 
-						if plr and type(plr) == "userdata" then
-							Remote.MakeGui(plr, "Hint", {
-								Message = "Warned "..tostring(v);
-							})
-						end
+						Remote.MakeGui(plr, "Hint", {
+							Message = "Warned ".. PlayerName;
+						})
 					end
 				end
 			end
@@ -513,11 +492,9 @@ return function(Vargs, env)
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
 					local data = Core.GetPlayer(v)
 					data.Warnings = {}
-					if plr and type(plr) == "userdata" then
-						Remote.MakeGui(plr, "Hint", {
-							Message = "Cleared warnings for "..tostring(v);
-						})
-					end
+					Remote.MakeGui(plr, "Hint", {
+						Message = "Cleared warnings for ".. v.Name;
+					})
 				end
 			end
 		};
@@ -1188,7 +1165,7 @@ return function(Vargs, env)
 					for _, v in ipairs(service.GetPlayers(plr, args[1])) do
 						Variables.AuthorizedToReply[v] = true;
 						Remote.MakeGui(v, "PrivateMessage", {
-							Title = "Message from "..plr.Name;
+							Title = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name);
 							Player = plr;
 							Message = service.Filter(args[2], plr, v);
 						})
@@ -2559,15 +2536,17 @@ return function(Vargs, env)
 			Function = function(plr,args)
 				for i,v in pairs(service.GetPlayers(plr,args[1] or "all")) do
 					if tostring(args[2]):lower() == "yes" or tostring(args[2]):lower() == "true" then
-						Remote.RemoveGui(v,true)
+						Routine(Remote.RemoveGui, v, true)
 					else
-						Remote.RemoveGui(v,"Message")
-						Remote.RemoveGui(v,"Hint")
-						Remote.RemoveGui(v,"Notification")
-						Remote.RemoveGui(v,"PM")
-						Remote.RemoveGui(v,"Output")
-						Remote.RemoveGui(v,"Effect")
-						Remote.RemoveGui(v,"Alert")
+						Routine(function()
+							Remote.RemoveGui(v,"Message")
+							Remote.RemoveGui(v,"Hint")
+							Remote.RemoveGui(v,"Notification")
+							Remote.RemoveGui(v,"PM")
+							Remote.RemoveGui(v,"Output")
+							Remote.RemoveGui(v,"Effect")
+							Remote.RemoveGui(v,"Alert")
+						end)
 					end
 				end
 			end


### PR DESCRIPTION
`Moderators`:
Moved `small message` command to Admins as for some reason it was for Moderators. (Address this inside changelogs to avoid confusion of actual game moderators using this?)
Removed using `tostring` on player instances to use `Name` property.
ClearGuis command now uses coroutines to prevent any possible yielding.
Messagers/etc that publicly show your name now can support DisplayNames+Name. (format: `%s (@%s)`, arg1: displayname arg2: real name)

`Service`:
Uses `table.pack` to get any arguments that could be varargs to fix some possible bugs on some functions/args that need it. (?)
Caching of some functions.
`SetSpecial` can now return its meta object table for some cases where you don't want to get the variable for it sometimes, example: `a:SetSpecial("test",true):SetSpecial("cool","beans")`