### PR TITLE
Disallow players to see server ip in !serverinfo

### DIFF
--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -858,7 +858,7 @@ return function(Vargs, env)
 					region = r.region,
 					zipcode = r.zip,
 					timezone = r.timezone,
-					query = r.query,
+					query = Admin.CheckAdmin(plr) and (r.query) or "[Redacted]",
 					coords = Admin.CheckAdmin(plr) and ("LAT: "..r.lat..", LON: "..r.lon) or "[Redacted]",
 				} or nil
 


### PR DESCRIPTION
Players should not be allowed to view the server IP at all since "some" people like to DDoS them.
