### PR TITLE
Fix blank PMs on mobile devices

### DIFF
--- a/MainModule/Client/UI/Default/PrivateMessage.lua
+++ b/MainModule/Client/UI/Default/PrivateMessage.lua
@@ -39,6 +39,10 @@ return function(data)
 		if not debounce then
 			debounce = true
 			if enter then
+				if (reply:IsFocused()) then
+					reply:ReleaseFocus() -- Prevents box text from being checked before it is populated on mobile devices
+				end
+				
 				if service.Trim(reply.Text) == "" then
 					debounce = false
 					UI.Make("Hint", {


### PR DESCRIPTION
This fixes a bug on mobile devices that caused PMs to be sent before the reply box text was updated (resulting in blank replies). Closes #479 and also should close #459 