### PR TITLE
`:cmdinfo` now shows admin rank for command, fix cmd alias typo

### DIFF
--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -73,8 +73,14 @@ return function(Vargs, env)
 				assert(args[1], "Argument #1 must be supplied")
 				assert(tonumber(args[1]), "Argument #1 must be a number")
 
-				if not Core.CrossServer("NewRunCommand", {Name = plr.Name; UserId = plr.UserId, AdminLevel = Admin.GetLevel(plr)}, Settings.Prefix.."forceplace all "..args[1]) then
-					error("CrossServer Handler Not Ready");
+				local ans = Remote.GetGui(plr,"YesNoPrompt",{
+					Question = "Force all game-players to teleport to place '".. args[1].."'?";
+					Title = "Force teleport all users?";
+				})
+				if ans == "Yes" then
+					if not Core.CrossServer("NewRunCommand", {Name = plr.Name; UserId = plr.UserId, AdminLevel = Admin.GetLevel(plr)}, Settings.Prefix.."forceplace all "..args[1]) then
+						error("CrossServer Handler Not Ready");
+					end
 				end
 			end;
 		};

--- a/MainModule/Server/Commands/Donors.lua
+++ b/MainModule/Server/Commands/Donors.lua
@@ -143,7 +143,7 @@ return function(Vargs, env)
 
 		DonorNeon = {
 			Prefix = Settings.PlayerPrefix;
-			Commands = {"neon";};
+			Commands = {"neon";"donorneon"};
 			Args = {"color";};
 			Hidden = false;
 			Description = "Changes your body material to neon and makes you the (optional) color of your choosing.";
@@ -288,7 +288,7 @@ return function(Vargs, env)
 
 		DonorParticle = {
 			Prefix = Settings.PlayerPrefix;
-			Commands = {"particle";};
+			Commands = {"particle";"donorparticle"};
 			Args = {"textureid";"startColor3";"endColor3";};
 			Hidden = false;
 			Description = "Put a custom particle emitter on your character";
@@ -352,7 +352,7 @@ return function(Vargs, env)
 
 		DonorUnparticle = {
 			Prefix = Settings.PlayerPrefix;
-			Commands = {"unparticle";"removeparticles";};
+			Commands = {"unparticle";"removeparticles";"undonorparticle"};
 			Args = {};
 			Hidden = false;
 			Description = "Removes donor particles on you";
@@ -414,7 +414,7 @@ return function(Vargs, env)
 
 		DonorHat = {
 			Prefix = Settings.PlayerPrefix;
-			Commands = {"hat";"gethat";};
+			Commands = {"hat";"gethat";"donorhat"};
 			Args = {"ID";};
 			Hidden = false;
 			Description = "Gives you the hat specified by <ID>";
@@ -470,7 +470,7 @@ return function(Vargs, env)
 		
  		DonorRemoveHat = {
 			Prefix = Settings.PlayerPrefix;
-			Commands = {"removehat";};
+			Commands = {"removehat";"removedonorhat"};
 			Args = {"Accessory"};
 			Hidden = false;
 			Description = "Remove any accessories you are currently wearing";

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -102,7 +102,7 @@ return function(Vargs, env)
 
 		PermenantBan = {
 			Prefix = Settings.Prefix;
-			Commands = {"permban", "permenantban", "pban", "gameban", "saveban", "databan"};
+			Commands = {"permban", "permanentban", "pban", "gameban", "saveban", "databan"};
 			Args = {"player", "reason"};
 			Description = "Bans the player from the game permenantly. If they join a different server they will be banned there too";
 			AdminLevel = "HeadAdmins";
@@ -129,7 +129,7 @@ return function(Vargs, env)
 
 		UnGameBan = {
 			Prefix = Settings.Prefix;
-			Commands = {"unpermban", "unpermenantban", "unpban", "ungameban", "saveunban", "undataban"};
+			Commands = {"unpermban", "unpermanentban", "unpban", "ungameban", "saveunban", "undataban"};
 			Args = {"player";};
 			Description = "UnBans the player from game (Saves)";
 			AdminLevel = "HeadAdmins";

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1687,7 +1687,7 @@ return function(Vargs, env)
 
 		AdminList = {
 			Prefix = Settings.Prefix;
-			Commands = {"admins";"adminlist";"HeadAdmins";"owners";"moderators";"ranks"};
+			Commands = {"admins";"adminlist";"headadmins";"owners";"moderators";"ranks"};
 			Args = {};
 			Hidden = false;
 			Description = "Shows you the list of admins, also shows admins that are currently in the server";
@@ -2578,7 +2578,7 @@ return function(Vargs, env)
 
 		Track = {
 			Prefix = Settings.Prefix;
-			Commands = {"track";"trace";"find";};
+			Commands = {"track";"trace";"find";"locate"};
 			Args = {"player";};
 			Hidden = false;
 			Description = "Shows you where the target player(s) is/are";
@@ -2627,7 +2627,7 @@ return function(Vargs, env)
 
 		UnTrack = {
 			Prefix = Settings.Prefix;
-			Commands = {"untrack";"untrace";"unfind";};
+			Commands = {"untrack";"untrace";"unfind";"unlocate"};
 			Args = {"player";};
 			Hidden = false;
 			Description = "Stops tracking the target player(s)";
@@ -3341,7 +3341,7 @@ return function(Vargs, env)
 
 		RemoveFog = {
 			Prefix = Settings.Prefix;
-			Commands = {"nofog";"fogoff";};
+			Commands = {"nofog";"fogoff";"unfog"};
 			Args = {"optional player"};
 			Hidden = false;
 			Description = "Fog Off";
@@ -4476,7 +4476,7 @@ return function(Vargs, env)
 
 		Volume = {
 			Prefix = Settings.Prefix;
-			Commands = {"volume"};
+			Commands = {"volume","vol"};
 			Args = {"number"};
 			Description = "Change the volume of the currently playing song";
 			AdminLevel = "Moderators";
@@ -4660,7 +4660,7 @@ return function(Vargs, env)
 
 		StopMusic = {
 			Prefix = Settings.Prefix;
-			Commands = {"stopmusic";"musicoff";};
+			Commands = {"stopmusic";"musicoff";"unmusic"};
 			Args = {};
 			Hidden = false;
 			Description = "Stop the currently playing song";

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -107,7 +107,7 @@ return function(Vargs, env)
 							{Text = "Prefix: "..cmd.Prefix, Desc = "Prefix used to run the command"},
 							{Text = "Commands: "..table.concat(cmd.Commands, ", "), Desc = "Valid default aliases for the command"},
 							{Text = "Arguments: "..cmdArgs, Desc = "Parameters taken by the command"},
-							{Text = "Admin Level: "..cmd.AdminLevel, Desc = "Rank required to run the command"},
+							{Text = "Admin Level: "..cmd.AdminLevel.." ("..Admin.LevelToListName(cmd.AdminLevel)..")", Desc = "Rank required to run the command"},
 							{Text = "Fun: "..tostring(cmd.Fun), Desc = "Is the command fun?"},
 							{Text = "Hidden: "..tostring(cmd.Hidden), Desc = "Is the command hidden from the command list?"},
 							{Text = "Description: "..cmd.Description, Desc = "Command description"}

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -108,8 +108,8 @@ return function(Vargs, env)
 							{Text = "Commands: "..table.concat(cmd.Commands, ", "), Desc = "Valid default aliases for the command"},
 							{Text = "Arguments: "..cmdArgs, Desc = "Parameters taken by the command"},
 							{Text = "Admin Level: "..cmd.AdminLevel.." ("..Admin.LevelToListName(cmd.AdminLevel)..")", Desc = "Rank required to run the command"},
-							{Text = "Fun: "..tostring(cmd.Fun), Desc = "Is the command fun?"},
-							{Text = "Hidden: "..tostring(cmd.Hidden), Desc = "Is the command hidden from the command list?"},
+							{Text = "Fun: "..tostring(cmd.Fun and "Yes" or "No"), Desc = "Is the command fun?"},
+							{Text = "Hidden: "..tostring(cmd.Hidden and "Yes" or "No"), Desc = "Is the command hidden from the command list?"},
 							{Text = "Description: "..cmd.Description, Desc = "Command description"}
 						};
 						Size = {400,220}


### PR DESCRIPTION
1. `:cmdinfo` now shows the admin rank a command is associated to and also prevent `nil` being returned by the `Fun` and `Hidden` command checks
![image](https://user-images.githubusercontent.com/77434904/134035943-bbf77fed-2fbe-4058-916b-7385cef9e070.png)
2. Fixes a typo in some command aliases introduced in #493 (`permenant`) - should be `permanent`
3. add confirm prompt for `:globalplace`
4. add some donor cmd aliases in case someone makes both `settings.Prefix` and `settings.PlayerPrefix` the same (maybe we should have some sort of in-game notification about this?)