### PR TITLE
Automatic GitHub actions deployments

### DIFF
--- a/.github/loader.deploy.project.json
+++ b/.github/loader.deploy.project.json
@@ -1,0 +1,6 @@
+{
+	"name": "Adonis_Loader",
+	"tree": {
+        "$path": "../Loader"
+	}
+} 

--- a/.github/module.deploy.project.json
+++ b/.github/module.deploy.project.json
@@ -1,0 +1,6 @@
+{
+	"name": "MainModule",
+	"tree": {
+		"$path": "../MainModule"
+	}
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
-name: loader
+name: publish
 
 on:
   release:
     types: [published]
 
 jobs:
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -17,5 +17,8 @@ jobs:
       - name: Set DebugMode off
         run: sed -i "s/DebugMode = true/DebugMode = false/g" Loader/Loader/Loader.server.lua 
 
-      - name: Deploy
+      - name: Deploy Loader
         run: rojo upload --cookie "${{ secrets.ROBLOSECURITY }}" --asset_id 7510622625 .github/loader.deploy.project.json
+
+      - name: Deploy MainModule
+        run: rojo upload --cookie "${{ secrets.ROBLOSECURITY }}" --asset_id 7510592873 .github/module.deploy.project.json

--- a/.github/workflows/publish_loader.yml
+++ b/.github/workflows/publish_loader.yml
@@ -1,0 +1,21 @@
+name: loader
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: Roblox/setup-foreman@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set DebugMode off
+        run: sed -i "s/DebugMode = true/DebugMode = false/g" Loader/Loader/Loader.server.lua 
+
+      - name: Deploy
+        run: rojo upload --cookie "${{ secrets.ROBLOSECURITY }}" --asset_id 7510622625 .github/loader.deploy.project.json


### PR DESCRIPTION
Automatically turns off `DebugMode` and uploads the loader (and MainModule, includes #502 as a combined action). Requires a `ROBLOSECURITY` secret to be set.