### PR TITLE
Music list cleanup

### DIFF
--- a/MainModule/Server/Core/Variables.lua
+++ b/MainModule/Server/Core/Variables.lua
@@ -113,17 +113,14 @@ return function(Vargs)
 
 		MusicList = {
 			{Name='jericho',ID=292340735};
-			{Name='dieinafire',ID=242222291};
 			{Name='beam',ID=165065112};
 			{Name='myswamp',ID=166325648};
 			{Name='skeletons',ID=168983825};
 			{Name='russianmen',ID=173038059};
 			{Name='freedom',ID=130760592};
 			{Name='seatbelt',ID=135625718};
-			{Name='tempest',ID=135554032};
 			{Name="focus",ID=136786547};
 			{Name="azylio",ID=137603138};
-			{Name="caramell",ID=2303479};
 			{Name="epic",ID=27697743};
 			{Name="halo",ID=1034065};
 			{Name="pokemon",ID=1372261};
@@ -150,27 +147,19 @@ return function(Vargs)
 			{Name="nezz",ID=8610025};
 			{Name="resist",ID=27697234};
 			{Name="schala",ID=5985787};
-			{Name="organ",ID=11231513};
 			{Name="tunnel",ID=9650822};
 			{Name="spanish",ID=5982975};
 			{Name="venom",ID=1372262};
 			{Name="wind",ID=1015394};
 			{Name="guitar",ID=5986151};
-			{Name="weapon",ID=142400410};
-			{Name="derezzed",ID=142402620};
-			{Name="sceptics",ID=153251489};
 			{Name="pianoremix",ID=142407859};
 			{Name="antidote",ID=145579822};
 			{Name="overtime",ID=135037991};
-			{Name="fluffyunicorns",ID=141444871};
 			{Name="tsunami",ID=569900517};
-			{Name="finalcountdownremix",ID=145162750};
-			{Name="stereolove",ID=142318819};
 			{Name="minecraftorchestral",ID=148900687};
 			{Name="superbacon",ID=300872612};
 			{Name="alonemarsh",ID=639750143}; -- Alone - Marshmello
 			{Name="crabraveoof",ID=2590490779}; -- Crab rave oof
-			{Name="rickroll",ID=4581203569};
 			{Name="deathbed",ID=4966153470};
 		};
 


### PR DESCRIPTION
The audios removed in this pr have been removed from the `:musiclist`, as Roblox has blocked the audios for copyright reasons and can no longer be played. Two of the audios were content deleted, this pr also removes them as they are also unplayable.


(these screenshots come from the `:audioplayer`)
![image](https://user-images.githubusercontent.com/77434904/132134557-0466a6ec-c2e4-47c8-ad16-f8164cf308e8.png)

![image](https://user-images.githubusercontent.com/77434904/132134577-2eadc299-f86b-41ef-97de-ff0011a4cabe.png)



