### PR TITLE
Pull Request Stats

### DIFF
--- a/.github/workflows/pr-stats.yml
+++ b/.github/workflows/pr-stats.yml
@@ -8,7 +8,8 @@ jobs:
     steps:
       - name: Run pull request stats
         uses: flowwer-dev/pull-request-stats@master
-        with:          
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           period: 30
           charts: true
           disable-links: true

--- a/.github/workflows/pr-stats.yml
+++ b/.github/workflows/pr-stats.yml
@@ -1,0 +1,15 @@
+name: Pull Request Stats
+
+on: pull_request
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run pull request stats
+        uses: flowwer-dev/pull-request-stats@master
+        with:          
+          period: 30
+          charts: true
+          disable-links: true
+          sort-by: 'COMMENTS'


### PR DESCRIPTION
https://github.com/marketplace/actions/pull-request-stats

Github action to print relevant stats about Pull Request reviewers.

The objective of this action is to:

- Reduce the time taken to review the pull requests.
- Encourage quality on reviews.
- Help deciding which people to assign as reviewers.