### PR TITLE
Command fixes, server change

### DIFF
--- a/MainModule/Client/Client.lua
+++ b/MainModule/Client/Client.lua
@@ -66,9 +66,12 @@ local dumplog = function() warn(":: Adonis :: Dumping client log...") for i,v in
 local log = function(...) table.insert(clientLog, table.concat({...}, " ")) end;
 
 --// Dump log on disconnect
+local isStudio = game:GetService("RunService"):IsStudio()
 game:GetService("NetworkClient").ChildRemoved:Connect(function(p)
-	warn("~! PLAYER DISCONNECTED/KICKED! DUMPING ADONIS CLIENT LOG!");
-	dumplog();
+	if not isStudio then
+		warn("~! PLAYER DISCONNECTED/KICKED! DUMPING ADONIS CLIENT LOG!");
+		dumplog();
+	end
 end)
 
 local unique = {}

--- a/MainModule/Client/Core/Core.lua
+++ b/MainModule/Client/Core/Core.lua
@@ -311,16 +311,10 @@ return function()
 							return data.Source, module
 						end
 					end);
-
-					ReportLBI = MetaFunc(function(scr, origin)
-						if origin == "Local" then
-							return true
-						end
-					end);
 				}, nil, nil, true);
 			}
 
-			AdonisGTable = NewProxy{
+			local AdonisGTable = NewProxy{
 				__index = function(tab,ind)
 					if ind == "Scripts" then
 						return API.Scripts
@@ -334,7 +328,7 @@ return function()
 						error("_G API is disabled")
 					end
 				end;
-				__newindex = function(tabl,ind,new)
+				__newindex = function()
 					error("Read-only")
 				end;
 				__metatable = "API";

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -8,6 +8,8 @@ return function(Vargs, env)
 
 	if env then setfenv(1, env) end
 
+	local Routine = env.Routine
+
 	return {
 		--[[
 		--// Unfortunately not viable

--- a/MainModule/Server/Commands/Donors.lua
+++ b/MainModule/Server/Commands/Donors.lua
@@ -52,7 +52,7 @@ return function(Vargs, env)
 					local AssetIdType = service.MarketPlace:GetProductInfo(ClothingId).AssetTypeId
 					local tShirt = ((AssetIdType == 11 or AssetIdType == 2) and service.Insert(ClothingId)) or (AssetIdType == 1 and Functions.CreateClothingFromImageId("ShirtGraphic", ClothingId)) or error("Item ID passed has invalid item type")
 
-					assert(Sthirt, "Could not retrieve shirt asset for the supplied ID")
+					assert(tShirt, "Could not retrieve shirt asset for the supplied ID")
 
 					for _, v in pairs(plr.Character:GetChildren()) do
 						if v:IsA("ShirtGraphic") then v:Destroy() end

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -8,6 +8,10 @@ return function(Vargs, env)
 
 	if env then setfenv(1, env) end
 
+	local Routine = env.Routine
+	local Pcall = env.Pcall
+	local cPcall = env.cPcall
+
 	return {
 		Glitch = {
 			Prefix = Settings.Prefix;
@@ -1766,7 +1770,7 @@ return function(Vargs, env)
 
 				Variables.WildFire = partsHit
 
-				function fire(part)
+				local function fire(part)
 					if finished or not partsHit or not objs then
 						objs = nil
 						partsHit = nil
@@ -3699,34 +3703,34 @@ return function(Vargs, env)
 							end
 						end
 					elseif human and human.RigType == Enum.HumanoidRigType.R6 then
+						local CFrame_new = CFrame.new
+
 						local Motors = {}
 						local Percent = num
 
 						table.insert(Motors, char.HumanoidRootPart.RootJoint)
-						for i, motor in pairs(char.Torso:GetChildren()) do
-							if Motor:IsA("Motor6D") == false then continue end
-							table.insert(Motors, Motor)
+						for _, motor in ipairs(char.Torso:GetChildren()) do
+							if motor:IsA("Motor6D") then table.insert(Motors, motor) end
 						end
-						for i, v in pairs(Motors) do
-							v.C0 = CFrame.new((v.C0.Position * Percent)) * (v.C0 - v.C0.Position)
-							v.C1 = CFrame.new((v.C1.Position * Percent)) * (v.C1 - v.C1.Position)
-						end
-
-
-						for i, part in pairs(char:GetChildren()) do
-							if Part:IsA("BasePart") == false then continue end
-							Part.Size = Part.Size * Percent
+						for _, Motor in pairs(Motors) do
+							Motor.C0 = CFrame_new((Motor.C0.Position * Percent)) * (Motor.C0 - Motor.C0.Position)
+							Motor.C1 = CFrame_new((Motor.C1.Position * Percent)) * (Motor.C1 - Motor.C1.Position)
 						end
 
 
-						for i, Accessory in pairs(char:GetChildren()) do
-							if Accessory:IsA("Accessory") == false then continue end
+						for _, part in ipairs(char:GetChildren()) do
+							if part:IsA("BasePart") then part.Size *= Percent end
+						end
 
-							Accessory.Handle.AccessoryWeld.C0 = CFrame.new((Accessory.Handle.AccessoryWeld.C0.Position * Percent)) * (Accessory.Handle.AccessoryWeld.C0 - Accessory.Handle.AccessoryWeld.C0.Position)
-							Accessory.Handle.AccessoryWeld.C1 = CFrame.new((Accessory.Handle.AccessoryWeld.C1.Position * Percent)) * (Accessory.Handle.AccessoryWeld.C1 - Accessory.Handle.AccessoryWeld.C1.Position)
-
-							if Accessory.Handle:FindFirstChildOfClass("SpecialMesh") then
-								Accessory.Handle:FindFirstChildOfClass("SpecialMesh").Scale *= Percent
+						for _, Accessory in pairs(char:GetChildren()) do
+							local Handle = Accessory:IsA("Accessory") and v:FindFirstChild("Handle")
+							if Handle then
+								Handle.AccessoryWeld.C0 = CFrame_new((Accessory.Handle.AccessoryWeld.C0.Position * Percent)) * (Accessory.Handle.AccessoryWeld.C0 - Accessory.Handle.AccessoryWeld.C0.Position)
+								Handle.AccessoryWeld.C1 = CFrame_new((Accessory.Handle.AccessoryWeld.C1.Position * Percent)) * (Accessory.Handle.AccessoryWeld.C1 - Accessory.Handle.AccessoryWeld.C1.Position)
+	
+								if Handle:FindFirstChildOfClass("SpecialMesh") then
+									Handle:FindFirstChildOfClass("SpecialMesh").Scale *= Percent
+								end
 							end
 						end
 					end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -4551,7 +4551,7 @@ return function(Vargs, env)
 		RemoveShirt = {
 			Prefix = Settings.Prefix;
 			Commands = {"removeshirt", "noshirt"};
-			Args = {"player", "ID"};
+			Args = {"player"};
 			Hidden = false;
 			Description = "Give the target player(s) the shirt that belongs to <ID>";
 			Fun = false;

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -8,6 +8,10 @@ return function(Vargs, env)
 
 	if env then setfenv(1, env) end
 
+	local Routine = env.Routine
+	local Pcall = env.Pcall
+	local cPcall = env.cPcall
+
 	return {
 		AudioPlayer = {
 			Prefix = Settings.Prefix;
@@ -1051,7 +1055,7 @@ return function(Vargs, env)
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, p in ipairs(service.GetPlayers(plr, args[1])) do
 					Remote.RemoveLocal(p, "WINDOW_COLORCORRECTION", "Camera")
 				end
 			end
@@ -1219,38 +1223,26 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local plrs = {}
-				local playz = Functions.GrabNilPlayers("all")
 				local update = (args[1] ~= "false")
 
 				Functions.Hint("Pinging players. Please wait. No ping = Ping > 5sec.", {plr})
-
-				for i, v in pairs(playz) do
+				for i, v in ipairs(Functions.GrabNilPlayers("all")) do
 					if type(v) == "string" and v == "NoPlayer" then
 						table.insert(plrs, {Text="PLAYERLESS CLIENT", Desc="PLAYERLESS SERVERREPLICATOR. COULD BE LOADING/LAG/EXPLOITER. CHECK AGAIN IN A MINUTE!"})
 					else
 						local ping = "..."
 
 						if v and service.Players:FindFirstChild(v.Name) then
-							local h = ""
-							local mh = ""
-							local ws = ""
-							local jp = ""
-							local hn = ""
 							local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
-
-							if v.Character and hum then
-								h = hum.Health
-								mh = hum.MaxHealth
-								ws = hum.WalkSpeed
-								jp = hum.JumpPower
-								hn = hum.Name
-							else
-								h = "NO CHARACTER/HUMANOID"
-							end
-
-							table.insert(plrs, {Text = "["..ping.."] "..v.Name.. " (".. v.DisplayName ..")", Desc = "Lower: "..string.lower(v.Name).." - Health: "..h..((not hum and "") or " - MaxHealth: "..mh.." - WalkSpeed: "..ws.." - JumpPower: "..jp.." - Humanoid Name: "..hum.Name)})
+							table.insert(plrs, {
+								Text = string.format("[%s] %s (@%s)", ping, v.Name, v.DisplayName);
+								Desc = string.format("Lower: %s - Health: %d - MaxHealth: %d - WalkSpeed: %d JumpPower: %d Humanoid Name: %s", v.Name, hum and hum.Health or 0, hum and hum.MaxHealth or 0, hum and hum.WalkSpeed or 0, hum and hum.JumpPower or 0, hum and hum.Name or "?");
+							})
 						else
-							table.insert(plrs, {Text = "[LOADING] "..v.Name, Desc = "Lower: "..string.lower(v.Name).." - Ping: "..ping})
+							table.insert(plrs, {
+								Text = "[LOADING] "..v.Name,
+								Desc = "Lower: "..string.lower(v.Name).." - Ping: "..ping
+							})
 						end
 					end
 				end
@@ -4489,8 +4481,8 @@ return function(Vargs, env)
 							humandescrip.GraphicTShirt = ClothingId
 						end
 
-						if Shirt:IsA("Model") then
-							Shirt = thirt:FindFirstChildOfClass("ShirtGraphic")
+						if Shirt and Shirt.ClassName == "Model" then
+							Shirt = Shirt:FindFirstChildOfClass("ShirtGraphic") or Shirt
 						end
 
 						Shirt:Clone().Parent = v.Character

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -4517,7 +4517,7 @@ return function(Vargs, env)
 
 		Shirt = {
 			Prefix = Settings.Prefix;
-			Commands = {"removetshirt", "giveshirt"};
+			Commands = {"shirt", "giveshirt"};
 			Args = {"player", "ID"};
 			Hidden = false;
 			Description = "Give the target player(s) the shirt that belongs to <ID>";
@@ -4530,9 +4530,12 @@ return function(Vargs, env)
 				assert(Shirt, "Unexpected error occured; clothing is missing")
 				for i, v in pairs(service.GetPlayers(plr, args[1])) do
 					if v.Character then
-						for g, k in pairs(v.Character:GetChildren()) do
-							if k:IsA("Shirt") then k:Destroy() end
+						for _, shirt in pairs(v.Character:GetChildren()) do
+							if shirt.ClassName == "Shirt" then
+								shirt:Destroy()
+							end
 						end
+
 						local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
 						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
 
@@ -4540,6 +4543,27 @@ return function(Vargs, env)
 							humandescrip.Shirt = ClothingId
 						end
 						Shirt:Clone().Parent = v.Character
+					end
+				end
+			end
+		};
+
+		RemoveShirt = {
+			Prefix = Settings.Prefix;
+			Commands = {"removeshirt", "noshirt"};
+			Args = {"player", "ID"};
+			Hidden = false;
+			Description = "Give the target player(s) the shirt that belongs to <ID>";
+			Fun = false;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						for _, shirt in pairs(v.Character:GetChildren()) do
+							if shirt.ClassName == "Shirt" then
+								shirt:Destroy()
+							end
+						end
 					end
 				end
 			end
@@ -5528,9 +5552,9 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				for i, v in pairs(service.GetPlayers(plr, args[1])) do
 					task.defer(function()
-						service.StartLoop(UserId .. "LOOPHEAL", 0.1, function()
+						service.StartLoop(v.UserId .. "LOOPHEAL", 0.1, function()
 							if not v or v.Parent ~= service.Players then
-								service.StopLoop(UserId .. "LOOPHEAL")
+								service.StopLoop(v.UserId .. "LOOPHEAL")
 							end
 
 							local Character = v.Character

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -7,7 +7,10 @@ origEnv = nil
 logError = nil
 
 --// Admin
-return function(Vargs)
+return function(Vargs, envVars, GetEnv)
+	local env = GetEnv(getfenv(), envVars)
+	setfenv(1, env)
+
 	local server = Vargs.Server;
 	local service = Vargs.Service;
 

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -7,7 +7,10 @@ origEnv = nil
 logError = nil
 
 --// Anti-Exploit
-return function(Vargs)
+return function(Vargs, envVars, GetEnv)
+	local env = GetEnv(getfenv(), envVars)
+	setfenv(1, env)
+
 	local server = Vargs.Server;
 	local service = Vargs.Service;
 
@@ -35,20 +38,19 @@ return function(Vargs)
 		Anti.RunAfterPlugins = nil;
 		Logs:AddLog("Script", "Anti Module RunAfterPlugins Finished");
 
-		function onPlayerAdded(player)
+		local function onPlayerAdded(player)
 			if not player.Character then
 				player.CharacterAdded:Wait()
 			end
 
 			if Admin.GetLevel(player) < 1 then --// Changed from Settings.Moderators.Level to just <1.... I figure we should just ignore anyone who's in any rank above normal player ~ Scel
-				Anti.CharacterCheck(player)
+				pcall(Anti.CharacterCheck, player)
 			end
 		end
 
 		for _, v in ipairs(service.Players:GetPlayers()) do
-			coroutine.wrap(pcall)(onPlayerAdded, v)
+			task.spawn(onPlayerAdded, v)
 		end
-
 		service.Players.PlayerAdded:Connect(onPlayerAdded)
 	end
 
@@ -309,7 +311,7 @@ return function(Vargs)
 
 						if humanoid then
 							humanoid:ChangeState(Enum.HumanoidStateType.Dead)
-							Humanoid.Health = 0
+							humanoid.Health = 0
 						end
 						player.Character:BreakJoints()
 					elseif string.lower(action) == "crash" then

--- a/MainModule/Server/Core/Commands.lua
+++ b/MainModule/Server/Core/Commands.lua
@@ -8,9 +8,13 @@ logError = nil
 
 --// Commands
 --// Highly recommended you disable Intellesense before editing this...
-return function(Vargs)
+return function(Vargs, envVars, GetEnv)
+	local env = GetEnv(getfenv(), envVars)
+	setfenv(1, env)
+
 	local server = Vargs.Server;
 	local service = Vargs.Service;
+
 	local Settings = server.Settings
 	local Functions, Commands, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Deps
 

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -18,7 +18,10 @@ function disableAllGUIs(folder)
 end;
 
 --// Core
-return function(Vargs)
+return function(Vargs, envVars, GetEnv)
+	local env = GetEnv(getfenv(), envVars)
+	setfenv(1, env)
+
 	local server = Vargs.Server;
 	local service = Vargs.Service;
 
@@ -884,7 +887,7 @@ return function(Vargs)
 		end;
 
 		ClearAllData = function()
-			local tabs = Core.GetData("SavedTables");
+			local tabs = Core.GetData("SavedTables") or {};
 
 			for i,v in pairs(tabs) do
 				if v.TableKey then
@@ -1099,7 +1102,7 @@ return function(Vargs)
 
 					if SavedTables then
 						for i,tData in pairs(SavedTables) do
-							if tData.TableName and tData.TableKey and not Blacklist[tData.TableName] then
+							if tData.TableName and tData.TableKey and not Blacklist[tData.tableName] then
 								local data = GetData(tData.TableKey);
 								if data then
 									for k,v in ipairs(data) do
@@ -1266,12 +1269,6 @@ return function(Vargs)
 							return data.Source, module
 						end
 					end);
-
-					ReportLBI = MetaFunc(function(scr, origin)
-						if origin == "Server" then
-							return true
-						end
-					end);
 				}, nil, nil, true);
 
 				CheckAdmin = MetaFunc(Admin.CheckAdmin);
@@ -1319,7 +1316,7 @@ return function(Vargs)
 						error("_G API is disabled")
 					end
 				end;
-				__newindex = function(tabl,ind,new)
+				__newindex = function()
 					error("Read-only")
 				end;
 				__metatable = true;

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1228,7 +1228,7 @@ return function(Vargs, envVars, GetEnv)
 			end
 			plr.Character = newCharacterModel
 
-			newCharacterModel:SetPivot(oldCFrame)
+			newCharacterModel:PivotTo(oldCFrame)
 			newCharacterModel.Parent = workspace
 
 			-- hacky way to fix other people being unable to see animations.

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -7,6 +7,7 @@ return function(Vargs, envVars, GetEnv)
 	local env = GetEnv(getfenv(), envVars)
 	setfenv(1, env)
 
+	local logError
 	local Functions, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Settings
 	local function Init()
 		Functions = server.Functions;
@@ -19,6 +20,7 @@ return function(Vargs, envVars, GetEnv)
 		Process = server.Process;
 		Variables = server.Variables;
 		Settings = server.Settings;
+		logError = server.logError;
 
 		Functions.Init = nil;
 		Logs:AddLog("Script", "Functions Module Initialized")

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -3,9 +3,9 @@ service = nil
 cPcall = nil
 
 --// Function stuff
-return function(Vargs)
-	local server = Vargs.Server;
-	local service = Vargs.Service;
+return function(Vargs, envVars, GetEnv)
+	local env = GetEnv(getfenv(), envVars)
+	setfenv(1, env)
 
 	local Functions, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Settings
 	local function Init()
@@ -256,7 +256,7 @@ return function(Vargs)
 									userId = tonumber(matched);
 								})
 
-								insert(players, fakePlayer)
+								table.insert(players, fakePlayer)
 								plus()
 							end
 						end
@@ -814,7 +814,7 @@ return function(Vargs)
 					Title = title;
 					Message = message;
 					Time = tim;
-					Icon = "rbxassetid://"..icon or "rbxassetid://7510999669" -- use default 'i' icon if icon argument is missing
+					Icon = string.format("rbxassetid://%d", icon or "7510999669") -- use default 'i' icon if icon argument is missing
 				})
 			end
 		end;
@@ -1206,12 +1206,12 @@ return function(Vargs)
 			end
 		end;
 
-		ConvertPlayerCharacterToRig = function(plr, rigType)
+		ConvertPlayerCharacterToRig = function(plr: Player, rigType: EnumItem)
 			rigType = rigType or Enum.HumanoidRigType.R15
 
 			local Humanoid = plr.Character and plr.Character:FindFirstChildOfClass("Humanoid")
 
-			local HumanoidDescription = Humanoid:GetAppliedDescription() or service.Players:GetHumanoidDescriptionFromUserId(userId)
+			local HumanoidDescription = Humanoid:GetAppliedDescription() or service.Players:GetHumanoidDescriptionFromUserId(plr.UserId)
 			local newCharacterModel = service.Players:CreateHumanoidModelFromDescription(HumanoidDescription, rigType)
 			local Animate = newCharacterModel.Animate
 

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1209,16 +1209,16 @@ return function(Vargs, envVars, GetEnv)
 		ConvertPlayerCharacterToRig = function(plr: Player, rigType: EnumItem)
 			rigType = rigType or Enum.HumanoidRigType.R15
 
-			local Humanoid = plr.Character and plr.Character:FindFirstChildOfClass("Humanoid")
+			local Humanoid: Humanoid = plr.Character and plr.Character:FindFirstChildOfClass("Humanoid")
 
 			local HumanoidDescription = Humanoid:GetAppliedDescription() or service.Players:GetHumanoidDescriptionFromUserId(plr.UserId)
-			local newCharacterModel = service.Players:CreateHumanoidModelFromDescription(HumanoidDescription, rigType)
-			local Animate = newCharacterModel.Animate
+			local newCharacterModel: Model = service.Players:CreateHumanoidModelFromDescription(HumanoidDescription, rigType)
+			local Animate: BaseScript = newCharacterModel.Animate
 
 			newCharacterModel.Humanoid.DisplayName = Humanoid.DisplayName
 			newCharacterModel.Name = plr.Name
 
-			local oldcframe = plr.Character and plr.Character.PrimaryPart and plr.Character.PrimaryPart.CFrame
+			local oldCFrame = plr.Character and plr.Character:GetPivot() or CFrame.new()
 
 			if plr.Character then
 				plr.Character:Destroy()
@@ -1226,9 +1226,7 @@ return function(Vargs, envVars, GetEnv)
 			end
 			plr.Character = newCharacterModel
 
-			if oldcframe then
-				newCharacterModel:SetPrimaryPartCFrame(oldcframe)
-			end
+			newCharacterModel:SetPivot(oldCFrame)
 			newCharacterModel.Parent = workspace
 
 			-- hacky way to fix other people being unable to see animations.

--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -7,7 +7,10 @@ origEnv = nil
 logError = nil
 
 --// HTTP
-return function(Vargs)
+return function(Vargs, envVars, GetEnv)
+	local env = GetEnv(getfenv(), envVars)
+	setfenv(1, env)
+
 	local server = Vargs.Server;
 	local service = Vargs.Service;
 

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -7,7 +7,10 @@ origEnv = nil
 logError = nil
 
 --// Special Variables
-return function(Vargs)
+return function(Vargs, envVars, GetEnv)
+	local env = GetEnv(getfenv(), envVars)
+	setfenv(1, env)
+
 	local server = Vargs.Server;
 	local service = Vargs.Service;
 
@@ -292,26 +295,16 @@ return function(Vargs)
 								end
 
 								if v and service.Players:FindFirstChild(v.Name) then
-									local h = ""
-									local mh = ""
-									local ws = ""
-									local jp = ""
-									local hn = ""
 									local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
-
-									if v.Character and hum then
-										h = hum.Health
-										mh = hum.MaxHealth
-										ws = hum.WalkSpeed
-										jp = hum.JumpPower
-										hn = hum.Name
-									else
-										h = "NO CHARACTER/HUMANOID"
-									end
-
-									table.insert(plrs,{Text = "["..ping.."] "..v.Name.. " (".. v.DisplayName ..")", Desc = 'Lower: '..v.Name:lower()..' - Health: '..h..((not hum and "") or " - MaxHealth: "..mh.." - WalkSpeed: "..ws.." - JumpPower: "..jp.." - Humanoid Name: "..hum.Name)})
+									table.insert(plrs, {
+										Text = string.format("[%s] %s (@%s)", ping, v.Name, v.DisplayName);
+										Desc = string.format("Lower: %s - Health: %d - MaxHealth: %d - WalkSpeed: %d JumpPower: %d Humanoid Name: %s", v.Name, hum and hum.Health or 0, hum and hum.MaxHealth or 0, hum and hum.WalkSpeed or 0, hum and hum.JumpPower or 0, hum and hum.Name or "?");
+									})
 								else
-									table.insert(plrs,{Text = '[LOADING] '..v.Name, Desc = 'Lower: '..v.Name:lower()..' - Ping: '..ping})
+									table.insert(plrs, {
+										Text = "[LOADING] "..v.Name,
+										Desc = "Lower: "..string.lower(v.Name).." - Ping: "..ping
+									})
 								end
 							end
 						end)

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -14,7 +14,7 @@ return function(Vargs, envVars, GetEnv)
 	local server = Vargs.Server;
 	local service = Vargs.Service;
 
-	local Commands, Decrypt, Encrypt, UnEncrypted, AddLog, TrackTask
+	local Commands, Decrypt, Encrypt, UnEncrypted, AddLog, TrackTask, Pcall
 	local Functions, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Settings, Defaults
 	local function Init()
 		Functions = server.Functions;
@@ -35,6 +35,7 @@ return function(Vargs, envVars, GetEnv)
 		UnEncrypted = Remote.UnEncrypted
 		AddLog = Logs.AddLog
 		TrackTask = service.TrackTask
+		Pcall = server.Pcall
 
 		--// NetworkServer Events
 		if service.NetworkServer then

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -7,7 +7,10 @@ origEnv = nil
 logError = nil
 
 --// Processing
-return function(Vargs)
+return function(Vargs, envVars, GetEnv)
+	local env = GetEnv(getfenv(), envVars)
+	setfenv(1, env)
+
 	local server = Vargs.Server;
 	local service = Vargs.Service;
 

--- a/MainModule/Server/Core/Remote.lua
+++ b/MainModule/Server/Core/Remote.lua
@@ -7,11 +7,14 @@ origEnv = nil
 logError = nil
 
 --// Remote
-return function(Vargs)
+return function(Vargs, envVars, GetEnv)
+	local env = GetEnv(getfenv(), envVars)
+	setfenv(1, env)
+
 	local server = Vargs.Server;
 	local service = Vargs.Service;
 
-	local Functions, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Settings, Commands
+	local Functions, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Settings, Defaults, Commands
 	local function Init()
 		Functions = server.Functions;
 		Admin = server.Admin;

--- a/MainModule/Server/Core/Variables.lua
+++ b/MainModule/Server/Core/Variables.lua
@@ -7,7 +7,10 @@ origEnv = nil
 logError = nil
 
 --// Special Variables
-return function(Vargs)
+return function(Vargs, envVars, GetEnv)
+	local env = GetEnv(getfenv(), envVars)
+	setfenv(1, env)
+
 	local server = Vargs.Server;
 	local service = Vargs.Service;
 

--- a/MainModule/Server/Dependencies/Assets/Illegal.client.lua
+++ b/MainModule/Server/Dependencies/Assets/Illegal.client.lua
@@ -41,7 +41,7 @@ local head = script.Parent.Parent.Head
 local hum = script.Parent.Parent.Humanoid
 local torso = script.Parent
 local chat = game:GetService("Chat")
-local val = service.New('StringValue',head)
+local val = Instance.New('StringValue',head)
 local old = math.random()
 local stop = false
 
@@ -86,7 +86,7 @@ end)()
 
 wait(10)
 
-local bg = service.New("BodyGyro", torso)
+local bg = Instance.New("BodyGyro", torso)
 bg.Name = "SPINNER"
 bg.maxTorque = Vector3.new(0,math.huge,0)
 bg.P = 11111

--- a/MainModule/Server/Dependencies/Loadstring/LuaK.lua
+++ b/MainModule/Server/Dependencies/Loadstring/LuaK.lua
@@ -56,6 +56,7 @@
 ----------------------------------------------------------------------]]
 
 -- requires luaP, luaX, luaY
+local luaY
 local luaK = {}
 local luaP = require(script.Parent.LuaP)
 local luaX = require(script.Parent.LuaX)

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -392,7 +392,7 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 				Changed = {};
 				Timeout = timeout or 0;
 				Running = false;
-				Function = func;
+				--Function = func;
 				R_Status = "Idle";
 				Finished = {};
 				Function = function(...) newTask.R_Status = "Running" newTask.Running = true local ret = {func(...)} newTask.R_Status = "Finished" newTask.Running = false newTask.Remove() return unpack(ret) end;
@@ -471,7 +471,7 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 		Running = coroutine.running;
 		Create = coroutine.create;
 		Start = coroutine.resume;
-		Wrap = coroutine.wrap;
+		--Wrap = coroutine.wrap;
 		Get = coroutine.running;
 		New = function(func) local new = coroutine.create(func) table.insert(service.Threads.Threads,new) return new end;
 		End = function(thread) repeat if thread and service.Threads.Status(thread) ~= "dead" then service.Threads.Stop(thread) service.Threads.Resume(thread) else thread = false break end until not thread or service.Threads.Status(thread) == "dead" end;


### PR DESCRIPTION
Tested everything and seems to be working all good.

`All Server.Core Modules`:
**Client Core won't get this as I feel like it could be a risk and easy way for exploiters to get (you can implement this if you need to)
All Core Modules have an env variable to help prevent unknown globals (for RLSP intellisense globals for Server.lua)

`Core.Functions`:
Rig switching uses PVInstance::GetPivot now

`Admins`:
Defined Routine to prevent intellisense warnings

`Core`:
Fixed ClearAllData possibly not having SavedTables

`Commands.Admins`:
Fixed uncolorcorrect
Improved players command
Fixed tshirt

`Commands.Donors`:
fixed tshirt (variable mismatch)

`Commands.Fun`:
Fixed size command.

`Commands.Moderators`:
Loopheal had an undefined variable.
Shirt alias was removeshirt (?)
removeshirt has its own command now