### PR TITLE
Resolve controversy & bugs with !profile, some fixes

### DIFF
--- a/MainModule/Client/Core/Variables.lua
+++ b/MainModule/Client/Core/Variables.lua
@@ -104,7 +104,6 @@ return function()
 		ParticlesEnabled = true;
 		CapesEnabled = true;
 		HideChatCommands = false;
-		PrivacyMode = false;
 		Particles = {};
 		KeyBinds = {};
 		Aliases = {};

--- a/MainModule/Client/UI/Default/List.lua
+++ b/MainModule/Client/UI/Default/List.lua
@@ -5,6 +5,7 @@ service = nil
 return function(data)
 	local Title = data.Title
 	local TitleButtons = data.TitleButtons or {}
+	local Icon = data.Icon
 	local Tabs = data.Tabs
 	local Tab = data.Table or data.Tab
 	local Update = data.Update
@@ -174,6 +175,7 @@ return function(data)
 	window = client.UI.Make("Window",{
 		Name  = "List";
 		Title = Title;
+		Icon = Icon;
 		Size  = Size or {240, 225};
 		MinSize = {150, 100};
 		OnRefresh = Update and function()

--- a/MainModule/Client/UI/Default/Profile.lua
+++ b/MainModule/Client/UI/Default/Profile.lua
@@ -12,7 +12,7 @@ return function(data)
 
 	local Routine = Routine
 
-	local player = data.Target
+	local player: Player = data.Target
 
 	local window = client.UI.Make("Window", {
 		Name  = "Profile_"..player.UserId;
@@ -74,7 +74,7 @@ return function(data)
 		BackgroundTransparency = 1;
 	})
 
-	do
+	do --// General Tab
 		generaltab:Add("ImageLabel", {
 			Size = UDim2.new(0, 120, 0, 120);
 			Position = UDim2.new(0, 5, 0, 5);
@@ -104,10 +104,9 @@ return function(data)
 		end
 
 		for i, v in ipairs({
-			{"Membership", player.MembershipType.Name, "The player's Roblox membership type (premium)"},
-			{"Safe Chat Enabled", (data.SafeChat), "Does the player have safe chat applied?"},
-			{"Can Chat", boolToStr(data.CanChat), "Does the player's account settings allow them to chat?"},
-			{"Country/Region Code", data.Code, "The player's country or region code based on geolocation"}
+			{"Membership", player.MembershipType.Name, "The player's Roblox membership type (Premium)"},
+			{"Safe Chat Enabled", data.SafeChat, "Does the player have safe chat applied?"},
+			{"Can Chat", data.CanChatGet[1] and boolToStr(data.CanChatGet[2]) or "[Error]", "Does the player's account settings allow them to chat?"},
 			}) do
 			generaltab:Add("TextLabel", {
 				Text = "  "..v[1]..": ";
@@ -124,30 +123,32 @@ return function(data)
 				TextXAlignment = "Right";
 			})
 		end
-
-		local credentials = {
+		
+		local c = 0
+		for i, v in ipairs({
+			{data.IsServerOwner, "Private Server Owner", client.MatIcons.Grade, "User owns the current private server"},
 			{data.IsDonor, "Adonis Donor", "rbxassetid://6877822142", "User has purchased the Adonis donation pass/shirt"},
 			{player:GetRankInGroup(886423) == 10, "Adonis Contributor (GitHub)", "rbxassetid://6878433601", "User has contributed to the Adonis admin system (see credit list)"},
 			{player:GetRankInGroup(886423) == 12, "Adonis Developer", "rbxassetid://6878433601", "User is an official developer of the Adonis admin system"},
 			-- haha? {player.UserId == 644946329, "I invented this profile interface! [Expertcoderz]", "rbxthumb://type=AvatarHeadShot&id=644946329&w=48&h=48", "yes"},
-			{player.UserId == (1237666 or 698712377), "Adonis Creator [Sceleratis/Davey_Bones]", "rbxassetid://6878433601", "You are looking at the creator of the Adonis admin system!"},
+			{player.UserId == (1237666 or 698712377), "Adonis Creator [Sceleratis/Davey_Bones]", "rbxassetid://6878433601", "You're looking at the creator of the Adonis admin system!"},
 			{player:IsInGroup(1200769) or player:IsInGroup(2868472), "ROBLOX Staff", "rbxassetid://6811962259", "User is an official Roblox employee (!)"},
 			{player:IsInGroup(3514227), "DevForum Member", "rbxassetid://6383940476", "User is a member of the Roblox Developer Forum"},
-		}
-		for i, v in ipairs(credentials) do
+			}) do
 			if v[1] then
 				generaltab:Add("TextLabel", {
 					Size = UDim2.new(1, -10, 0, 30);
-					Position = UDim2.new(0, 5, 0, (32*(i-1))+255);
+					Position = UDim2.new(0, 5, 0, 32*c + 225);
 					BackgroundTransparency = 0.4;
 					Text = v[2];
-					ToolTip = v[4]
+					ToolTip = v[4];
 				}):Add("ImageLabel", {
 					Image = v[3];
 					BackgroundTransparency = 1;
 					Size = UDim2.new(0, 24, 0, 24);
 					Position = UDim2.new(0, 4, 0, 3);
 				})
+				c += 1
 			end
 		end
 
@@ -156,7 +157,7 @@ return function(data)
 
 	window:Ready()
 
-	do
+	do --// Friends Tab
 		local function iterPageItems(pages)
 			return coroutine.wrap(function()
 				local pagenum = 1
@@ -267,7 +268,7 @@ return function(data)
 
 	end
 
-	do
+	do --// Groups Tab
 		local sortedGroups = {}    
 		local groupInfoRef = {}
 
@@ -294,7 +295,7 @@ return function(data)
 			Size = UDim2.new(1, -10, 0, 25);
 			Position = UDim2.new(0, 5, 0, 5);
 			BackgroundTransparency = 0.5;
-			PlaceholderText = ("Search %d groups (%d owned)"):format(groupCount, ownCount);
+			PlaceholderText = ("Search %d group%s (%d owned)"):format(groupCount, groupCount ~= 1 and "s" or "", ownCount);
 			Text = "";
 			TextStrokeTransparency = 0.8;
 		})
@@ -352,7 +353,7 @@ return function(data)
 		getList()
 	end
 
-	if data.GameData then
+	if data.GameData then --// Game Tab
 		local gameplayDataToDisplay = {
 			{"Admin Level", data.GameData.AdminLevel, "The player's Adonis rank"},
 			{"Muted", boolToStr(data.GameData.IsMuted), "Is the player muted? (IGNORES TRELLO MUTELIST)"},
@@ -382,10 +383,8 @@ return function(data)
 				Size = UDim2.new(1, -10, 0, 30);
 				Position = UDim2.new(0, 5, 0, (30*(i-1))+5);
 				TextXAlignment = "Left";
-			}):Add("TextBox", {
+			}):Add("TextLabel", {
 				Text = v[2];
-				TextEditable = false;
-				ClearTextOnFocus = false;
 				BackgroundTransparency = 1;
 				Size = UDim2.new(0, 120, 1, 0);
 				Position = UDim2.new(1, -130, 0, 0);
@@ -396,25 +395,19 @@ return function(data)
 
 		gametab:Add("TextButton", {
 			Text = "View Tools";
+			ToolTip = string.format("%sviewtools%s%s", data.CmdPrefix, data.CmdSplitKey, player.Name);
 			BackgroundTransparency = (i%2 == 0 and 0) or 0.2;
 			Size = UDim2.new(1, -10, 0, 35);
 			Position = UDim2.new(0, 5, 0, (30*(i-1))+10);
-			OnClicked = function()
-				local tools = {}
-				for k,t in pairs(player.Backpack:GetChildren()) do
-					if t.ClassName == "Tool" then
-						table.insert(tools, {Text=t.Name,Desc="Class: "..t.ClassName.." | ToolTip: "..t.ToolTip})
-					elseif t.ClassName == "HopperBin" then
-						table.insert(tools, {Text=t.Name,Desc="Class: "..t.ClassName.." | BinType: "..tostring(t.BinType)})
-					else
-						table.insert(tools, {Text=t.Name,Desc="Class: "..t.ClassName})
-					end
+			OnClicked = function(self)
+				if self.Active then
+					self.Active = false
+					self.AutoButtonColor = false
+					client.Remote.Send("ProcessCommand", string.format("%sviewtools%s%s", data.CmdPrefix, data.CmdSplitKey, player.Name))
+					wait(2)
+					self.AutoButtonColor = true
+					self.Active = true
 				end
-				client.UI.Make("List", {
-					Title = "@"..player.Name.."'s tools";
-					Icon = client.MatIcons["Inventory 2"];
-					Table = tools;
-				})
 			end
 		})
 

--- a/MainModule/Client/UI/Default/Terminal.lua
+++ b/MainModule/Client/UI/Default/Terminal.lua
@@ -27,9 +27,9 @@ return function(data)
 		Text = "";
 		Size = UDim2.new(1, 0, 0, 30);
 		Position = UDim2.new(0, 0, 1, -30);
-		--Text = "";
 		PlaceholderText = "Enter command";
 		TextXAlignment = "Left"
+		ClearTextOnFocus = false;
 	})
 	textbox:Add("UIPadding", {PaddingLeft = UDim.new(0, 6);})
 	

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -796,14 +796,14 @@ return function(Vargs, env)
 						end
 					end
 					local policyResult, policyInfo = pcall(service.PolicyService.GetPolicyInfoForPlayerAsync, service.PolicyService, v)
-					local hasSafeChat = if policyResult then
+					local hasSafeChat = if elevated and policyResult then
 						(table.find(policyInfo.AllowedExternalLinkReferences, "Discord") and "No" or "Yes")
-						else "[Error]"
+						else "[Error/Redacted]"
 
 					Remote.RemoveGui(plr, "Profile_"..v.UserId)
 					Remote.MakeGui(plr, "Profile", {
 						Target = v;
-						SafeChat = elevated and hasSafeChat;
+						SafeChat = hasSafeChat;
 						CanChatGet = table.pack(pcall(service.Chat.CanUserChatAsync, service.Chat, v.UserId));
 						IsDonor = service.MarketPlace:UserOwnsGamePassAsync(v.UserId, Variables.DonorPass[1]);
 						GameData = gameData;


### PR DESCRIPTION
To start with the simple things,
- Added title icons support for List UIs, this should have been done in my Material Icons PR but either I forgot or the changes disappeared.
<img width="132" alt="image" src="https://user-images.githubusercontent.com/81153405/143677041-9fd0c87c-2275-4986-a0a9-77875786daaa.png">

- Set `ClearTextOnFocus` for the Terminal window command input box to ``false``.
<img width="203" alt="image" src="https://user-images.githubusercontent.com/81153405/143677005-a3fd5a49-ed24-478f-bbb8-3939b7eb15ce.png">


## Changes to the Profile command
- Re-added as a player command.
- Completely removed country/region code from being displayed. Players and moderators alike do _not_ need this information, it has caused more trouble/questioning than what is worth the satisfaction of individual curiosity.
- Now indicates if the user is the private server owner. Also fixed a critical visual bug with mispositioning.
### **Before: (non-admin's perspective)**
<img width="315" alt="image" src="https://user-images.githubusercontent.com/81153405/143676863-383757f0-5e3c-4fde-8992-afe8fa58d0ce.png">

### **After: (non-admin's perspective)** 
<img width="307" alt="image" src="https://user-images.githubusercontent.com/81153405/143676785-ed2c5740-b55e-4cf2-a5b0-f82eed2d7a23.png">

- The 'View Tools' button under the 'Game' tab now runs ``:viewtools`` internally.