### PR TITLE
Update jail command description to not use UK English spellings

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2516,7 +2516,7 @@ return function(Vargs, env)
 			Commands = {"jail", "imprison"};
 			Args = {"player", "BrickColor"};
 			Hidden = false;
-			Description = "Jails the target player(s), removing their tools until they are un-jailed; Specify a BrickColor to change the colour of the jail bars";
+			Description = "Jails the target player(s), removing their tools until they are un-jailed; Specify a BrickColor to change the color of the jail bars";
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})


### PR DESCRIPTION
(yes i know some other countries also use british spellings)

This was done for a couple of reasons after a discussion about this on the discord:
1. It can be confusing for people who do not understand this variant of english.
2. Most programming languages use US english for spelling.
3. Most of Roblox's playerbase is american and not everyone knows british spellings...
e.g. people might know what `center` means but not `centre` 