### PR TITLE
Admin/Commands/Core/Process.lua | Optimizations

### DIFF
--- a/MainModule/Client/Client.lua
+++ b/MainModule/Client/Client.lua
@@ -86,7 +86,7 @@ local service = {}
 local ServiceSpecific = {}
 
 local function isModule(module)
-	for ind, modu in next, client.Modules do
+	for ind, modu in pairs(client.Modules) do
 		if rawequal(module, modu) then
 			return true
 		end
@@ -185,7 +185,7 @@ GetEnv = function(env, repl)
 	})
 
 	if repl and type(repl)=="table" then
-		for ind, val in next,repl do
+		for ind, val in pairs(repl) do
 			scriptEnv[ind] = val
 		end
 	end
@@ -278,7 +278,7 @@ locals = {
 
 log("Create service metatable");
 
-service = setfenv(require(Folder.Shared.Service), GetEnv(nil, {client = client}))(function(eType, msg, desc, ...)
+service = require(Folder.Shared.Service)(function(eType, msg, desc, ...)
 	local extra = {...}
 	if eType == "MethodError" and service.Detected then
 		Kill()("Shananigans denied")
@@ -301,73 +301,74 @@ end, function(c, parent, tab)
 	if not isModule(c) and c ~= script and c ~= Folder and parent == nil then
 		tab.UnHook()
 	end
-end, ServiceSpecific)
+end, ServiceSpecific, GetEnv(nil, {client = client}))
 
 --// Localize
 log("Localize");
-os = service.Localize(os)
-math = service.Localize(math)
-table = service.Localize(table)
-string = service.Localize(string)
-coroutine = service.Localize(coroutine)
-Instance = service.Localize(Instance)
-Vector2 = service.Localize(Vector2)
-Vector3 = service.Localize(Vector3)
-CFrame = service.Localize(CFrame)
-UDim2 = service.Localize(UDim2)
-UDim = service.Localize(UDim)
-Ray = service.Localize(Ray)
-Rect = service.Localize(Rect)
-Faces = service.Localize(Faces)
-Color3 = service.Localize(Color3)
-NumberRange = service.Localize(NumberRange)
-NumberSequence = service.Localize(NumberSequence)
-NumberSequenceKeypoint = service.Localize(NumberSequenceKeypoint)
-ColorSequenceKeypoint = service.Localize(ColorSequenceKeypoint)
-PhysicalProperties = service.Localize(PhysicalProperties)
-ColorSequence = service.Localize(ColorSequence)
-Region3int16 = service.Localize(Region3int16)
-Vector3int16 = service.Localize(Vector3int16)
-BrickColor = service.Localize(BrickColor)
-TweenInfo = service.Localize(TweenInfo)
-Axes = service.Localize(Axes)
-task = service.Localize(task)
+local Localize = service.Localize
+os = Localize(os)
+math = Localize(math)
+table = Localize(table)
+string = Localize(string)
+coroutine = Localize(coroutine)
+Instance = Localize(Instance)
+Vector2 = Localize(Vector2)
+Vector3 = Localize(Vector3)
+CFrame = Localize(CFrame)
+UDim2 = Localize(UDim2)
+UDim = Localize(UDim)
+Ray = Localize(Ray)
+Rect = Localize(Rect)
+Faces = Localize(Faces)
+Color3 = Localize(Color3)
+NumberRange = Localize(NumberRange)
+NumberSequence = Localize(NumberSequence)
+NumberSequenceKeypoint = Localize(NumberSequenceKeypoint)
+ColorSequenceKeypoint = Localize(ColorSequenceKeypoint)
+PhysicalProperties = Localize(PhysicalProperties)
+ColorSequence = Localize(ColorSequence)
+Region3int16 = Localize(Region3int16)
+Vector3int16 = Localize(Vector3int16)
+BrickColor = Localize(BrickColor)
+TweenInfo = Localize(TweenInfo)
+Axes = Localize(Axes)
+task = Localize(task)
 
 --// Wrap
 log("Wrap")
 
-local service_wrap = service.Wrap
-local service_unwrap = service.UnWrap
+local service_Wrap = service.Wrap
+local service_UnWrap = service.UnWrap
 
-for i,val in next,service do if type(val) == "userdata" then service[i] = service_wrap(val, true) end end
+for i,val in pairs(service) do if type(val) == "userdata" then service[i] = service_Wrap(val, true) end end
 
 --// Folder Wrap
-Folder = service_wrap(Folder, true)
+Folder = service_Wrap(Folder, true)
 
 --// Global Wrapping
-Enum = service_wrap(Enum, true)
+Enum = service_Wrap(Enum, true)
 rawequal = service.RawEqual
-script = service_wrap(script, true)
-game = service_wrap(game, true)
-workspace = service_wrap(workspace, true)
+script = service_Wrap(script, true)
+game = service_Wrap(game, true)
+workspace = service_Wrap(workspace, true)
 Instance = {
 	new = function(obj, parent)
 		local nobj = oldInstNew(obj)
-		local par = parent and service_unwrap(parent)
+		local par = parent and service_UnWrap(parent)
 		if par then nobj.Parent = par end
-		return service_wrap(nobj, true)
+		return service_Wrap(nobj, true)
 	end
 }
 require = function(obj)
-	return service_wrap(oldReq(service_unwrap(obj)), true)
+	return service_Wrap(oldReq(service_UnWrap(obj)), true)
 end
 
 client.Service = service
-client.Module = service_wrap(client.Module, true)
+client.Module = service_Wrap(client.Module, true)
 
 --// Setting things up
 log("Setting things up")
-for ind,loc in next,{
+for ind,loc in pairs({
 	_G = _G;
 	game = game;
 	spawn = spawn;
@@ -432,7 +433,7 @@ for ind,loc in next,{
 	task = task;
 	tick = tick;
 	service = service;
-	} do locals[ind] = loc end
+	}) do locals[ind] = loc end
 
 --// Init
 log("Return init function");
@@ -445,8 +446,8 @@ return service.NewProxy({
 
 		setfenv(1,setmetatable({}, {__metatable = unique}))
 		client.Folder = Folder;
-		client.UIFolder = Folder:WaitForChild("UI");
-		client.Shared = Folder:WaitForChild("Shared");
+		client.UIFolder = Folder:WaitForChild("UI",9e9);
+		client.Shared = Folder:WaitForChild("Shared",9e9);
 		client.Loader = data.Loader
 		client.Module = data.Module
 		client.DepsName = depsName
@@ -456,7 +457,7 @@ return service.NewProxy({
 
 		--// Toss deps into a table so we don't need to directly deal with the Folder instance they're in
 		log("Get dependencies")
-		for ind,obj in next,Folder:WaitForChild("Dependencies"):GetChildren() do client.Deps[obj.Name] = obj end
+		for ind,obj in ipairs(Folder:WaitForChild("Dependencies",9e9):GetChildren()) do client.Deps[obj.Name] = obj end
 
 		--// Do this before we start hooking up events
 		log("Destroy script object")
@@ -465,7 +466,7 @@ return service.NewProxy({
 
 		--// Intial setup
 		log("Initial services caching")
-		for ind, serv in next,ServicesWeUse do local temp = service[serv] end
+		for ind, serv in ipairs(ServicesWeUse) do local temp = service[serv] end
 
 		--// Client specific service variables/functions
 		log("Add service specific")
@@ -521,7 +522,7 @@ return service.NewProxy({
 
 		--// Load Core Modules
 		log("Loading core modules")
-		for ind,load in next,LoadingOrder do
+		for ind,load in ipairs(LoadingOrder) do
 			local modu = Folder.Core:FindFirstChild(load)
 			if modu then
 				log("~! Loading Core Module: ".. tostring(load))
@@ -541,13 +542,13 @@ return service.NewProxy({
 			if client.Core.Key then
 				--// Run anything from core modules that needs to be done after the client has finished loading
 				log("~! Doing run after loaded")
-				for i,f in next,runAfterLoaded do
+				for i,f in pairs(runAfterLoaded) do
 					Pcall(f, data);
 				end
 
 				--// Stuff to run after absolutely everything else
 				log("~! Doing run last")
-				for i,f in next,runLast do
+				for i,f in pairs(runLast) do
 					Pcall(f, data);
 				end
 
@@ -567,7 +568,7 @@ return service.NewProxy({
 
 		--// Initialize Cores
 		log("~! Init cores");
-		for i,name in next,LoadingOrder do
+		for i,name in ipairs(LoadingOrder) do
 			local core = client[name]
 			log("~! INIT: ".. tostring(name))
 
@@ -604,19 +605,19 @@ return service.NewProxy({
 
 		--// Load any afterinit functions from modules (init steps that require other modules to have finished loading)
 		log("~! Running after init")
-		for i,f in next,runAfterInit do
+		for i,f in pairs(runAfterInit) do
 			Pcall(f, data);
 		end
 
 		--// Load Plugins
 		log("~! Running plugins")
-		for index,plugin in next,Folder.Plugins:GetChildren() do
+		for index,plugin in ipairs(Folder.Plugins:GetChildren()) do
 			LoadModule(plugin, false, {script = plugin}); --noenv
 		end
 
 		--// We need to do some stuff *after* plugins are loaded (in case we need to be able to account for stuff they may have changed before doing something, such as determining the max length of remote commands)
 		log("~! Running after plugins")
-		for i,f in next,runAfterPlugins do
+		for i,f in pairs(runAfterPlugins) do
 			Pcall(f, data);
 		end
 

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1469,7 +1469,7 @@ return function(Vargs, env)
 
 				local nilPlayers = 0
 				for i,v in pairs(service.NetworkServer:GetChildren()) do
-					if v and v:GetPlayer() and not service.Players:FindFirstChild(v:GetPlayer().Name) then
+					if v:IsA("NetworkReplicator") and v:GetPlayer() and not service.Players:FindFirstChild(v:GetPlayer().Name) then
 						nilPlayers = nilPlayers + 1
 					end
 				end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2871,29 +2871,40 @@ return function(Vargs, env)
 			Function = function(plr,args)
 				for i,v in pairs(service.GetPlayers(plr,args[1])) do
 					Routine(function()
-						if v and v.Character and v.Character:FindFirstChild("Humanoid") then
-							v.Character.Archivable = true
-							local cl = v.Character:Clone()
+						local Character = v.Character
+						local Humanoid = Character and Character:FindFirstChildOfClass("Humanoid")
+
+						if Humanoid then
+							Character.Archivable = true
+
+							local cl = Character:Clone()
 							table.insert(Variables.Objects,cl)
+
+							local Animate
 							local anim = cl:FindFirstChild("Animate")
 							if anim then
-								local Animate = v.Character.Humanoid.RigType == Enum.HumanoidRigType.R15 and Deps.Assets.R15Animate:Clone() or Deps.Assets.R6Animate:Clone()
+								Animate = Humanoid.RigType == Enum.HumanoidRigType.R15 and Deps.Assets.R15Animate:Clone() or Deps.Assets.R6Animate:Clone()
 								Animate:ClearAllChildren()
-								for _,v in ipairs(anim:GetChildren()) do
+								for _, v in ipairs(anim:GetChildren()) do
 									v.Parent = Animate
 								end
-								Animate.Parent = cl
-								Animate.Disabled = false
 								anim:Destroy()
+
+								Animate.Parent = cl
 							end
+
+							if Character.PrimaryPart then
+								cl:SetPrimaryPartCFrame(Character.PrimaryPart.CFrame)
+							end
+							if Animate then
+								Animate.Disabled = false
+							end
+							cl:FindFirstChild("Humanoid").Died:Connect(function()
+								cl:Destroy()
+							end)
+
+							cl.Archivable = false
 							cl.Parent = workspace
-							cl:MoveTo(v.Character:GetModelCFrame().p)
-							cl:MakeJoints()
-							cl:WaitForChild("Humanoid")
-							v.Character.Archivable = false
-							repeat wait(0.5) until not cl:FindFirstChild("Humanoid") or cl.Humanoid.Health <= 0
-							wait(5)
-							if cl then cl:Destroy() end
 						end
 					end)
 				end
@@ -5887,10 +5898,10 @@ return function(Vargs, env)
 
 				local function makeBot(player)
 					local char = player.Character
-					local torso = player.Character:FindFirstChild("HumanoidRootPart")
+					local torso = char:FindFirstChild("HumanoidRootPart") or char.PrimaryPart
 					local pos = torso.CFrame
-					local clone
 
+					local clone
 					char.Archivable = true
 					clone = char:Clone()
 					char.Archivable = false
@@ -5898,13 +5909,14 @@ return function(Vargs, env)
 					for i = 1, num do
 						local new = clone:Clone()
 						local hum = new:FindFirstChildOfClass("Humanoid")
+
 						local brain = Deps.Assets.BotBrain:Clone()
 						local event = brain.Event
+
 						local oldAnim = new:FindFirstChild("Animate")
 						local isR15 = (hum.RigType == "R15")
 						local anim = (isR15 and Deps.Assets.R15Animate:Clone()) or Deps.Assets.R6Animate:Clone()
 
-						new.Parent = workspace
 						new.Name = player.Name
 						new.HumanoidRootPart.CFrame = pos*CFrame.Angles(0,math.rad((360/num)*i),0)*CFrame.new((num*0.2)+5,0,0)
 
@@ -5917,10 +5929,11 @@ return function(Vargs, env)
 						end
 
 						anim.Parent = new
-						anim.Disabled = false
-
 						brain.Parent = new
+
+						anim.Disabled = false
 						brain.Disabled = false
+						new.Parent = workspace
 
 						wait()
 

--- a/MainModule/Server/Core/Commands.lua
+++ b/MainModule/Server/Core/Commands.lua
@@ -51,9 +51,10 @@ return function(Vargs)
 
 		--// Load command modules
 		if server.CommandModules then
+			local env = GetEnv()
 			for i,module in ipairs(server.CommandModules:GetChildren()) do
 				local func = require(module)
-				local ran,tab = pcall(func, Vargs, getfenv())
+				local ran,tab = pcall(func, Vargs, env)
 
 				if ran and tab and type(tab) == "table" then
 					for ind,cmd in pairs(tab) do

--- a/MainModule/Server/Core/Commands.lua
+++ b/MainModule/Server/Core/Commands.lua
@@ -87,13 +87,14 @@ return function(Vargs)
 		end
 
 		--// Change command permissions based on settings
+		local Trim = service.Trim
 		for ind, cmd in pairs(Settings.Permissions or {}) do
 			local com,level = string.match(cmd, "^(.*):(.*)")
 			if com and level then
 				if string.find(level, ",") then
 					local newLevels = {}
 					for lvl in string.gmatch(level, "[^%,]+") do
-						table.insert(newLevels, service.Trim(lvl))
+						table.insert(newLevels, Trim(lvl))
 					end
 
 					Admin.SetPermission(com, newLevels)

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -925,7 +925,7 @@ return function(Vargs)
 					sets = sets or {}
 
 					for i,v in pairs(sets) do
-						if Functions.CheckMatch(tab, v.Table) and CheckMatch(v.Value, value) then
+						if CheckMatch(tab, v.Table) and CheckMatch(v.Value, value) then
 							table.remove(sets,i)
 						end
 					end

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -23,7 +23,7 @@ return function(Vargs)
 	local service = Vargs.Service;
 
 	local Functions, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Settings, Deps;
-
+	local AddLog, Queue, TrackTask
 	local function Init(data)
 		Functions = server.Functions;
 		Admin = server.Admin;
@@ -35,7 +35,11 @@ return function(Vargs)
 		Process = server.Process;
 		Variables = server.Variables;
 		Settings = server.Settings;
-		Deps = server.Deps
+		Deps = server.Deps;
+
+		AddLog = Logs.AddLog;
+		Queue = service.Queue;
+		TrackTask = service.TrackTask;
 
 		--// Core variables
 		Core.Themes = data.Themes or {}
@@ -63,7 +67,7 @@ return function(Vargs)
 
 		local remoteParent = service.ReplicatedStorage;
 		remoteParent.ChildRemoved:Connect(function(c)
-			if server.Core.RemoteEvent and not server.Core.FixingEvent and (function() for i,v in next,server.Core.RemoteEvent do if c == v then return true end end end)() then
+			if server.Core.RemoteEvent and not server.Core.FixingEvent and (function() for i,v in pairs(server.Core.RemoteEvent) do if c == v then return true end end end)() then
 				wait();
 				server.Core.MakeEvent()
 			end
@@ -72,7 +76,7 @@ return function(Vargs)
 		--// Load data
 		Core.DataStore = server.Core.GetDataStore()
 		if Core.DataStore then
-			service.TrackTask("Thread: DSLoadAndHook", function()
+			TrackTask("Thread: DSLoadAndHook", function()
 				pcall(server.Core.LoadData)
 			end)
 		end
@@ -86,7 +90,7 @@ return function(Vargs)
 		--// Start API
 		if service.NetworkServer then
 			--service.Threads.RunTask("_G API Manager",server.Core.StartAPI)
-			service.TrackTask("Thread: API Manager", Core.StartAPI)
+			TrackTask("Thread: API Manager", Core.StartAPI)
 		end
 
 		--// Occasionally save all player data to the datastore to prevent data loss if the server abruptly crashes
@@ -132,7 +136,7 @@ return function(Vargs)
 			if Core.RemoteEvent and not Core.FixingEvent then
 				Core.FixingEvent = true;
 
-				for name,event in next,Core.RemoteEvent.Events do
+				for name,event in pairs(Core.RemoteEvent.Events) do
 					event:Disconnect()
 				end
 
@@ -203,7 +207,7 @@ return function(Vargs)
 
 		UpdateConnections = function()
 			if service.NetworkServer then
-				for i,cli in next,service.NetworkServer:GetChildren() do
+				for i,cli in ipairs(service.NetworkServer:GetChildren()) do
 					Core.Connections[cli] = cli:GetPlayer()
 				end
 			end
@@ -211,7 +215,7 @@ return function(Vargs)
 
 		UpdateConnection = function(p)
 			if service.NetworkServer then
-				for i,cli in next,service.NetworkServer:GetChildren() do
+				for i,cli in ipairs(service.NetworkServer:GetChildren()) do
 					if cli:GetPlayer() == p then
 						Core.Connections[cli] = p
 					end
@@ -221,7 +225,7 @@ return function(Vargs)
 
 		GetNetworkClient = function(p)
 			if service.NetworkServer then
-				for i,v in pairs(service.NetworkServer:GetChildren()) do
+				for i,v in ipairs(service.NetworkServer:GetChildren()) do
 					if v:GetPlayer() == p then
 						return v
 					end
@@ -234,7 +238,7 @@ return function(Vargs)
 				local loader = Core.ClientLoader;
 				loader.Removing = true;
 
-				for i,v in next,loader.Events do
+				for i,v in pairs(loader.Events) do
 					v:Disconnect()
 				end
 
@@ -413,7 +417,7 @@ return function(Vargs)
 		LoadExistingPlayer = function(p)
 			warn("Loading existing player: ".. tostring(p))
 
-			service.TrackTask("Thread: Setup Existing Player: ".. tostring(p), function()
+			TrackTask("Thread: Setup Existing Player: ".. tostring(p), function()
 				Process.PlayerAdded(p)
 				--Core.MakeClient(p:FindFirstChildOfClass("PlayerGui") or p:WaitForChild("PlayerGui", 120))
 			end)
@@ -573,7 +577,7 @@ return function(Vargs)
 						data.AdminNotes = (data.AdminNotes and Functions.DSKeyNormalize(data.AdminNotes, true)) or {}
 						data.Warnings = (data.Warnings and Functions.DSKeyNormalize(data.Warnings, true)) or {}
 
-						for i,v in next,data do
+						for i,v in pairs(data) do
 							PlayerData[i] = v
 						end
 					end
@@ -644,6 +648,14 @@ return function(Vargs)
 				return service.DataStoreService:GetDataStore(string.sub(Settings.DataStore, 1, 50),"Adonis")
 			end)
 
+			-- DataStore studio check.
+			if ran and store and service.RunService:IsStudio() then
+				local success, res = pcall(store.GetAsync, store, math.random())
+				if not success and string.find(res, "403", 1, true) then
+					return;
+				end
+			end
+
 			return ran and store
 		end;
 
@@ -682,7 +694,7 @@ return function(Vargs)
 
 		DS_WriteLimiter = function(type, func, ...)
 			local vararg = table.pack(...)
-			return service.Queue("DataStoreWriteData_" .. tostring(type), function()
+			return Queue("DataStoreWriteData_" .. tostring(type), function()
 				local gotDelay = Core.DS_GetRequestDelay(type); --// Wait for budget, also return how long we should wait before the next request is allowed to go
 				func(unpack(vararg, 1, vararg.n))
 				task.wait(gotDelay)
@@ -690,19 +702,22 @@ return function(Vargs)
 		end;
 
 		RemoveData = function(key)
-			local ran2, err2 = service.Queue("DataStoreWriteData" .. tostring(key), function()
-				local ran, ret = Core.DS_WriteLimiter("Write", Core.DataStore.RemoveAsync, Core.DataStore, Core.DataStoreEncode(key))
-				if ran then
-					Core.DataCache[key] = nil
-				else
-					logError("DataStore RemoveAsync Failed: ".. tostring(ret))
+			local DataStore = Core.DataStore
+			if DataStore then
+				local ran2, err2 = Queue("DataStoreWriteData" .. tostring(key), function()
+					local ran, ret = Core.DS_WriteLimiter("Write", DataStore.RemoveAsync, DataStore, Core.DataStoreEncode(key))
+					if ran then
+						Core.DataCache[key] = nil
+					else
+						logError("DataStore RemoveAsync Failed: ".. tostring(ret))
+					end
+
+					task.wait(6)
+				end, 120, true)
+
+				if not ran2 then
+					warn("DataStore RemoveData Failed: ".. tostring(err2))
 				end
-
-				task.wait(6)
-			end, 120, true)
-
-			if not ran2 then
-				warn("DataStore RemoveData Failed: ".. tostring(err2))
 			end
 		end;
 
@@ -711,12 +726,13 @@ return function(Vargs)
 				warn("Retrying SetData request for ".. key);
 			end
 
-			if Core.DataStore then
+			local DataStore = Core.DataStore
+			if DataStore then
 				if value == nil then
 					return Core.RemoveData(key)
 				else
-					local ran2, err2 = service.Queue("DataStoreWriteData" .. tostring(key), function()
-						local ran, ret = Core.DS_WriteLimiter("Write", Core.DataStore.SetAsync, Core.DataStore, Core.DataStoreEncode(key), value)
+					local ran2, err2 = Queue("DataStoreWriteData" .. tostring(key), function()
+						local ran, ret = Core.DS_WriteLimiter("Write", DataStore.SetAsync, DataStore, Core.DataStoreEncode(key), value)
 						if ran then
 							Core.DataCache[key] = value
 							return;
@@ -748,10 +764,11 @@ return function(Vargs)
 				warn("Retrying UpdateData request for ".. key);
 			end
 
-			if Core.DataStore then
+			local DataStore = Core.DataStore
+			if DataStore then
 				local err = false;
-				local ran2, err2 = service.Queue("DataStoreWriteData" .. tostring(key), function()
-					local ran, ret = Core.DS_WriteLimiter("Update", Core.DataStore.UpdateAsync, Core.DataStore, Core.DataStoreEncode(key), func)
+				local ran2, err2 = Queue("DataStoreWriteData" .. tostring(key), function()
+					local ran, ret = Core.DS_WriteLimiter("Update", DataStore.UpdateAsync, DataStore, Core.DataStoreEncode(key), func)
 
 					if not ran then
 						err = ret;
@@ -783,9 +800,10 @@ return function(Vargs)
 				warn("Retrying GetData request for ".. key);
 			end
 
-			if Core.DataStore then
-				local ran2, err2 = service.Queue("DataStoreReadData", function()
-					local ran, ret = pcall(Core.DataStore.GetAsync, Core.DataStore, Core.DataStoreEncode(key))
+			local DataStore = Core.DataStore
+			if DataStore then
+				local ran2, err2 = Queue("DataStoreReadData", function()
+					local ran, ret = pcall(DataStore.GetAsync, DataStore, Core.DataStoreEncode(key))
 					if ran then
 						Core.DataCache[key] = ret
 						return ret
@@ -839,7 +857,7 @@ return function(Vargs)
 		ClearAllData = function()
 			local tabs = Core.GetData("SavedTables");
 
-			for i,v in next, tabs do
+			for i,v in pairs(tabs) do
 				if v.TableKey then
 					Core.RemoveData(v.TableKey);
 				end
@@ -856,7 +874,7 @@ return function(Vargs)
 
 			local foundTable = nil;
 
-			for i,v in next,tabs do
+			for i,v in pairs(tabs) do
 				if type(v) == "table" and v.TableName and v.TableName == tableName then
 					foundTable = v
 					break;
@@ -902,11 +920,12 @@ return function(Vargs)
 				data.Action = "Remove"
 				data.Time = os.time()
 
+				local CheckMatch = Functions.CheckMatch
 				Core.UpdateData(key, function(sets)
 					sets = sets or {}
 
-					for i,v in next,sets do
-						if Functions.CheckMatch(tab, v.Table) and Functions.CheckMatch(v.Value, value) then
+					for i,v in pairs(sets) do
+						if Functions.CheckMatch(tab, v.Table) and CheckMatch(v.Value, value) then
 							table.remove(sets,i)
 						end
 					end
@@ -925,11 +944,12 @@ return function(Vargs)
 				data.Action = "Add"
 				data.Time = os.time()
 
+				local CheckMatch = Functions.CheckMatch
 				Core.UpdateData(key, function(sets)
 					sets = sets or {}
 
-					for i,v in next,sets do
-						if Functions.CheckMatch(tab, v.Table) and Functions.CheckMatch(v.Value, value) then
+					for i,v in pairs(sets) do
+						if CheckMatch(tab, v.Table) and CheckMatch(v.Value, value) then
 							table.remove(sets, i)
 						end
 					end
@@ -971,22 +991,22 @@ return function(Vargs)
 				local displayName = type(indList) == "table" and table.concat(indList, ".") or tableName;
 
 				if realTable and tab.Action == "Add" then
-					for i,v in next,realTable do
+					for i,v in pairs(realTable) do
 						if CheckMatch(v,tab.Value) then
 							table.remove(realTable, i)
 						end
 					end
 
-					Logs.AddLog("Script",{
+					AddLog("Script",{
 						Text = "Added value to ".. displayName;
 						Desc = "Added "..tostring(tab.Value).." to ".. displayName .." from datastore";
 					})
 
 					table.insert(realTable, tab.Value)
 				elseif realTable and tab.Action == "Remove" then
-					for i,v in next,realTable do
+					for i,v in pairs(realTable) do
 						if CheckMatch(v, tab.Value) then
-							Logs.AddLog("Script",{
+							AddLog("Script",{
 								Text = "Removed value from ".. displayName;
 								Desc = "Removed "..tostring(tab.Value).." from ".. displayName .." from datastore";
 							})
@@ -1000,14 +1020,16 @@ return function(Vargs)
 				local SavedTables
 				local Blacklist = {DataStoreKey = true;}
 				if Core.DataStore and Settings.DataStoreEnabled then
+					local GetData, LoadData, SaveData, DoSave = Core.GetData, Core.LoadData, Core.SaveData, Core.DoSave
+
 					if not key then
-						SavedSettings = Core.GetData("SavedSettings")
-						SavedTables = Core.GetData("SavedTables")
+						SavedSettings = GetData("SavedSettings")
+						SavedTables = GetData("SavedTables")
 					elseif key and not data then
 						if key == "SavedSettings" then
-							SavedSettings = Core.GetData("SavedSettings")
+							SavedSettings = GetData("SavedSettings")
 						elseif key == "SavedTables" then
-							SavedTables = Core.GetData("SavedTables")
+							SavedTables = GetData("SavedTables")
 						end
 					elseif key and data then
 						if key == "SavedSettings" then
@@ -1020,17 +1042,17 @@ return function(Vargs)
 					if not key and not data then
 						if not SavedSettings then
 							SavedSettings = {}
-							Core.SaveData("SavedSettings",{})
+							SaveData("SavedSettings",{})
 						end
 
 						if not SavedTables then
 							SavedTables = {}
-							Core.SaveData("SavedTables",{})
+							SaveData("SavedTables",{})
 						end
 					end
 
 					if SavedSettings then
-						for setting,value in next,SavedSettings do
+						for setting,value in pairs(SavedSettings) do
 							if not Blacklist[setting] then
 								if setting == 'Prefix' or setting == 'AnyPrefix' or setting == 'SpecialPrefix' then
 									local orig = Settings[setting]
@@ -1047,24 +1069,24 @@ return function(Vargs)
 					end
 
 					if SavedTables then
-						for i,tData in next,SavedTables do
+						for i,tData in pairs(SavedTables) do
 							if tData.TableName and tData.TableKey then
-								local data = Core.GetData(tData.TableKey);
+								local data = GetData(tData.TableKey);
 								if data then
 									for k,v in ipairs(data) do
-										Core.LoadData("TableUpdate", v)
+										LoadData("TableUpdate", v)
 									end
 								end
 							elseif tData.Table and tData.Action then
-								Core.LoadData("TableUpdate", tData)
+								LoadData("TableUpdate", tData)
 							end
 						end
 
 						if Core.Variables.TimeBans then
-							for i,v in next, Core.Variables.TimeBans do
+							for i,v in pairs(Core.Variables.TimeBans) do
 								if v.EndTime-os.time() <= 0 then
 									table.remove(Core.Variables.TimeBans, i)
-									Core.DoSave({
+									DoSave({
 										Type = "TableRemove";
 										Table = {"Core", "Variables", "TimeBans"};
 										Value = v;

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -54,7 +54,7 @@ return function(Vargs)
 		disableAllGUIs(server.Client.UI);
 
 		Core.Init = nil;
-		Logs:AddLog("Script", "Core Module Initialized")
+		AddLog("Script", "Core Module Initialized")
 	end;
 
 	local function RunAfterPlugins(data)
@@ -97,7 +97,7 @@ return function(Vargs)
 		service.StartLoop("SaveAllPlayerData", Core.DS_AllPlayerDataSaveInterval, Core.SaveAllPlayerData, true)
 
 		Core.RunAfterPlugins = nil;
-		Logs:AddLog("Script", "Core Module RunAfterPlugins Finished");
+		AddLog("Script", "Core Module RunAfterPlugins Finished");
 	end
 
 	server.Core = {
@@ -193,7 +193,7 @@ return function(Vargs)
 					event.Parent = remoteParent;
 					secureTriggered = false;
 
-					Logs.AddLog(Logs.Script,{
+					AddLog(Logs.Script,{
 						Text = "Created RemoteEvent";
 						Desc = "RemoteEvent was successfully created";
 					})
@@ -342,7 +342,7 @@ return function(Vargs)
 
 			clientLoader.Removing = false;
 
-			Logs:AddLog("Script", "Created client");
+			AddLog("Script", "Created client");
 		end;
 
 		HookClient = function(p)
@@ -613,7 +613,7 @@ return function(Vargs)
 					data.Warnings = Functions.DSKeyNormalize(data.Warnings)
 
 					Core.SetData(key, data)
-					Logs.AddLog(Logs.Script,{
+					AddLog(Logs.Script,{
 						Text = "Saved data for ".. p.Name;
 						Desc = "Player data was saved to the datastore";
 					})
@@ -964,7 +964,7 @@ return function(Vargs)
 				Core.CrossServer("LoadData", "TableUpdate", data);
 			end
 
-			Logs.AddLog(Logs.Script,{
+			AddLog(Logs.Script,{
 				Text = "Saved setting change to datastore";
 				Desc = "A setting change was issued and saved";
 			})
@@ -1098,7 +1098,7 @@ return function(Vargs)
 						end
 					end
 
-					Logs.AddLog(Logs.Script,{
+					AddLog(Logs.Script,{
 						Text = "Loaded saved data";
 						Desc = "Data was retrieved from the datastore and loaded successfully";
 					})
@@ -1126,6 +1126,7 @@ return function(Vargs)
 			local service = service
 			local Routine = Routine
 			local cPcall = cPcall
+			local MetaFunc = service.MetaFunc
 			local API_Special = {
 				AddAdmin = Settings.Allowed_API_Calls.DataStore;
 				RemoveAdmin = Settings.Allowed_API_Calls.DataStore;
@@ -1150,7 +1151,7 @@ return function(Vargs)
 			}
 
 			local API = {
-				Access = service.MetaFunc(function(...)
+				Access = MetaFunc(function(...)
 					local args = {...}
 					local key = args[1]
 					local ind = args[2]
@@ -1167,7 +1168,7 @@ return function(Vargs)
 							return service.NewProxy {
 								__index = function(tab,inde)
 									if targ[inde] ~= nil and API_Special[inde] == nil or API_Special[inde] == true then
-										Logs.AddLog(Logs.Script,{
+										AddLog(Logs.Script,{
 											Text = "Access to "..tostring(inde).." was granted";
 											Desc = "A server script was granted access to "..tostring(inde);
 										})
@@ -1178,7 +1179,7 @@ return function(Vargs)
 											return targ[inde]
 										end
 									elseif API_Special[inde] == false then
-										Logs.AddLog(Logs.Script,{
+										AddLog(Logs.Script,{
 											Text = "Access to "..tostring(inde).." was denied";
 											Desc = "A server script attempted to access "..tostring(inde).." via _G.Adonis.Access";
 										})
@@ -1204,7 +1205,7 @@ return function(Vargs)
 				end);
 
 				Scripts = service.ReadOnly({
-					ExecutePermission = function(srcScript, code)
+					ExecutePermission = MetaFunc(function(srcScript, code)
 						local exists;
 
 						for i,v in pairs(Core.ScriptCache) do
@@ -1237,48 +1238,48 @@ return function(Vargs)
 							end
 							return data.Source, module
 						end
-					end;
+					end);
 
-					ReportLBI = function(scr, origin)
+					ReportLBI = MetaFunc(function(scr, origin)
 						if origin == "Server" then
 							return true
 						end
-					end;
+					end);
 				}, nil, nil, true);
 
-				CheckAdmin = service.MetaFunc(Admin.CheckAdmin);
+				CheckAdmin = MetaFunc(Admin.CheckAdmin);
 
-				IsAdmin = service.MetaFunc(Admin.CheckAdmin);
+				IsAdmin = MetaFunc(Admin.CheckAdmin);
 
-				IsBanned = service.MetaFunc(Admin.CheckBan);
+				IsBanned = MetaFunc(Admin.CheckBan);
 
-				IsMuted = service.MetaFunc(Admin.IsMuted);
+				IsMuted = MetaFunc(Admin.IsMuted);
 
-				CheckDonor = service.MetaFunc(Admin.CheckDonor);
+				CheckDonor = MetaFunc(Admin.CheckDonor);
 
-				GetLevel = service.MetaFunc(Admin.GetLevel);
+				GetLevel = MetaFunc(Admin.GetLevel);
 
-				SetLighting = service.MetaFunc(Functions.SetLighting);
+				SetLighting = MetaFunc(Functions.SetLighting);
 
-				SetPlayerLighting = service.MetaFunc(Remote.SetLighting);
+				SetPlayerLighting = MetaFunc(Remote.SetLighting);
 
-				NewParticle = service.MetaFunc(Functions.NewParticle);
+				NewParticle = MetaFunc(Functions.NewParticle);
 
-				RemoveParticle = service.MetaFunc(Functions.RemoveParticle);
+				RemoveParticle = MetaFunc(Functions.RemoveParticle);
 
-				NewLocal = service.MetaFunc(Remote.NewLocal);
+				NewLocal = MetaFunc(Remote.NewLocal);
 
-				MakeLocal = service.MetaFunc(Remote.MakeLocal);
+				MakeLocal = MetaFunc(Remote.MakeLocal);
 
-				MoveLocal = service.MetaFunc(Remote.MoveLocal);
+				MoveLocal = MetaFunc(Remote.MoveLocal);
 
-				RemoveLocal = service.MetaFunc(Remote.RemoveLocal);
+				RemoveLocal = MetaFunc(Remote.RemoveLocal);
 
-				Hint = service.MetaFunc(Functions.Hint);
+				Hint = MetaFunc(Functions.Hint);
 
-				Message = service.MetaFunc(Functions.Message);
+				Message = MetaFunc(Functions.Message);
 
-				RunCommandAsNonAdmin = service.MetaFunc(server.Admin.RunCommandAsNonAdmin);
+				RunCommandAsNonAdmin = MetaFunc(Admin.RunCommandAsNonAdmin);
 			}
 
 			local AdonisGTable = service.NewProxy({
@@ -1305,7 +1306,7 @@ return function(Vargs)
 			end
 
 
-			Logs.AddLog(Logs.Script,{
+			AddLog(Logs.Script,{
 				Text = "Started _G API";
 				Desc = "_G API was initialized and is ready to use";
 			})

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -208,7 +208,9 @@ return function(Vargs)
 		UpdateConnections = function()
 			if service.NetworkServer then
 				for i,cli in ipairs(service.NetworkServer:GetChildren()) do
-					Core.Connections[cli] = cli:GetPlayer()
+					if cli:IsA("NetworkReplicator") then
+						Core.Connections[cli] = cli:GetPlayer()
+					end
 				end
 			end
 		end;
@@ -216,7 +218,7 @@ return function(Vargs)
 		UpdateConnection = function(p)
 			if service.NetworkServer then
 				for i,cli in ipairs(service.NetworkServer:GetChildren()) do
-					if cli:GetPlayer() == p then
+					if cli:IsA("NetworkReplicator") and cli:GetPlayer() == p then
 						Core.Connections[cli] = p
 					end
 				end
@@ -225,9 +227,9 @@ return function(Vargs)
 
 		GetNetworkClient = function(p)
 			if service.NetworkServer then
-				for i,v in ipairs(service.NetworkServer:GetChildren()) do
-					if v:GetPlayer() == p then
-						return v
+				for i,cli in ipairs(service.NetworkServer:GetChildren()) do
+					if cli:IsA("NetworkReplicator") and cli:GetPlayer() == p then
+						return cli
 					end
 				end
 			end

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1061,7 +1061,7 @@ return function(Vargs)
 
 		CleanWorkspace = function()
 			for _, v in ipairs(workspace:GetChildren()) do
-				if v.ClassName == "Tool" or v.ClassName == "HopperBin" or v:IsA("Accessory") or v:IsA("Hat") then
+				if v.ClassName == "Tool" or v.ClassName == "HopperBin" or v:IsA("Accessory") or v:IsA("Accoutrement") or v.ClassName == "Hat" then
 					v:Destroy()
 				end
 			end
@@ -1083,7 +1083,7 @@ return function(Vargs)
 			local AllGrabbedPlayers = {}
 			for i,v in pairs(service.NetworkServer:GetChildren()) do
 				pcall(function()
-					if v:IsA("ServerReplicator") then
+					if v:IsA("NetworkReplicator") then
 						if string.sub(string.lower(v:GetPlayer().Name),1,#name)==string.lower(name) or name=='all' then
 							table.insert(AllGrabbedPlayers, (v:GetPlayer() or "NoPlayer"))
 						end

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -360,8 +360,8 @@ return function(Vargs)
 				if not plr or Admin.CheckAdmin(plr) then
 					local tab, nilplayers, nonnumber, adminnumber = {}, 0, 0, 0
 
-					for i,v in pairs(service.NetworkServer:GetChildren()) do
-						if v and v:GetPlayer() and not service.Players:FindFirstChild(v:GetPlayer().Name) then
+					for i,cli in pairs(service.NetworkServer:GetChildren()) do
+						if cli:IsA("NetworkReplicator") and cli and cli:GetPlayer() and not service.Players:FindFirstChild(cli:GetPlayer().Name) then
 							nilplayers+=1
 						end
 					end

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -149,7 +149,7 @@ return function(Vargs)
 									keys.LoadingStatus = "LOADING"
 									keys.RemoteReady = true
 
-									Logs:AddLog("Script", string.format("%s requested client keys", p.Name))
+									AddLog("Script", string.format("%s requested client keys", p.Name))
 								else
 									--Anti.Detected(p, "kick","Communication Key Error (r10003)")
 								end
@@ -542,7 +542,7 @@ return function(Vargs)
 		]==]
 
 		PlayerAdded = function(p)
-			Logs:AddLog("Script", "Doing PlayerAdded Event for ".. p.Name)
+			AddLog("Script", "Doing PlayerAdded Event for ".. p.Name)
 
 			local key = tostring(p.UserId)
 			local keyData = {
@@ -609,7 +609,7 @@ return function(Vargs)
 			end)
 
 			if not ran then
-				Logs:AddLog("Errors", p.Name .." PlayerAdded Failed: ".. tostring(err))
+				AddLog("Errors", p.Name .." PlayerAdded Failed: ".. tostring(err))
 				warn("~! :: Adonis :: SOMETHING FAILED DURING PLAYERADDED:");
 				warn(tostring(err))
 			end
@@ -678,7 +678,7 @@ return function(Vargs)
 				end
 			end)
 
-			Logs.AddLog("Script", {
+			AddLog("Script", {
 				Text = string.format("Triggerd PlayerRemoving for %s", p.Name);
 				Desc = "Player left the game (PlayerRemoving)";
 				Player = p;

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -12,7 +12,7 @@ return function(Vargs)
 	local service = Vargs.Service;
 
 	local Commands, Decrypt, Encrypt, UnEncrypted, AddLog, TrackTask
-	local Functions, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Settings
+	local Functions, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Settings, Defaults
 	local function Init()
 		Functions = server.Functions;
 		Admin = server.Admin;
@@ -24,6 +24,7 @@ return function(Vargs)
 		Process = server.Process;
 		Variables = server.Variables;
 		Settings = server.Settings;
+		Defaults = server.Defaults
 
 		Commands = Remote.Commands
 		Decrypt = Remote.Decrypt
@@ -62,18 +63,18 @@ return function(Vargs)
 				Core.LoadExistingPlayer(p);
 			end
 		end
-		
+
 		service.TrackTask("Thread: ChatCharacterLimit", function()
 			local ChatModules = service.Chat:WaitForChild("ClientChatModules",5)
 			if ChatModules then
 				local ChatSettings = ChatModules:WaitForChild("ChatSettings",5)
-				if ChatSettings then 
+				if ChatSettings then
 					local success, ChatSettingsModule = pcall(function()
 						return require(ChatSettings)
 					end)
-					if success then 
+					if success then
 						local NewChatLimit = ChatSettingsModule.MaximumMessageLength
-						if NewChatLimit and type(NewChatLimit) == 'number' then 
+						if NewChatLimit and type(NewChatLimit) == 'number' then
 							Process.MaxChatCharacterLimit = NewChatLimit
 							AddLog("Script", "Chat Character Limit automatically set to " .. NewChatLimit);
 						end
@@ -591,8 +592,9 @@ return function(Vargs)
 				if Variables.Whitelist.Enabled then
 					local listed = false
 
-					for listName, list in next,Variables.Whitelist.Lists do
-						if Admin.CheckTable(p, list) then
+					local CheckTable = Admin.CheckTable
+					for listName, list in pairs(Variables.Whitelist.Lists) do
+						if CheckTable(p, list) then
 							listed = true
 							break;
 						end
@@ -698,6 +700,15 @@ return function(Vargs)
 				Desc = "Client finished loading";
 			})
 
+			--// Run OnJoin commands
+			for i,v in pairs(Settings.OnJoin) do
+				TrackTask("Thread: OnJoin_Cmd: ".. tostring(v), Admin.RunCommandAsPlayer, v, p)
+				AddLog("Script", {
+					Text = "OnJoin: Executed "..tostring(v);
+					Desc = "Executed OnJoin command; "..tostring(v)
+				})
+			end
+
 			--// Start keybind listener
 			Remote.Send(p, "Function", "KeyBindListener", PlayerData.Keybinds or {})
 
@@ -771,7 +782,7 @@ return function(Vargs)
 
 						wait(1)
 
-						if level > 300 and Settings.DataStoreKey == server.Defaults.Settings.DataStoreKey then
+						if level > 300 and Settings.DataStoreKey == Defaults.Settings.DataStoreKey then
 							Remote.MakeGui(p,"Notification",{
 								Title = "Warning!";
 								Message = "Using default datastore key!";
@@ -797,15 +808,6 @@ return function(Vargs)
 					if newVer then
 						Core.SetData("VersionNumber",newVer)
 					end
-				end
-
-				--// Run OnJoin commands
-				for i,v in next,Settings.OnJoin do
-					AddLog("Script", {
-						Text = "OnJoin: Executed "..tostring(v);
-						Desc = "Executed OnJoin command; "..tostring(v)
-					})
-					Admin.RunCommandAsPlayer(v, p)
 				end
 
 				--// REF_1_ALBRT - 57s_Dxl - 100392_659;
@@ -841,30 +843,31 @@ return function(Vargs)
 				Remote.Get(p,"UIKeepAlive");
 
 				--//GUI loading
+				local MakeGui = Remote.MakeGui
 				if Variables.NotifMessage then
-					Remote.MakeGui(p,"Notif",{
+					MakeGui(p,"Notif",{
 						Message = Variables.NotifMessage
 					})
 				end
 
 				if Settings.Console and (not Settings.Console_AdminsOnly or (Settings.Console_AdminsOnly and level > 0)) then
-					Remote.MakeGui(p,"Console")
+					MakeGui(p,"Console")
 				end
 
 				if Settings.HelpButton then
-					Remote.MakeGui(p,"HelpButton")
+					MakeGui(p,"HelpButton")
 				end
 
 				if Settings.TopBarShift then
-					Remote.MakeGui(p, "TopBar")
+					MakeGui(p, "TopBar")
 				end
 
 				if Settings.CustomChat then
-					Remote.MakeGui(p,"Chat")
+					MakeGui(p,"Chat")
 				end
 
 				if Settings.PlayerList then
-					Remote.MakeGui(p,"PlayerList")
+					MakeGui(p,"PlayerList")
 				end
 
 				if level < 1 then
@@ -884,18 +887,18 @@ return function(Vargs)
 					end
 				end--]=]
 
-				Functions.Donor(p)
+				spawn(Functions.Donor, p)
 
 				--// Fire added event
 				service.Events.CharacterAdded:Fire(p, Character, ...)
 
 				--// Run OnSpawn commands
-				for i,v in next,Settings.OnSpawn do
+				for i,v in pairs(Settings.OnSpawn) do
+					TrackTask("Thread: OnSpawn_Cmd: ".. tostring(v), Admin.RunCommandAsPlayer, v, p)
 					AddLog("Script", {
 						Text = "OnSpawn: Executed "..tostring(v);
 						Desc = "Executed OnSpawn command; "..tostring(v)
 					})
-					Admin.RunCommandAsPlayer(v,p)
 				end
 			end
 		end;

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -736,7 +736,7 @@ return function(errorHandler, eventChecker, fenceSpecific)
 		end;
 
 		EscapeSpecialCharacters = function(x)
-			return x:gsub("([^%w])", "%%%1")
+			return string.gsub(x, "([^%w])", "%%%1")
 		end;
 
 		MetaFunc = function(func)
@@ -766,7 +766,7 @@ return function(errorHandler, eventChecker, fenceSpecific)
 			if ran then
 				return "Unknown"
 			else
-				return err:match("%S+$")
+				return string.match(err, "%S+$")
 			end
 		end;
 

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -36,7 +36,9 @@ local methods = setmetatable({},{
 })
 
 
-return function(errorHandler, eventChecker, fenceSpecific)
+return function(errorHandler, eventChecker, fenceSpecific, env)
+	if env then setfenv(1, env) end
+
 	local _G, game, script, getfenv, setfenv, workspace,
 	getmetatable, setmetatable, loadstring, coroutine,
 	rawequal, typeof, print, math, warn, error,  pcall,

--- a/WebPanel.lua
+++ b/WebPanel.lua
@@ -109,7 +109,7 @@ return function(Vargs)
 
 		local admins = {}
 		for _, v in pairs(service.NetworkServer:GetChildren()) do
-			if v and v:GetPlayer() and Admin.CheckAdmin(v:GetPlayer(), false) then
+			if v:IsA("NetworkReplicator") and v:GetPlayer() and Admin.CheckAdmin(v:GetPlayer(), false) then
 				table.insert(admins, v:GetPlayer().Name)
 			end
 		end


### PR DESCRIPTION
`Admin`:
switched some string metamethods
Cached to some tables that could possibly get huge (depends if on settings and datastores)

`Commands`:
Switched to getEnv instead of giving the commands env.

`Core`:
`GetDataStore` will now check if you can actually use DataStores in studio first before setting to prevent a big warn pileup if they are disabled.
Switch of `next` to `pairs`
More caching to datastores (datastore entries can get really big in size overtime so having it be pretty fast is essential)

`Process`:
`OnSpawn` and `OnJoin` will run synchronous to prevent yields to the function.

`Service`:
Changing of string metamethods.