### PR TITLE
Confirm prompt to `:clearplayerdata`, add option to disable cross-server commands, global time messages, some other stuff

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -282,6 +282,7 @@ local descs = {};			--// Contains settings descriptions
 
 	settings.FunCommands = true			-- Are fun commands enabled?
 	settings.PlayerCommands = true 	-- Are players commands enabled?
+	settings.CrossServerCommands = true -- Are commands which affect more than one server enabled?
 	settings.ChatCommands = true 		-- If false you will not be able to run commands via the chat; Instead you MUST use the console or you will be unable to run commands
 	settings.CreatorPowers = true		-- Gives me creator level admin; This is strictly used for debugging; I can't debug without full access to the script
 	settings.CodeExecution = true		-- Enables the use of code execution in Adonis; Scripting related and a few other commands require this
@@ -385,6 +386,7 @@ local descs = {};			--// Contains settings descriptions
 
 	descs.FunCommands = [[ Are fun commands enabled? ]]
 	descs.PlayerCommands = [[ Are players commands enabled? ]]
+	descs.CrossServerCommands = [[ Are commands which affect more than one server enabled? ]]
 	descs.ChatCommands = [[ If false you will not be able to run commands via the chat; Instead you MUST use the console or you will be unable to run commands ]]
 
 	descs.BanMessage = [[ Message shown to banned users ]]
@@ -481,6 +483,7 @@ local descs = {};			--// Contains settings descriptions
 		" ";
 		"FunCommands";
 		"PlayerCommands";
+		"CrossServerCommands";
 		"ChatCommands";
 		"CreatorPowers";
 		"CodeExecution";

