### PR TITLE
Adonis Loader Studio warning

### DIFF
--- a/Loader/Loader/Loader.server.lua
+++ b/Loader/Loader/Loader.server.lua
@@ -86,6 +86,9 @@ else
 		setTab = {}
 	end
 
+	if service.RunService:IsStudio() then
+		warn("Adonis is running in a Roblox Studio enviroment. Some commands (such as those which utilise TeleportService) and features may not work correctly.")
+
 	data.Settings = setTab.Settings;
 	data.Descriptions = setTab.Description;
 	data.Order = setTab.Order;

--- a/Loader/Loader/Loader.server.lua
+++ b/Loader/Loader/Loader.server.lua
@@ -80,14 +80,15 @@ else
 		moduleId = model.Parent.MainModule
 	end
 
+	if game:GetService("RunService"):IsStudio() then
+		warn("Adonis is running in a Roblox Studio enviroment. Some commands and features may be disabled or not work correctly due to Studio restrictions.")
+	end
+
 	local a,setTab = pcall(require, settings)
 	if not a then
 		warn('Settings module errored while loading; Using defaults; Error Message: ',setTab)
 		setTab = {}
 	end
-
-	if service.RunService:IsStudio() then
-		warn("Adonis is running in a Roblox Studio enviroment. Some commands (such as those which utilise TeleportService) and features may not work correctly.")
 
 	data.Settings = setTab.Settings;
 	data.Descriptions = setTab.Description;


### PR DESCRIPTION
Adonis loader will now output a message to the console saying that some commands and features may not work due to studio restrictions (e.g. teleportservice or access to datastores if studio access to api services is disabled)