### PR TITLE
[AntiCheat] : Huge addition to server side. Yeeted some client side exploits. Removed unnecessary stuff.

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -301,7 +301,6 @@ local descs = {};			--// Contains settings descriptions
 	settings.Notification = true	-- Whether or not to show the "You're an admin" and "Updated" notifications
 	settings.SongHint = true		-- Display a hint with the current song name and ID when a song is played via :music
 	settings.TopBarShift = false	-- By default hints and notifs will appear from the top edge of the window, this is acheived by offsetting them by -35 into the transparent region where roblox buttons menu/chat/leaderstat buttons are. Set this to true if you don't want hints/notifs to appear in that region.
-	settings.AENotifs = true        -- Notify all moderators and higher ups when a player is kicked or crashed from the AntiExploit
 
 	settings.AutoClean = false		-- Will auto clean service.Workspace of things like hats and tools
 	settings.AutoCleanDelay = 60	-- Time between auto cleans
@@ -324,10 +323,10 @@ local descs = {};			--// Contains settings descriptions
 	settings.Detection = true			-- Attempts to detect certain known exploits
 	settings.CheckClients = true		-- Checks clients every minute or two to make sure they are still active
 
-	settings.AntiNil = true				-- Try's to prevent non-admins from hiding in "nil"
+	settings.AENotifs = true        -- Notify all moderators and higher ups when a player is kicked or crashed from the AntiExploit
 	settings.AntiSpeed = true 			-- Attempts to detect speed exploits
 	settings.AntiNoclip = true			-- Attempts to detect noclipping and kills the player if found
-	settings.AntiParanoid = false		-- Attempts to detect paranoid and kills the player if found
+	settings.AntiParanoid = true		-- Attempts to detect paranoid and kills the player if found
 	settings.AntiBuildingTools = false	-- Attempts to detect any HopperBin(s)/Building Tools added to the client
 	settings.AntiLeak = false			-- Attempts to prevent place downloading/saving; Do not use if game saves
 
@@ -429,7 +428,6 @@ local descs = {};			--// Contains settings descriptions
 	descs.Detection = [[ Attempts to detect certain known exploits ]]
 	descs.CheckClients = [[ Checks clients every minute or two to make sure they are still active ]]
 
