### PR TITLE
Add timeban alias `:tempban`

### DIFF
--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1313,6 +1313,7 @@ return function(Vargs, env)
 					Remote.MakeGui(v,"Message",{
 						Title = args[1];
 						Message = args[2];
+						Time = (#tostring(args[1]) / 19) + 2.5;
 						--service.Filter(args[1],plr,v);
 					})
 				end

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -11,7 +11,7 @@ return function(Vargs, env)
 	return {
 		TimeBan = {
 			Prefix = Settings.Prefix;
-			Commands = {"tban";"timedban";"timeban";};
+			Commands = {"tban";"timedban";"timeban";"tempban";"temporaryban"};
 			Args = {"player";"number<s/m/h/d>";};
 			Hidden = false;
 			Filter = true;
@@ -75,7 +75,7 @@ return function(Vargs, env)
 
 		UnTimeBan = {
 			Prefix = Settings.Prefix;
-			Commands = {"untimeban";"untimedban";"untban";};
+			Commands = {"untimeban";"untimedban";"untban";"untempban";"untemporaryban"};
 			Args = {"player";};
 			Hidden = false;
 			Description = "Removes specified player from Timebans list";


### PR DESCRIPTION
Add timeban alias as per https://roblox.fandom.com/wiki/Ban/In-experience_ban
This adds an alias which is more familiar to players, especially those who have used other admin systems. 
This is what #493 is doing however it didn't an alias for `:timeban` so this will add the alias 

also this makes the duration of `:cm` stays on the screen for depend on how long the message is 