--- a/MainModule/Client/UI/Default/YesNoPrompt.lua
+++ b/MainModule/Client/UI/Default/YesNoPrompt.lua
@@ -8,7 +8,7 @@ return function(data)
 	
 	local window = client.UI.Make("Window",{
 		Name  = "Prompt";
-		Title = "Prompt";
+		Title = data.Title or "Prompt";
 		Size  = {225,150};
 		SizeLocked = true;
 		--Icon = "rbxassetid://136615916";

--- a/MainModule/Client/UI/Default/YesNoPrompt.lua
+++ b/MainModule/Client/UI/Default/YesNoPrompt.lua
@@ -9,7 +9,7 @@ return function(data)
 	local window = client.UI.Make("Window",{
 		Name  = "Prompt";
 		Title = data.Title or "Prompt";
-		Size  = {225,150};
+		Size  = data.Size or {225,150};
 		SizeLocked = true;
 		--Icon = "rbxassetid://136615916";
 		OnClose = function()

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -659,7 +659,7 @@ return function(Vargs, env)
 
 		RemoveTeam = {
 			Prefix = Settings.Prefix;
-			Commands = {"removeteam";};
+			Commands = {"removeteam";"deleteteam"};
 			Args = {"name";};
 			Hidden = false;
 			Description = "Remove the specified team";

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1385,6 +1385,9 @@ return function(Vargs, env)
 			Args = {"player", "reason"};
 			Description = "Bans the player from the server";
 			AdminLevel = "Admins";
+			Filter = true;
+			Hidden = false;
+			Fun = false;
 			Function = function(plr,args,data)
 				local level = data.PlayerData.Level
 				local reason = args[2] or "No reason provided";

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -437,7 +437,7 @@ return function(Vargs, env)
 			Commands = {"setmessage";"notif";"setmsg";};
 			Args = {"message OR off";};
 			Filter = true;
-			Description = "Set message";
+			Description = "Sets a small hint message at the top of the screen";
 			AdminLevel = "Admins";
 			Function = function(plr,args)
 				assert(args[1],"Argument missing or nil")
@@ -1409,7 +1409,7 @@ return function(Vargs, env)
 			Prefix = Settings.Prefix;
 			Commands = {"unban";};
 			Args = {"player";};
-			Description = "UnBan";
+			Description = "Unbans the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr,args)
 				local ret = Admin.RemoveBan(args[1])

--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -68,6 +68,7 @@ return function(Vargs, env)
 			Description = "Force all game-players to teleport to a desired place";
 			AdminLevel = "Creators";
 			CrossServerDenied = true;
+			IsCrossServer = true;
 			Function = function(plr,args)
 				assert(args[1], "Argument #1 must be supplied")
 				assert(tonumber(args[1]), "Argument #1 must be a number")

--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -224,8 +224,8 @@ return function(Vargs, env)
 				local username = (game:GetService("Players"):GetNameFromUserIdAsync(args[1]))
 				local ans = Remote.GetGui(plr,"YesNoPrompt",{
 					Question = "Clearing all PlayerData for "..username.." will erase all warns, notes, bans, and other data associated with " ..username.. " such as theme preference.\n Are you sure you want to erase "..username.."'s PlayerData? This action is irreversible.";
-					Title = "Clear PlayerData";
-					Size = {337.5,225};
+					Title = "Clear PlayerData for "..username.."?";
+					Size = {281.25,187.5};
 				})
 				if ans == "Yes" then
 					Core.RemoveData(tostring(id));

--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -210,14 +210,19 @@ return function(Vargs, env)
 
 		ClearPlayerData = {
 			Prefix = Settings.Prefix;
-			Commands = {"clearplayerdata"};
+			Commands = {"clearplayerdata","clrplrdata","clearplrdata"};
 			Arguments = {"UserId"};
 			Description = "Clears PlayerData linked to the specified UserId";
 			AdminLevel = "Creators";
 			Function = function(plr, args)
 				local id = tonumber(args[1]);
 				assert(id, "Must supply valid UserId");
-
+				local ans = Remote.GetGui(plr,"YesNoPrompt",{
+					Question = "Clearing the PlayerData for user "..tostring(args[1]).." will cause all user settings such as theme preference and the console key to reset to defaults.\n\nAre you sure you want to clear the PlayerData for user "..tostring(args[1]).."?";
+					Title = "Clear PlayerData";
+				})
+				if ans == "Yes" then
+				end
 				Core.RemoveData(tostring(id));
 				Core.PlayerData[tostring(id)] = nil;
 

--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -221,9 +221,11 @@ return function(Vargs, env)
 			Function = function(plr, args)
 				local id = tonumber(args[1]);
 				assert(id, "Must supply valid UserId");
+				local username = (game:GetService("Players"):GetNameFromUserIdAsync(args[1]))
 				local ans = Remote.GetGui(plr,"YesNoPrompt",{
-					Question = "Clearing the PlayerData for user "..tostring(args[1]).." will cause all user settings such as theme preference and the console key to reset to defaults.\n\nAre you sure you want to clear the PlayerData for user "..tostring(args[1]).."?";
+					Question = "Clearing all PlayerData for "..username.." will erase all warns, notes, bans, and other data associated with " ..username.. " such as theme preference.\n Are you sure you want to erase "..username.."'s PlayerData? This action is irreversible.";
 					Title = "Clear PlayerData";
+					Size = {337.5,225};
 				})
 				if ans == "Yes" then
 					Core.RemoveData(tostring(id));

--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -226,15 +226,15 @@ return function(Vargs, env)
 					Title = "Clear PlayerData";
 				})
 				if ans == "Yes" then
+					Core.RemoveData(tostring(id));
+					Core.PlayerData[tostring(id)] = nil;
+	
+					Remote.MakeGui(plr,"Notification",{
+						Title = "Notification";
+						Message = "Cleared data for ".. id;
+						Time = 10;
+					})
 				end
-				Core.RemoveData(tostring(id));
-				Core.PlayerData[tostring(id)] = nil;
-
-				Remote.MakeGui(plr,"Notification",{
-					Title = "Notification";
-					Message = "Cleared data for ".. id;
-					Time = 10;
-				})
 			end;
 		};
 

--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -15,6 +15,9 @@ return function(Vargs, env)
 			Args = {"player", "reason"};
 			Description = "DirectBans the player (Saves)";
 			AdminLevel = "Creators";
+			Filter = true;
+			Hidden = false;
+			Fun = false;
 			Function = function(plr,args,data)
 				local reason = args[2] or "No reason provided";
 

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -226,6 +226,41 @@ return function(Vargs, env)
 			end;
 		};
 
+		GlobalTimeMessage = {
+			Prefix = Settings.Prefix;
+			Commands = {"gtm","globaltimedmessage","globaltimemessage","globaltimem"};
+			Args = {"time","message"};
+			Description = "Sends a global message to all servers and makes it stay on the screen for the amount of time (in seconds) you supply";
+			AdminLevel = "HeadAdmins";
+			Filter = true;
+			CrossServerDenied = true;
+			Function = function(plr,args)
+				assert(args[1], "Argument #1 must be supplied")
+				assert(args[2], "Argument #2 must be supplied")
+
+
+				local globalMessage = string.format([[
+					local server = server
+					local service = server.Service
+					local Remote = server.Remote
+
+					for i,v in pairs(service.Players:GetPlayers()) do
+						Remote.RemoveGui(v, "Message")
+						Remote.MakeGui(v, "Message", {
+							Title = "Global Message from %s";
+							Message = "%s";
+							Scroll = true;
+							Time = %s;
+						})
+					end
+				]], plr.Name, args[2], args[1])
+
+				if not Core.CrossServer("Loadstring", globalMessage) then
+					error("CrossServer Handler Not Ready");
+				end
+			end;
+		};
+
 		MakeList = {
 			Prefix = Settings.Prefix;
 			Commands = {"makelist";"newlist";"newtrellolist";"maketrellolist";};

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -14,6 +14,7 @@ return function(Vargs, env)
 			Commands = {"tban";"timedban";"timeban";};
 			Args = {"player";"number<s/m/h/d>";};
 			Hidden = false;
+			Filter = true;
 			Description = "Bans the target player(s) for the supplied amount of time; Data Persistent; Undone using :untimeban";
 			Fun = false;
 			AdminLevel = "HeadAdmins";
@@ -105,6 +106,9 @@ return function(Vargs, env)
 			Args = {"player", "reason"};
 			Description = "Bans the player from the game (Saves)";
 			AdminLevel = "HeadAdmins";
+			Filter = true;
+			Hidden = false;
+			Fun = false;
 			Function = function(plr,args,data)
 				local level = data.PlayerData.Level
 				local reason = args[2] or "No reason provided";

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -204,6 +204,7 @@ return function(Vargs, env)
 			Description = "Sends a global message to all servers";
 			AdminLevel = "HeadAdmins";
 			Filter = true;
+			IsCrossServer = true;
 			CrossServerDenied = true;
 			Function = function(plr,args)
 				assert(args[1], "Argument #1 must be supplied")
@@ -237,6 +238,7 @@ return function(Vargs, env)
 			Description = "Sends a global message to all servers and makes it stay on the screen for the amount of time (in seconds) you supply";
 			AdminLevel = "HeadAdmins";
 			Filter = true;
+			IsCrossServer = true;
 			CrossServerDenied = true;
 			Function = function(plr,args)
 				assert(args[1], "Argument #1 must be supplied")
@@ -427,6 +429,7 @@ return function(Vargs, env)
 			PanicMode = true;
 			AdminLevel = "HeadAdmins";
 			Filter = true;
+			IsCrossServer = true;
 			Function = function(plr,args)
 				assert(args[1], "Reason must be supplied for this command!")
 				local ans = Remote.GetGui(plr,"YesNoPrompt",{

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -434,6 +434,7 @@ return function(Vargs, env)
 				assert(args[1], "Reason must be supplied for this command!")
 				local ans = Remote.GetGui(plr,"YesNoPrompt",{
 					Question = "Shutdown all running servers for the reason "..tostring(args[1]).."?";
+					Title = "Shutdown all running servers?";
 				})
 				if ans == "Yes" then
 				if not Core.CrossServer("NewRunCommand", {Name = plr.Name; UserId = plr.UserId, AdminLevel = Admin.GetLevel(plr)}, Settings.Prefix.."shutdown "..args[1] .. "\n\n\n[GLOBAL SHUTDOWN]") then

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -5290,7 +5290,7 @@ return function(Vargs, env)
 						if v:IsA("Sound") and v.Name == "ADONIS_SOUND" then
 							if v.IsPaused == true then
 								local ans,event = Remote.GetGui(plr,"YesNoPrompt",{
-									Title = "Override paused track?"
+									Title = "Override paused track?";
 									Question = "There is currently a track paused, do you wish to override it?";
 								})
 

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -176,7 +176,7 @@ return function(Vargs, env)
 				else
 					Admin.SlowMode = nil;
 					Admin.SlowCache = {};
-					Functions.Hint("Chat slow mode disabled", service.GetPlayers())
+					Functions.Hint("Chat slow mode disabled", {plr})
 				end
 			end
 		};

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -176,6 +176,7 @@ return function(Vargs, env)
 				else
 					Admin.SlowMode = nil;
 					Admin.SlowCache = {};
+					Functions.Hint("Chat slow mode disabled", service.GetPlayers())
 				end
 			end
 		};
@@ -256,7 +257,7 @@ return function(Vargs, env)
 
 		TimeMessage = {
 			Prefix = Settings.Prefix;
-			Commands = {"tm";"timem";"timedmessage";};
+			Commands = {"tm";"timem";"timedmessage","timemessage";};
 			Args = {"time";"message";};
 			Filter = true;
 			Description = "Make a message and makes it stay for the amount of time (in seconds) you supply";
@@ -2669,7 +2670,7 @@ return function(Vargs, env)
 
 		Sell = {
 			Prefix = Settings.Prefix;
-			Commands = {"sell";};
+			Commands = {"sell";"promptpurchase"};
 			Args = {"player";"id";};
 			Hidden = false;
 			Description = "Prompts the player(s) to buy the product belonging to the ID you supply";
@@ -2840,7 +2841,7 @@ return function(Vargs, env)
 			Commands = {"noclip";};
 			Args = {"player";};
 			Hidden = false;
-			Description = "NoClips the target player(s)";
+			Description = "NoClips the target player(s); allowing them to walk through walls";
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
@@ -3716,7 +3717,7 @@ return function(Vargs, env)
 
 		Invisible = {
 			Prefix = Settings.Prefix;
-			Commands = {"invisible";};
+			Commands = {"invisible";"invis"};
 			Args = {"player";};
 			Hidden = false;
 			Description = "Makes the target player(s) invisible";
@@ -3749,7 +3750,7 @@ return function(Vargs, env)
 
 		Visible = {
 			Prefix = Settings.Prefix;
-			Commands = {"visible";};
+			Commands = {"visible";"vis"};
 			Args = {"player";};
 			Hidden = false;
 			Description = "Makes the target player(s) visible";
@@ -3782,10 +3783,10 @@ return function(Vargs, env)
 
 		Lock = {
 			Prefix = Settings.Prefix;
-			Commands = {"lock";};
+			Commands = {"lock";"lockplr";"lockplayer"};
 			Args = {"player";};
 			Hidden = false;
-			Description = "Locks the target player(s)";
+			Description = "Locks the target player(s), preventing the use of btools on the character";
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr,args)
@@ -3805,7 +3806,7 @@ return function(Vargs, env)
 
 		UnLock = {
 			Prefix = Settings.Prefix;
-			Commands = {"unlock";};
+			Commands = {"unlock";"unlockplr";"unlockplayer"};
 			Args = {"player";};
 			Hidden = false;
 			Description = "UnLocks the the target player(s), makes it so you can use btools on them";
@@ -5289,6 +5290,7 @@ return function(Vargs, env)
 						if v:IsA("Sound") and v.Name == "ADONIS_SOUND" then
 							if v.IsPaused == true then
 								local ans,event = Remote.GetGui(plr,"YesNoPrompt",{
+									Title = "Override paused track?"
 									Question = "There is currently a track paused, do you wish to override it?";
 								})
 

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -256,7 +256,7 @@ return function(Vargs, env)
 
 		RequestHelp = {
 			Prefix = Settings.PlayerPrefix;
-			Commands = {"help";"requesthelp";"gethelp";"lifealert";};
+			Commands = {"help";"requesthelp";"gethelp";"lifealert";"sos";};
 			Args = {};
 			Hidden = false;
 			Description = "Calls admins for help";
@@ -315,7 +315,7 @@ return function(Vargs, env)
 						end)
 					end
 				else
-					Functions.Message("Help System","Help System Disabled by Place Owner",{plr})
+					Functions.Message("Help System","The help system has been disabled by the place owner.",{plr})
 				end
 			end
 		};
@@ -635,7 +635,7 @@ return function(Vargs, env)
 		};
 		
 		TimeDate = {
-			Prefix = Settings.Prefix;
+			Prefix = Settings.PlayerPrefix;
 			Commands = {"timedate";"date";"datetime";};
 			Args = {};
 			Hidden = false;

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -989,10 +989,13 @@ return function(Vargs)
 			local isDonor = (pDat.isDonor and (Settings.DonorCommands or cmd.AllowDonors))
 			local comLevel = cmd.AdminLevel
 			local funAllowed = Settings.FunCommands
+			local crossServerAllowed = Settings.CrossServerCommands
 
 			if adminLevel >= 900 then
 				return true
 			elseif cmd.Fun and not funAllowed then
+				return false
+			elseif cmd.IsCrossServer and not crossServerAllowed then
 				return false
 			elseif cmd.Donors and isDonor then
 				return true

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -282,6 +282,7 @@ local descs = {};			--// Contains settings descriptions
 
 	settings.FunCommands = true			-- Are fun commands enabled?
 	settings.PlayerCommands = true 	-- Are players commands enabled?
+	settings.CrossServerCommands = true -- Are commands which affect more than one server enabled?
 	settings.ChatCommands = true 		-- If false you will not be able to run commands via the chat; Instead you MUST use the console or you will be unable to run commands
 	settings.CreatorPowers = true		-- Gives me creator level admin; This is strictly used for debugging; I can't debug without full access to the script
 	settings.CodeExecution = true		-- Enables the use of code execution in Adonis; Scripting related and a few other commands require this
@@ -385,6 +386,7 @@ local descs = {};			--// Contains settings descriptions
 
 	descs.FunCommands = [[ Are fun commands enabled? ]]
 	descs.PlayerCommands = [[ Are players commands enabled? ]]
+	descs.CrossServerCommands = [[ Are commands which affect more than one server enabled? ]]
 	descs.ChatCommands = [[ If false you will not be able to run commands via the chat; Instead you MUST use the console or you will be unable to run commands ]]
 
 	descs.BanMessage = [[ Message shown to banned users ]]
@@ -481,6 +483,7 @@ local descs = {};			--// Contains settings descriptions
 		" ";
 		"FunCommands";
 		"PlayerCommands";
+		"CrossServerCommands";
 		"ChatCommands";
 		"CreatorPowers";
 		"CodeExecution";

--- a/MainModule/Server/Plugins/Cross_Server.lua
+++ b/MainModule/Server/Plugins/Cross_Server.lua
@@ -129,6 +129,7 @@ return function(Vargs)
 		Description = "Runs the specified command string on all servers";
 		AdminLevel = "HeadAdmins";
 		CrossServerDenied = true; --// Makes it so this command cannot be ran via itself causing an infinite spammy loop of cross server commands...
+		IsCrossServer = true; --// Used in settings.CrossServerCommands in case a game creator wants to disable the cross-server commands
 		Function = function(plr,args)
 			if not Core.CrossServer("NewRunCommand", {Name = plr.Name; UserId = plr.UserId, AdminLevel = Admin.GetLevel(plr)}, args[1]) then
 				error("CrossServer Handler Not Ready");
@@ -215,6 +216,7 @@ return function(Vargs)
 		Description = "Lets you ask players in all servers a question with a list of answers and get the results";
 		AdminLevel = "Moderators";
 		CrossServerDenied = true;
+		IsCrossServer = true;
 		Function = function(plr,args)
 			local question = args[2]
 			if not question then error("You forgot to supply a question!") end

--- a/MainModule/Server/Plugins/Cross_Server.lua
+++ b/MainModule/Server/Plugins/Cross_Server.lua
@@ -210,7 +210,7 @@ return function(Vargs)
 
 	Commands.CrossServerVote = {
 		Prefix = Settings.Prefix;
-		Commands = {"crossservervote", "crsvote"};
+		Commands = {"crossservervote", "crsvote","globalvote","gv","gvote"};
 		Args = {"answer1,answer2,etc (NO SPACES)";"question";};
 		Filter = true;
 		Description = "Lets you ask players in all servers a question with a list of answers and get the results";

--- a/MainModule/Server/Plugins/Cross_Server.lua
+++ b/MainModule/Server/Plugins/Cross_Server.lua
@@ -144,6 +144,7 @@ return function(Vargs)
 		Description = "Attempts to list all active servers (at the time the command was ran)";
 		AdminLevel = "Admins";
 		CrossServerDenied = true;
+		IsCrossServer = true;
 		Function = function(plr,args)
 			local disced = false;
 			local updateKey = "SERVERPING".. math.random();


### PR DESCRIPTION
- Adds confirm prompt to `:clearplayerdata` so people don't reset PlayerData by accident (also adds the ability to have a custom title for YesNoPrompt)
![image](https://user-images.githubusercontent.com/77434904/133384553-82ff86a1-5414-46cb-8586-93e5ad7e5213.png)

- Adds several aliases to some commands as they may be useful to some people as some of these are shorter while still being recognisable to users (not like `:oa` or `:pa` as these were for setting ranks and people were using them in a way to mislead unfamiliar mod/admins into admining them)
- Adds `:globaltimemessage` - it works the same as `:gm` but it allows you to set a custom amount of time on the message
- Enable filtering to the ban commands (will avoid possible moderation action against people's games and Adonis) and #488 will add the ability to add a reason to `:timeban` so we will enable filtering in preperation for that

- Add the ability to disable the cross-server commands - some people may not want mods/admins to run commands on other servers and this will allow them to toggle the commands off (this will make sure that as new cross-server commands are added, this will make sure that they will also be disabled if the command has `IsCrossServer = true;`)
- Add "chat slowmode disabled" message to `:slowmode` however this currently only shows up to the person running the command (this could possibly be updated to show up to admins)