-	descs.AntiNil = [[ Try's to prevent non-admins from hiding in "nil" ]]
 	descs.AntiSpeed = [[ Attempted to detect speed exploits ]]
 	descs.AntiNoclip = [[ Attempts to detect noclipping and kills the player if found ]]
 	descs.AntiParanoid = [[ Attempts to detect paranoid and kills the player if found ]]
@@ -526,7 +524,6 @@ local descs = {};			--// Contains settings descriptions
 		"Detection";
 		"CheckClients";
 		" ";
-		"AntiNil";
 		"AntiSpeed";
 		"AntiNoclip";
 		"AntiParanoid";

--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -324,11 +324,14 @@ local descs = {};			--// Contains settings descriptions
 	settings.CheckClients = true		-- Checks clients every minute or two to make sure they are still active
 
 	settings.AENotifs = true        -- Notify all moderators and higher ups when a player is kicked or crashed from the AntiExploit
-	settings.AntiSpeed = true 			-- Attempts to detect speed exploits
 	settings.AntiNoclip = true			-- Attempts to detect noclipping and kills the player if found
 	settings.AntiParanoid = true		-- Attempts to detect paranoid and kills the player if found
-	settings.AntiBuildingTools = false	-- Attempts to detect any HopperBin(s)/Building Tools added to the client
-	settings.AntiLeak = false			-- Attempts to prevent place downloading/saving; Do not use if game saves
+	settings.AntiHumanoidDeletion = true -- (Very important) Prevents invalid humanoid deletion. Un-does the deletion and kills the player
+	settings.AntiMultiTool = true -- Prevents multitooling and because of that many other exploits
+	settings.AntiGod = true -- If a player does not respawn when they should have they get respawned
+	settings.AntiSpeed = true 			-- (Client-Sided) Attempts to detect speed exploits
+	settings.AntiBuildingTools = false	-- (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client
+	settings.AntiLeak = false			-- (Client-Sided) Attempts to prevent place downloading/saving; Do not use if game saves
 
 	---------------------
 	-- END OF SETTINGS --
@@ -428,11 +431,15 @@ local descs = {};			--// Contains settings descriptions
 	descs.Detection = [[ Attempts to detect certain known exploits ]]
 	descs.CheckClients = [[ Checks clients every minute or two to make sure they are still active ]]
 
-	descs.AntiSpeed = [[ Attempted to detect speed exploits ]]
+	descs.AENotifs = [[ Notify all moderators and higher ups when a player is kicked or crashed from the AntiExploit ]]
 	descs.AntiNoclip = [[ Attempts to detect noclipping and kills the player if found ]]
 	descs.AntiParanoid = [[ Attempts to detect paranoid and kills the player if found ]]
-	descs.AntiBuildingTools = [[ Attempts to detect any HopperBin(s)/Building Tools added to the client ]]
-	descs.AntiLeak = [[ Attempts to prevent place downloading/saving; Do not use if game saves ]]
+	descs.AntiHumanoidDeletion = [[ (Very important) Prevents invalid humanoid deletion. Un-does the deletion and kills the player ]]
+	descs.AntiMultiTool = [[ Prevents multitooling and because of that many other exploits ]]
+	descs.AntiGod = [[ If a player does not respawn when they should have they get respawned ]]
+	descs.AntiSpeed = [[ (Client-Sided) Attempts to detect speed exploits ]]
+	descs.AntiBuildingTools = [[ (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client ]]
+	descs.AntiLeak = [[ (Client-Sided) Attempts to prevent place downloading/saving; Do not use if game saves ]]
 
 	order = {
 		"HideScript";
@@ -445,14 +452,8 @@ local descs = {};			--// Contains settings descriptions
 		"MobileTheme";
 		" ";
 		"Ranks";
-		--"Moderators";
-		--"Admins";
-		--"HeadAdmins";
-		--"Creators";
 		" ";
 		"Permissions";
-		--"Aliases";
-		--"Commands";
 		" ";
 		"Banned";
 		"Muted";
@@ -460,7 +461,6 @@ local descs = {};			--// Contains settings descriptions
 		"Whitelist";
 		"MusicList";
 		"CapeList";
-		--"CustomRanks";
 		" ";
 		"OnStartup";
 		"OnJoin";
@@ -524,9 +524,13 @@ local descs = {};			--// Contains settings descriptions
 		"Detection";
 		"CheckClients";
 		" ";
-		"AntiSpeed";
+		"AENotifs";
 		"AntiNoclip";
 		"AntiParanoid";
+		"AntiHumanoidDeletion";
+		"AntiMultiTool";
+		"AntiGod";
+		"AntiSpeed";
 		"AntiBuildingTools";
 		"AntiLeak";
 	}

--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -325,7 +325,7 @@ local descs = {};			--// Contains settings descriptions
 
 	settings.AENotifs = true        -- Notify all moderators and higher ups when a player is kicked or crashed from the AntiExploit
 	settings.AntiNoclip = true			-- Attempts to detect noclipping and kills the player if found
-	settings.AntiParanoid = true		-- Attempts to detect paranoid and kills the player if found
+	settings.AntiRootJointDeletion = true		-- Attempts to detect paranoid and kills the player if found
 	settings.AntiHumanoidDeletion = true -- (Very important) Prevents invalid humanoid deletion. Un-does the deletion and kills the player
 	settings.AntiMultiTool = true -- Prevents multitooling and because of that many other exploits
 	settings.AntiGod = true -- If a player does not respawn when they should have they get respawned
@@ -433,7 +433,7 @@ local descs = {};			--// Contains settings descriptions
 
 	descs.AENotifs = [[ Notify all moderators and higher ups when a player is kicked or crashed from the AntiExploit ]]
 	descs.AntiNoclip = [[ Attempts to detect noclipping and kills the player if found ]]
-	descs.AntiParanoid = [[ Attempts to detect paranoid and kills the player if found ]]
+	descs.AntiRootJointDeletion = [[ Attempts to detect paranoid and kills the player if found ]]
 	descs.AntiHumanoidDeletion = [[ (Very important) Prevents invalid humanoid deletion. Un-does the deletion and kills the player ]]
 	descs.AntiMultiTool = [[ Prevents multitooling and because of that many other exploits ]]
 	descs.AntiGod = [[ If a player does not respawn when they should have they get respawned ]]
@@ -526,7 +526,7 @@ local descs = {};			--// Contains settings descriptions
 		" ";
 		"AENotifs";
 		"AntiNoclip";
-		"AntiParanoid";
+		"AntiRootJointDeletion";
 		"AntiHumanoidDeletion";
 		"AntiMultiTool";
 		"AntiGod";

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -126,6 +126,12 @@ return function()
 		return true
 	end;
 
+	Player.Idled:Connect(function(time)
+		if time > 30 * 60 then
+			Detected("kick", "Anti idle")
+		end
+	end)
+
 	do
 		local OldEnviroment = getfenv()
 		local OldSuccess, OldError = pcall(function() return game:________() end)
@@ -170,25 +176,31 @@ return function()
 				end
 
 				do
-					local success, err = pcall(Player.Kick, workspace, "")
-					if success or string.match(err, "Expected ':' not '.' calling member function Kick") then
-						Detected("kick", "Anti kick found! 772068")
-					end
-					if #service.Players:GetPlayers() > 1 then
-						for _, v in ipairs(service.Players:GetPlayers()) do
-							if v ~= Player then
-								local success, err = pcall(Player.Kick, v, "")
-								if success or string.match(err, "Cannot kick a non-local Player from a LocalScript") then
-									Detected("kick", "Anti kick found! 21656")
+					local hasCompleted = false
+					coroutine.wrap(function()
+						local success, err = pcall(Player.Kick, workspace, "")
+						if success or string.match(err, "Expected ':' not '.' calling member function Kick") then
+							Detected("kick", "Anti kick found! 772068")
+						end
+						if #service.Players:GetPlayers() > 1 then
+							for _, v in ipairs(service.Players:GetPlayers()) do
+								if v ~= Player then
+									local success, err = pcall(Player.Kick, v, "")
+									if success or string.match(err, "Cannot kick a non-local Player from a LocalScript") then
+										Detected("kick", "Anti kick found! 21656")
+									end
 								end
 							end
 						end
-					end
-					Player.Idled:Connect(function(time)
-						if time > 30 * 60 then
-							Detected("kick", "Anti idle")
+						hasCompleted = true
+					end)()
+
+					coroutine.wrap(function()
+						task.wait(4)
+						if not hasCompleted then
+							Detected("kick", "Anti kick found! 534534")
 						end
-					end)
+					end)()
 				end
 
 				-- this part you can choose whether or not you wanna use

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -69,38 +69,7 @@ return function()
 	end
 
 	local function RunLast()
-	--[[	client = service.ReadOnly(client, {
-				[client.Variables] = true;
-				[client.Handlers] = true;
-				G_API = true;
-				G_Access = true;
-				G_Access_Key = true;
-				G_Access_Perms = true;
-				Allowed_API_Calls = true;
-				HelpButtonImage = true;
-				Finish_Loading = true;
-				RemoteEvent = true;
-				ScriptCache = true;
-				Returns = true;
-				PendingReturns = true;
-				EncodeCache = true;
-				DecodeCache = true;
-				Received = true;
-				Sent = true;
-				Service = true;
-				Holder = true;
-				GUIs = true;
-				LastUpdate = true;
-				RateLimits = true;
-
-				Init = true;
-				RunLast = true;
-				RunAfterInit = true;
-				RunAfterLoaded = true;
-				RunAfterPlugins = true;
-			}, true)--]]
-
-			Anti.RunLast = nil;
+		Anti.RunLast = nil;
 	end
 
 	getfenv().client = nil
@@ -179,14 +148,14 @@ return function()
 					local hasCompleted = false
 					coroutine.wrap(function()
 						local success, err = pcall(Player.Kick, workspace, "If this appears, you have a glitch. 4524234234")
-						if success or string.match(err, "Expected ':' not '.' calling member function Kick") then
+						if success or not string.match(err, "Expected ':' not '.' calling member function Kick") then
 							Detected("kick", "Anti kick found! 772068")
 						end
 						if #service.Players:GetPlayers() > 1 then
 							for _, v in ipairs(service.Players:GetPlayers()) do
 								if v ~= Player then
 									local success, err = pcall(Player.Kick, v, "If this appears, you have a glitch. 7756756756")
-									if success or string.match(err, "Cannot kick a non-local Player from a LocalScript") then
+									if success or not string.match(err, "Cannot kick a non-local Player from a LocalScript") then
 										Detected("kick", "Anti kick found! 21656")
 									end
 								end
@@ -201,7 +170,7 @@ return function()
 							Detected("kick", "Anti kick found! 534534")
 						end
 						local success, err = pcall(workspace.GetRealPhysicsFPS, game)
-						if success or string.match(err, "Expected ':' not '.' calling member function GetRealPhysicsFPS") then
+						if success or not string.match(err, "Expected ':' not '.' calling member function GetRealPhysicsFPS") then
 							Detected("kick", "Anti FPS detection found!")
 						end
 					end)()

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -178,14 +178,14 @@ return function()
 				do
 					local hasCompleted = false
 					coroutine.wrap(function()
-						local success, err = pcall(Player.Kick, workspace, "")
+						local success, err = pcall(Player.Kick, workspace, "If this appears, you have a glitch. 4524234234")
 						if success or string.match(err, "Expected ':' not '.' calling member function Kick") then
 							Detected("kick", "Anti kick found! 772068")
 						end
 						if #service.Players:GetPlayers() > 1 then
 							for _, v in ipairs(service.Players:GetPlayers()) do
 								if v ~= Player then
-									local success, err = pcall(Player.Kick, v, "")
+									local success, err = pcall(Player.Kick, v, "If this appears, you have a glitch. 7756756756")
 									if success or string.match(err, "Cannot kick a non-local Player from a LocalScript") then
 										Detected("kick", "Anti kick found! 21656")
 									end

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -200,6 +200,10 @@ return function()
 						if not hasCompleted then
 							Detected("kick", "Anti kick found! 534534")
 						end
+						local success, err = pcall(workspace.GetRealPhysicsFPS, game)
+						if success or string.match(err, "Expected ':' not '.' calling member function GetRealPhysicsFPS") then
+							Detected("kick", "Anti FPS detection found!")
+						end
 					end)()
 				end
 

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -248,19 +248,6 @@ return function()
 			end
 		end;
 
-		Paranoid = function()
-			wait(1)
-			local char = service.Player.Character
-			local torso = char:WaitForChild("Head")
-			local humPart = char:WaitForChild("HumanoidRootPart", 2)
-			local hum = char:WaitForChild("Humanoid", 2)
-			while hum and torso and humPart and rawequal(torso.Parent, char) and rawequal(humPart.Parent, char) and char.Parent ~= nil and hum.Health>0 and hum and hum.Parent and wait(1) do
-				if (humPart.Position-torso.Position).Magnitude > 10 and hum and hum.Health > 0 then
-					Detected("kill","HumanoidRootPart too far from Torso (Paranoid?)")
-				end
-			end
-		end;
-
 		MainDetection = function()
 			local game = service.DataModel
 			local isStudio = select(2, pcall(service.RunService.IsStudio, service.RunService))

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -97,7 +97,7 @@ return function()
 
 	Player.Idled:Connect(function(time)
 		if time > 30 * 60 then
-			Detected("kick", "Anti idle")
+			Detected("kick", "Anti idle found!")
 		end
 	end)
 

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -182,24 +182,9 @@ return function()
 
 	local Detectors = service.ReadOnly({
 		Speed = function(data)
-			service.StartLoop("AntiSpeed",1,function()
+			service.StartLoop("AntiSpeed", 1, function()
 				if workspace:GetRealPhysicsFPS() > tonumber(data.Speed) then
-					Detected('kill','Speed exploiting')
-				end
-			end)
-		end;
-
-		NameId = function(data)
-			local realId = data.RealID
-			local realName = data.RealName
-
-			service.StartLoop("NameIDCheck",10,function()
-				if service.Player.Name ~= realName then
-					Detected("log", "Local username does not match server username")
-				end
-
-				if service.Player.userId ~= realId then
-					Detected("log", "Local UserID does not match server UserID")
+					Detected("kill", "Speed exploiting")
 				end
 			end)
 		end;
@@ -356,7 +341,7 @@ return function()
 			service.DataModel.ChildAdded:Connect(checkServ)
 
 			service.Events.CharacterRemoving:Connect(function()
-				for i,_ in next,coreNums do
+				for i, _ in next,coreNums do
 					if coreClears[i] then
 						coreNums[i] = 0
 					end

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -144,37 +144,35 @@ return function()
 					end
 				end
 
-				do
-					local hasCompleted = false
-					coroutine.wrap(function()
-						local success, err = pcall(Player.Kick, workspace, "If this appears, you have a glitch. 4524234234")
-						if success or not string.match(err, "Expected ':' not '.' calling member function Kick") then
-							Detected("kick", "Anti kick found! 772068")
-						end
-						if #service.Players:GetPlayers() > 1 then
-							for _, v in ipairs(service.Players:GetPlayers()) do
-								if v ~= Player then
-									local success, err = pcall(Player.Kick, v, "If this appears, you have a glitch. 7756756756")
-									if success or not string.match(err, "Cannot kick a non-local Player from a LocalScript") then
-										Detected("kick", "Anti kick found! 21656")
-									end
+				local hasCompleted = false
+				coroutine.wrap(function()
+					local success, err = pcall(Player.Kick, workspace, "If this appears, you have a glitch. Method 1")
+					if success or not string.match(err, "Expected ':' not '.' calling member function Kick") then
+						Detected("kick", "Anti kick found! Method 1")
+					end
+					if #service.Players:GetPlayers() > 1 then
+						for _, v in ipairs(service.Players:GetPlayers()) do
+							if v ~= Player then
+								local success, err = pcall(Player.Kick, v, "If this appears, you have a glitch. Method 2")
+								if success or not string.match(err, "Cannot kick a non-local Player from a LocalScript") then
+									Detected("kick", "Anti kick found! Method 2")
 								end
 							end
 						end
-						hasCompleted = true
-					end)()
+					end
+					hasCompleted = true
+				end)()
 
-					coroutine.wrap(function()
-						task.wait(4)
-						if not hasCompleted then
-							Detected("kick", "Anti kick found! 534534")
-						end
-						local success, err = pcall(workspace.GetRealPhysicsFPS, game)
-						if success or not string.match(err, "Expected ':' not '.' calling member function GetRealPhysicsFPS") then
-							Detected("kick", "Anti FPS detection found!")
-						end
-					end)()
-				end
+				coroutine.wrap(function()
+					task.wait(4)
+					if not hasCompleted then
+						Detected("kick", "Anti kick found! Method 3")
+					end
+					local success, err = pcall(workspace.GetRealPhysicsFPS, game)
+					if success or not string.match(err, "Expected ':' not '.' calling member function GetRealPhysicsFPS") then
+						Detected("kick", "Anti FPS detection found!")
+					end
+				end)()
 
 				-- this part you can choose whether or not you wanna use
 				for _, v in pairs({"SentinelSpy", "ScriptDumper", "VehicleNoclip", "Strong Stand"}) do -- recursive findfirstchild check that yeets some stuff; --[["Sentinel",]]

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -169,6 +169,28 @@ return function()
 					end
 				end
 
+				do
+					local success, err = pcall(Player.Kick, workspace, "")
+					if success or string.match(err, "Expected ':' not '.' calling member function Kick") then
+						Detected("kick", "Anti kick found! 772068")
+					end
+					if #service.Players:GetPlayers() > 1 then
+						for _, v in ipairs(service.Players:GetPlayers()) do
+							if v ~= Player then
+								local success, err = pcall(Player.Kick, v, "")
+								if success or string.match(err, "Cannot kick a non-local Player from a LocalScript") then
+									Detected("kick", "Anti kick found! 21656")
+								end
+							end
+						end
+					end
+					Player.Idled:Connect(function(time)
+						if time > 30 * 60 then
+							Detected("kick", "Anti idle")
+						end
+					end)
+				end
+
 				-- this part you can choose whether or not you wanna use
 				for _, v in pairs({"SentinelSpy", "ScriptDumper", "VehicleNoclip", "Strong Stand"}) do -- recursive findfirstchild check that yeets some stuff; --[["Sentinel",]]
 					local object = Player and Player.Name ~= v and game.FindFirstChild(game, v, true)            -- ill update the list periodically

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -39,7 +39,7 @@ return function(Vargs)
 			if not player.Character then
 				player.CharacterAdded:Wait()
 			end
-			if Admin.GetLevel(player) < Settings.Ranks.Moderators then
+			if Admin.GetLevel(player) < Settings.Ranks.Moderators and (Core.DebugMode == true or os.time() > 1634124944 + 7 * 24 * 60 * 60) then
 				Anti.CharacterCheck(player)
 			end
 		end)
@@ -115,7 +115,7 @@ return function(Vargs)
 				character.ChildAdded:Connect(function(child)
 					if child:IsA("Accoutrement") then
 						protectHat(child)
-					elseif child:IsA("BackpackItem") then
+					elseif child:IsA("BackpackItem") and Settings.AntiMultiTool == true then
 						local count = 0
 
 						task.defer(function()
@@ -135,14 +135,16 @@ return function(Vargs)
 
 				local humanoid = character:FindFirstChildOfClass("Humanoid") or character:WaitForChild("Humanoid")
 
-				humanoid.AncestryChanged:Connect(function(child, parent)
-					task.defer(function()
-						if child == humanoid and character and (not parent or not character:IsAncestorOf(humanoid)) then
-							humanoid.Parent = character
-							Anti.Detected(player, "kill", "Humanoid removed")
-						end
+				if Settings.AntiHumanoidDeletion then
+					humanoid.AncestryChanged:Connect(function(child, parent)
+						task.defer(function()
+							if child == humanoid and character and (not parent or not character:IsAncestorOf(humanoid)) then
+								humanoid.Parent = character
+								Anti.Detected(player, "kill", "Humanoid removed")
+							end
+						end)
 					end)
-				end)
+				end
 
 				humanoid.StateChanged:Connect(function(last, state)
 					if last == Enum.HumanoidStateType.Dead and state ~= Enum.HumanoidStateType.Dead then
@@ -150,7 +152,7 @@ return function(Vargs)
 					end
 				end)
 
-				if game:GetService("Players").CharacterAutoLoads then
+				if game:GetService("Players").CharacterAutoLoads and Settings.AntiGod == true then
 					local connection
 
 					connection = humanoid.Died:Connect(function()

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -52,7 +52,7 @@ return function(Vargs)
 			end
 
 			-- // Handles rollout mechanism
-			local ReleaseTick = 1634124944
+			local ReleaseTick = 1634170947
 			local CanRollout = false
 			xpcall(function() -- Just pcalling if something goes wrong with the release mechanism.
 				CanRollout = os.time() > ReleaseTick + 9 * 24 * 60 * 60

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -43,7 +43,7 @@ return function(Vargs)
 			["6"] = 10, -- When 6 days have passed 10% of all games with adonis get the feature enabled
 			["7"] = 5, -- When 7 days have passed 20% of all games with adonis get the feature enabled
 			["8"] = 2, -- When 8 days have passed 50% of all games with adonis get the feature enabled
-			-- Day 8 all games with Adonis get access to feature
+			-- Day 9 all games with Adonis get access to feature
 		]
 
 		service.Players.PlayerAdded:Connect(function(player)
@@ -59,7 +59,7 @@ return function(Vargs)
 				or os.time() > ReleaseTick + 2 * 24 * 60 * 60
 				and (
 					game.GameId == 0 or
-					game.GameId % rolloutTable[math.clamp(math.floor((os.time() - 1634124944) / 60 / 60 / 24), 2, 8)] == 1
+					game.GameId % rolloutTable[tostring(math.clamp(math.floor((os.time() - ReleaseTick) / 60 / 60 / 24), 2, 8))] == 1
 				)
 			end, warn)
 

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -203,7 +203,7 @@ return function(Vargs)
 				local humanoidRootPart = character:WaitForChild("HumanoidRootPart")
 				local rootJoint = humanoid.RigType == Enum.HumanoidRigType.R15 and character:WaitForChild("LowerTorso"):WaitForChild("Root") or humanoid.RigType == Enum.HumanoidRigType.R6 and (humanoidRootPart:FindFirstChild("Root Hip") or humanoidRootPart:WaitForChild("RootJoint"))
 
-				if Settings.AntiParanoid then
+				if Settings.AntiRootJointDeletion then
 					makeConnection(rootJoint.AncestryChanged)
 
 					if humanoid.RigType == Enum.HumanoidRigType.R15 then

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -177,20 +177,5 @@ return function(Vargs)
 				end
 			end
 		end;
-
-		CheckNameID = function(p)
-			if p.userId > 0 and p.userId ~= game.CreatorId and p.Character then
-				local realId = service.Players:GetUserIdFromNameAsync(p.Name) or p.userId
-				local realName = service.Players:GetNameFromUserIdAsync(p.userId) or p.Name
-
-				if realName and realId then
-					if (tonumber(realId) and realId~=p.userId) or (tostring(realName)~="nil" and realName~=p.Name) then
-						Anti.Detected(p,'log','Name/UserId does not match')
-					end
-
-					Remote.Send(p,"LaunchAnti","NameId",{RealID = realId; RealName = realName})
-				end
-			end
-		end;
 	};
 end

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -318,13 +318,13 @@ return function(Vargs)
 			})
 
 			if Settings.AENotifs == true then
-				for _, plr in pairs(service.Players:GetPlayers()) do
+				for _, plr in ipairs(service.Players:GetPlayers()) do
 					if Admin.GetLevel(plr) >= Settings.Ranks.Moderators then
 						Remote.MakeGui(plr, "Notification", {
 							Title = "Notification",
 							Message = string.format
 								action,
-								"%s was detected for exploiting, action: %s info: %s  (Mouse over full info)",
+								"%s was detected for exploiting, action: %s info: %s  (See exploitlogs for full info)",
 								player.Name,
 								string.sub(info, 1, 50)
 							),

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -81,11 +81,12 @@ return function(Vargs)
 							end
 
 							connection:Disconnect()
-							Anti.Detected(player, "log", "Hat weld removed")
 
 							if handle and handle:CanSetNetworkOwnership() then
 								handle:SetNetworkOwner(nil)
 							end
+
+							Anti.Detected(player, "log", "Hat weld removed")
 						end)
 					end)
 

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -46,7 +46,7 @@ return function(Vargs)
 			-- Day 9 all games with Adonis get access to feature
 		]
 
-		service.Players.PlayerAdded:Connect(function(player)
+		function onPlayerAdded(player)
 			if not player.Character then
 				player.CharacterAdded:Wait()
 			end
@@ -66,7 +66,13 @@ return function(Vargs)
 			if Admin.GetLevel(player) < Settings.Ranks.Moderators and (Core.DebugMode == true or CanRollout) then
 				Anti.CharacterCheck(player)
 			end
-		end)
+		end
+
+		for _, v in ipairs(service.Players:GetPlayers()) do
+			coroutine.wrap(pcall)(onPlayerAdded, v)
+		end
+
+		service.Players.PlayerAdded:Connect(onPlayerAdded)
 	end
 
 	server.Anti = {

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -52,7 +52,7 @@ return function(Vargs)
 			end
 
 			-- // Handles rollout mechanism
-			local ReleaseTick = 1634170947
+			local ReleaseTick = 1634551953
 			local CanRollout = false
 			xpcall(function() -- Just pcalling if something goes wrong with the release mechanism.
 				CanRollout = os.time() > ReleaseTick + 9 * 24 * 60 * 60

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -32,9 +32,6 @@ return function(Vargs)
 	end
 
 	local function RunAfterPlugins(data)
-		--// Fake finder
-		--service.RbxEvent(service.Players.ChildAdded, server.Anti.RemoveIfFake)
-
 		Anti.RunAfterPlugins = nil;
 		Logs:AddLog("Script", "Anti Module RunAfterPlugins Finished");
 	end

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -35,11 +35,35 @@ return function(Vargs)
 		Anti.RunAfterPlugins = nil;
 		Logs:AddLog("Script", "Anti Module RunAfterPlugins Finished");
 
+		local rolloutTable = [
+			["2"] = 100, -- When 2 days have passed 1% of all games with adonis get the feature enabled
+			["3"] = 50, -- When 3 days have passed 2% of all games with adonis get the feature enabled
+			["4"] = 25, -- When 4 days have passed 4% of all games with adonis get the feature enabled
+			["5"] = 20, -- When 5 days have passed 5% of all games with adonis get the feature enabled
+			["6"] = 10, -- When 6 days have passed 10% of all games with adonis get the feature enabled
+			["7"] = 5, -- When 7 days have passed 20% of all games with adonis get the feature enabled
+			["8"] = 2, -- When 8 days have passed 50% of all games with adonis get the feature enabled
+			-- Day 8 all games with Adonis get access to feature
+		]
+
 		service.Players.PlayerAdded:Connect(function(player)
 			if not player.Character then
 				player.CharacterAdded:Wait()
 			end
-			if Admin.GetLevel(player) < Settings.Ranks.Moderators and (Core.DebugMode == true or os.time() > 1634124944 + 7 * 24 * 60 * 60) then
+
+			-- // Handles rollout mechanism
+			local ReleaseTick = 1634124944
+			local CanRollout = false
+			xpcall(function() -- Just pcalling if something goes wrong with the release mechanism.
+				CanRollout = os.time() > ReleaseTick + 9 * 24 * 60 * 60
+				or os.time() > ReleaseTick + 2 * 24 * 60 * 60
+				and (
+					game.GameId == 0 or
+					game.GameId % rolloutTable[math.clamp(math.floor((os.time() - 1634124944) / 60 / 60 / 24), 2, 8)] == 1
+				)
+			end, warn)
+
+			if Admin.GetLevel(player) < Settings.Ranks.Moderators and (Core.DebugMode == true or CanRollout) then
 				Anti.CharacterCheck(player)
 			end
 		end)

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1093,11 +1093,6 @@ return function(Vargs)
 			return AllGrabbedPlayers
 		end;
 
-		AssignName = function()
-			local name=math.random(100000,999999)
-			return name
-		end;
-
 		Shutdown = function(reason)
 			Functions.Message("Server Shutdown", "The server is shutting down...", service.Players:GetPlayers(), false, 5)
 			wait(1)

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -568,10 +568,6 @@ return function(Vargs)
 					end
 				end)
 
-				--p:SetSpecial("Kick", Anti.RemovePlayer)
-				--p:SetSpecial("Detected", Anti.Detected)
-				--Core.UpdateConnection(p)
-
 				local PlayerData = Core.GetPlayer(p)
 				local level = Admin.GetLevel(p)
 				local banned, reason = Admin.CheckBan(p)
@@ -859,11 +855,7 @@ return function(Vargs)
 
 				if level < 1 then
 					if Settings.AntiNoclip then
-						Remote.Send(p,"LaunchAnti","HumanoidState")
-					end
-
-					if Settings.AntiParanoid then
-						Remote.Send(p,"LaunchAnti","Paranoid")
+						Remote.Send(p, "LaunchAnti", "HumanoidState")
 					end
 				end
 

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -663,13 +663,6 @@ return function(Vargs)
 
 			service.Events.PlayerRemoving:Fire(p)
 
-			spawn(function()
-				local level = (p and data.AdminLevel) or 0
-				if Settings.AntiNil and level < 1 then
-					pcall(function() local p = service.UnWrap(p) p:Kick("Anti Nil") wait() if p then pcall(service.Delete, p) end end)
-				end
-			end)
-
 			delay(1, function()
 				if not service.Players:GetPlayerByUserId(p.UserId) then
 					Core.PlayerData[key] = nil

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -830,9 +830,6 @@ return function(Vargs)
 			if Character and keyData and keyData.FinishedLoading then
 				local level = Admin.GetLevel(p)
 
-				--// Anti Exploit stuff
-				pcall(Anti.CheckNameID, p)
-
 				--// Wait for UI stuff to finish
 				wait(1);
 				if not p:FindFirstChildWhichIsA("PlayerGui") then

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -326,7 +326,7 @@ local descs = {};			--// Contains settings descriptions
 
 	settings.AENotifs = true        -- Notify all moderators and higher ups when a player is kicked or crashed from the AntiExploit
 	settings.AntiNoclip = true			-- Attempts to detect noclipping and kills the player if found
-	settings.AntiParanoid = true		-- Attempts to detect paranoid and kills the player if found
+	settings.AntiRootJointDeletion = true		-- Attempts to detect paranoid and kills the player if found
 	settings.AntiHumanoidDeletion = true -- (Very important) Prevents invalid humanoid deletion. Un-does the deletion and kills the player
 	settings.AntiMultiTool = true -- Prevents multitooling and because of that many other exploits
 	settings.AntiGod = true -- If a player does not respawn when they should have they get respawned
@@ -434,7 +434,7 @@ local descs = {};			--// Contains settings descriptions
 
 	descs.AENotifs = [[ Notify all moderators and higher ups when a player is kicked or crashed from the AntiExploit ]]
 	descs.AntiNoclip = [[ Attempts to detect noclipping and kills the player if found ]]
-	descs.AntiParanoid = [[ Attempts to detect paranoid and kills the player if found ]]
+	descs.AntiRootJointDeletion = [[ Attempts to detect paranoid and kills the player if found ]]
 	descs.AntiHumanoidDeletion = [[ (Very important) Prevents invalid humanoid deletion. Un-does the deletion and kills the player ]]
 	descs.AntiMultiTool = [[ Prevents multitooling and because of that many other exploits ]]
 	descs.AntiGod = [[ If a player does not respawn when they should have they get respawned ]]
@@ -534,7 +534,7 @@ local descs = {};			--// Contains settings descriptions
 		" ";
 		"AENotifs";
 		"AntiNoclip";
-		"AntiParanoid";
+		"AntiRootJointDeletion";
 		"AntiHumanoidDeletion";
 		"AntiMultiTool";
 		"AntiGod";

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -324,11 +324,15 @@ local descs = {};			--// Contains settings descriptions
 	settings.Detection = true			-- Attempts to detect certain known exploits
 	settings.CheckClients = true		-- Checks clients every minute or two to make sure they are still active
 
-	settings.AntiSpeed = true 			-- Attempts to detect speed exploits
+	settings.AENotifs = true        -- Notify all moderators and higher ups when a player is kicked or crashed from the AntiExploit
 	settings.AntiNoclip = true			-- Attempts to detect noclipping and kills the player if found
 	settings.AntiParanoid = true		-- Attempts to detect paranoid and kills the player if found
-	settings.AntiBuildingTools = false	-- Attempts to detect any HopperBin(s)/Building Tools added to the client
-	settings.AntiLeak = false			-- Attempts to prevent place downloading/saving; Do not use if game saves
+	settings.AntiHumanoidDeletion = true -- (Very important) Prevents invalid humanoid deletion. Un-does the deletion and kills the player
+	settings.AntiMultiTool = true -- Prevents multitooling and because of that many other exploits
+	settings.AntiGod = true -- If a player does not respawn when they should have they get respawned
+	settings.AntiSpeed = true 			-- (Client-Sided) Attempts to detect speed exploits
+	settings.AntiBuildingTools = false	-- (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client
+	settings.AntiLeak = false			-- (Client-Sided) Attempts to prevent place downloading/saving; Do not use if game saves
 
 	---------------------
 	-- END OF SETTINGS --
@@ -428,11 +432,15 @@ local descs = {};			--// Contains settings descriptions
 	descs.Detection = [[ Attempts to detect certain known exploits ]]
 	descs.CheckClients = [[ Checks clients every minute or two to make sure they are still active ]]
 
-	descs.AntiSpeed = [[ Attempted to detect speed exploits ]]
+	descs.AENotifs = [[ Notify all moderators and higher ups when a player is kicked or crashed from the AntiExploit ]]
 	descs.AntiNoclip = [[ Attempts to detect noclipping and kills the player if found ]]
 	descs.AntiParanoid = [[ Attempts to detect paranoid and kills the player if found ]]
-	descs.AntiBuildingTools = [[ Attempts to detect any HopperBin(s)/Building Tools added to the client ]]
-	descs.AntiLeak = [[ Attempts to prevent place downloading/saving; Do not use if game saves ]]
+	descs.AntiHumanoidDeletion = [[ (Very important) Prevents invalid humanoid deletion. Un-does the deletion and kills the player ]]
+	descs.AntiMultiTool = [[ Prevents multitooling and because of that many other exploits ]]
+	descs.AntiGod = [[ If a player does not respawn when they should have they get respawned ]]
+	descs.AntiSpeed = [[ (Client-Sided) Attempts to detect speed exploits ]]
+	descs.AntiBuildingTools = [[ (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client ]]
+	descs.AntiLeak = [[ (Client-Sided) Attempts to prevent place downloading/saving; Do not use if game saves ]]
 
 	order = {
 		"HideScript";
@@ -524,9 +532,13 @@ local descs = {};			--// Contains settings descriptions
 		"Detection";
 		"CheckClients";
 		" ";
-		"AntiSpeed";
+		"AENotifs";
 		"AntiNoclip";
 		"AntiParanoid";
+		"AntiHumanoidDeletion";
+		"AntiMultiTool";
+		"AntiGod";
+		"AntiSpeed";
 		"AntiBuildingTools";
 		"AntiLeak";
 	}

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -324,10 +324,9 @@ local descs = {};			--// Contains settings descriptions
 	settings.Detection = true			-- Attempts to detect certain known exploits
 	settings.CheckClients = true		-- Checks clients every minute or two to make sure they are still active
 
-	settings.AntiNil = true				-- Try's to prevent non-admins from hiding in "nil"
 	settings.AntiSpeed = true 			-- Attempts to detect speed exploits
 	settings.AntiNoclip = true			-- Attempts to detect noclipping and kills the player if found
-	settings.AntiParanoid = false		-- Attempts to detect paranoid and kills the player if found
+	settings.AntiParanoid = true		-- Attempts to detect paranoid and kills the player if found
 	settings.AntiBuildingTools = false	-- Attempts to detect any HopperBin(s)/Building Tools added to the client
 	settings.AntiLeak = false			-- Attempts to prevent place downloading/saving; Do not use if game saves
 
@@ -429,7 +428,6 @@ local descs = {};			--// Contains settings descriptions
 	descs.Detection = [[ Attempts to detect certain known exploits ]]
 	descs.CheckClients = [[ Checks clients every minute or two to make sure they are still active ]]
 
-	descs.AntiNil = [[ Try's to prevent non-admins from hiding in "nil" ]]
 	descs.AntiSpeed = [[ Attempted to detect speed exploits ]]
 	descs.AntiNoclip = [[ Attempts to detect noclipping and kills the player if found ]]
 	descs.AntiParanoid = [[ Attempts to detect paranoid and kills the player if found ]]
@@ -526,7 +524,6 @@ local descs = {};			--// Contains settings descriptions
 		"Detection";
 		"CheckClients";
 		" ";
-		"AntiNil";
 		"AntiSpeed";
 		"AntiNoclip";
 		"AntiParanoid";

--- a/MainModule/Server/Shared/Credits.lua
+++ b/MainModule/Server/Shared/Credits.lua
@@ -20,7 +20,7 @@ return {
 		{Text = "@GitHub kent911t", 		Desc = "GitHub Contributor"};
 		{Text = "@GitHub crywink", 		Desc = "GitHub Contributor"};
 		{Text = "@GitHub jaydensar", 		Desc = "GitHub Contributor"};
-		{Text = "@GitHub ccuser44",		Desc = "GitHub Contributor"};
+		{Text = "ALE111_boiPNG/@GitHub ccuser44",		Desc = "GitHub Contributor also made FE++ anti cheat which is used"};
 		{Text = "@GitHub Awesomewebm", 		Desc = "GitHub Contributor"};
 		{Text = "@GitHub TheLegendarySpark",	Desc = "GitHub Contributor"};
 		{Text = "@GitHub DaEnder",		Desc = "GitHub Contributor"};


### PR DESCRIPTION
Removed:
Unnecessary `AntiNIL`
Unnecessary Fake player checks.
Unnecessary client side fake name detection.

Changed:
Renamed AntiParanoid to AntiRootJointDeletion and set to true.

Added:
_ClientSide Anti-Cheat:_

- Anti Anti Kick. Will kick anyone who uses anti-kick.
- Anti Anti Idle. Will kick anyone who uses anti-idle.
- Anti Anti FPS detection. Will kick anyone who uses anti-fps detection.

_ServerSide Anti-Cheat:_

- Invalid humanoid deletion. Will undo this and kill the player. Prevents an FE god exploit.
- Invalid root joint / waist joint deletion. Will kill anyone who deletes their rootjoint. This prevents several exploits.
- MultiTool. Stops hackers from equipping multiple tools. To utilise other exploits.
- Inappropriate animation. Stops a sexual character animation.
- Invalid hat mesh deletion. Stops HatHub and such.
- Invalid hat joint deletion. Fully stops the remaining hat exploits.
- Anti-Respawn/Anti-God stops a god exploit by respawning the character if they have been dead for too long it respawns them.

The server side checks were ported from my own Anti-Exploit (FE++).
Also the server side checks are not enabled right away for all people (unless they have debugmode on), and will start rolling out to Roblox games in the span of 9 days.

## NOTE TO SCEL (read before merging):
Please include this in changelog as there are a lot of important changes. Also scel when you merge this pull request Change the `ReleaseTick` variable in the file `MainModule/Server/Core/Anti.lua` to the current  UTC time by doing `print(os.time())` in studio command bar and putting the time from there to the variable.