### PR TITLE
made console show all sub-commands/aliases for commands

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -929,8 +929,8 @@ return function(Vargs)
 			end
 		end;
 
-		FormatCommand = function(command)
-			local text = command.Prefix.. command.Commands[1]
+		FormatCommand = function(command,cmdn)
+			local text = command.Prefix.. command.Commands[cmdn or 1]
 			local cmdArgs = command.Args or command.Arguments
 			local splitter = Settings.SplitKey
 

--- a/MainModule/Server/Core/Remote.lua
+++ b/MainModule/Server/Core/Remote.lua
@@ -397,7 +397,9 @@ return function(Vargs)
 				local tab = {}
 				for i,v in pairs(commands) do
 					if not v.Hidden and not v.Disabled then
-						table.insert(tab,Admin.FormatCommand(v))
+						for a,b in pairs(v.Commands) do
+							table.insert(tab,Admin.FormatCommand(v,a))
+						end
 					end
 				end
 				return tab


### PR DESCRIPTION
title is pretty explaniatory, basically the console will now show all aliases for commands in the Command.Commands table, instead of only the first one.