### PR TITLE
Added a command called "TransparentPart", which allows you to make individual parts and more transparent

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -4338,16 +4338,17 @@ return function(Vargs, env)
 								
 								
 								-- Clean up the parts we don't need, depending on rigType, to allow this command to be more dynamic
-                                for i=#partInput,1,-1 do
-                                    if (partInput[i] == "RightArm") then
-                                        if (rigType == Enum.HumanoidRigType.R15) then
+								
+								if (rigType == Enum.HumanoidRigType.R15) then
+									for i=#partInput,1,-1 do
+	                                    if (partInput[i] == "RightArm") then
                                             local foundKeys = {}
                                             for k2,v2 in pairs(partInput) do
                                                 if (v2 == "RightUpperArm" or v2 == "RightLowerArm" or v2 == "RightHand") then
                                                     table.insert(foundKeys, k2)
                                                 end
                                             end
-                                            -- If not all 3 were found just remove all 3 and add them manually
+                                            -- If not all keys were found just remove all keys and add them manually
                                             if (#foundKeys ~= 3) then
                                                 for _,foundKey in pairs(foundKeys) do
                                                     table.remove(partInput, foundKey)
@@ -4356,24 +4357,16 @@ return function(Vargs, env)
                                                 table.insert(partInput, "RightLowerArm")
                                                 table.insert(partInput, "RightHand")
                                             end
-                                            table.remove(partInput, i) -- Remove the group part input
-                                            
-                                        elseif (rigType == Enum.HumanoidRigType.R6) then
-                                            for i=#partInput,1,-1 do
-                                                if (partInput[i] == "RightUpperArm" or partInput[i] == "RightLowerArm" or partInput[i] == "RightHand") then
-                                                    table.remove(partInput, i)
-                                                end
-                                            end
-                                        end
-                                    elseif (partInput[i] == "LeftArm") then
-                                        if (rigType == Enum.HumanoidRigType.R15) then
+											table.remove(partInput, i) -- Remove the group part input
+											
+	                                    elseif (partInput[i] == "LeftArm") then
                                             local foundKeys = {}
                                             for k2,v2 in pairs(partInput) do
                                                 if (v2 == "LeftUpperArm" or v2 == "LeftLowerArm" or v2 == "LeftHand") then
                                                     table.insert(foundKeys, k2)
                                                 end
-                                            end
-                                            -- If not all 3 were found just remove all 3 and add them manually
+											end
+											
                                             if (#foundKeys ~= 3) then
                                                 for _,foundKey in pairs(foundKeys) do
                                                     table.remove(partInput, foundKey)
@@ -4382,24 +4375,16 @@ return function(Vargs, env)
                                                 table.insert(partInput, "LeftLowerArm")
                                                 table.insert(partInput, "LeftHand")
                                             end
-                                            table.remove(partInput, i) -- Remove the group part input
-                                            
-                                        elseif (rigType == Enum.HumanoidRigType.R6) then
-                                            for i=#partInput,1,-1 do
-                                                if (partInput[i] == "LeftUpperArm" or partInput[i] == "LeftLowerArm" or partInput[i] == "LeftHand") then
-                                                    table.remove(partInput, i)
-                                                end
-                                            end
-                                        end
-                                    elseif (partInput[i] == "RightLeg") then
-                                        if (rigType == Enum.HumanoidRigType.R15) then
+                                            table.remove(partInput, i)
+
+	                                    elseif (partInput[i] == "RightLeg") then
                                             local foundKeys = {}
                                             for i=#partInput,1,-1 do
                                                 if (partInput[i] == "RightUpperLeg" or partInput[i] == "RightLowerLeg" or partInput[i] == "RightFoot") then
                                                     table.insert(foundKeys, partInput[i])
                                                 end
-                                            end
-                                            -- If not all 3 were found just remove all 3 and add them manually
+											end
+											
                                             if (#foundKeys ~= 3) then
                                                 for _,foundKey in pairs(foundKeys) do
                                                     table.remove(partInput, foundKey)
@@ -4408,24 +4393,16 @@ return function(Vargs, env)
                                                 table.insert(partInput, "RightLowerLeg")
                                                 table.insert(partInput, "RightFoot")
                                             end
-                                            table.remove(partInput, i) -- Remove the group part input
- 
-                                        elseif (rigType == Enum.HumanoidRigType.R6) then
-                                            for i=#partInput,1,-1 do
-                                                if (partInput[i] == "RightUpperLeg" or partInput[i] == "RightLowerLeg" or partInput[i] == "RightFoot") then
-                                                    table.remove(partInput, i)
-                                                end
-                                            end
-                                        end
-                                    elseif (partInput[i] == "LeftLeg") then
-                                        if (rigType == Enum.HumanoidRigType.R15) then
+											table.remove(partInput, i)
+											
+	                                    elseif (partInput[i] == "LeftLeg") then
                                             local foundKeys = {}
                                             for k2,v2 in pairs(partInput) do
                                                 if (v2 == "LeftUpperLeg" or v2 == "LeftLowerLeg" or v2 == "LeftFoot") then
                                                     table.insert(foundKeys, k2)
                                                 end
-                                            end
-                                            -- If not all 3 were found just remove all 3 and add them manually
+											end
+											
                                             if (#foundKeys ~= 3) then
                                                 for _,foundKey in pairs(foundKeys) do
                                                     table.remove(partInput, foundKey)
@@ -4434,24 +4411,16 @@ return function(Vargs, env)
                                                 table.insert(partInput, "LeftLowerLeg")
                                                 table.insert(partInput, "LeftFoot")
                                             end
-                                            table.remove(partInput, i) -- Remove the group part input
- 
-                                        elseif (rigType == Enum.HumanoidRigType.R6) then
-                                            for i=#partInput,1,-1 do
-                                                if (partInput[i] == "LeftUpperLeg" or partInput[i] == "LeftLowerLeg" or partInput[i] == "LeftFoot") then
-                                                    table.remove(partInput, i)
-                                                end
-                                            end
-                                        end
-                                    elseif (partInput[i] == "Torso") then
-                                        if (rigType == Enum.HumanoidRigType.R15) then
+											table.remove(partInput, i)
+											
+	                                    elseif (partInput[i] == "Torso") then
                                             local foundKeys = {}
                                             for k2,v2 in pairs(partInput) do
                                                 if (v2 == "UpperTorso" or v2 == "LowerTorso") then
                                                     table.insert(foundKeys, k2)
                                                 end
-                                            end
-                                            -- If not all 2 were found just remove all 2 and add them manually
+											end
+											
                                             if (#foundKeys ~= 2) then
                                                 for _,foundKey in pairs(foundKeys) do
                                                     table.remove(partInput, foundKey)
@@ -4459,19 +4428,28 @@ return function(Vargs, env)
                                                 table.insert(partInput, "UpperTorso")
                                                 table.insert(partInput, "LowerTorso")
                                             end
-                                            table.remove(partInput, i) -- Remove the group part input
- 
-                                        elseif (rigType == Enum.HumanoidRigType.R6) then
-                                            for i=#partInput,1,-1 do
-                                                if (partInput[i] == "UpperTorso" or partInput[i] == "LowerTorso") then
-                                                    table.remove(partInput, i)
-                                                end
-                                            end
-                                        end
-                                    end
+											table.remove(partInput, i)
+	                                    end
+									end
 								end
-								
-								
+									
+								if (rigType == Enum.HumanoidRigType.R6) then
+									for i=#partInput,1,-1 do
+										if (partInput[i] == "RightUpperArm" or partInput[i] == "RightLowerArm" or partInput[i] == "RightHand") then
+											table.remove(partInput, i)
+										elseif (partInput[i] == "LeftUpperArm" or partInput[i] == "LeftLowerArm" or partInput[i] == "LeftHand") then
+											table.remove(partInput, i)
+										elseif (partInput[i] == "RightUpperLeg" or partInput[i] == "RightLowerLeg" or partInput[i] == "RightFoot") then
+											table.remove(partInput, i)
+										elseif (partInput[i] == "LeftUpperLeg" or partInput[i] == "LeftLowerLeg" or partInput[i] == "LeftFoot") then
+											table.remove(partInput, i)
+										elseif (partInput[i] == "UpperTorso" or partInput[i] == "LowerTorso") then
+											table.remove(partInput, i)
+										end
+									end
+								end
+									
+									
 								-- Make chosen parts transparent
 								for k,v in pairs(partInput) do
 									if (v ~= "limbs" or v ~= "face" or v ~= "accessories") then

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -4246,6 +4246,296 @@ return function(Vargs, env)
 				end
 			end
 		};
+		
+		TransparentPart = {
+			Prefix = Settings.Prefix;
+			Commands = {"transparentpart"};
+			Args = {"player", "parts", "value (0-1)"};
+			Hidden = false;
+			Description = "Set the transparency of the target's character's parts, including accessories. Supports comma separated list of parts.";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				for i, player in pairs(service.GetPlayers(plr, args[1])) do
+					if player.Character then
+						local humanoid = player.Character:FindFirstChildOfClass("Humanoid")
+						if humanoid then
+							local rigType =  humanoid.RigType
+							local GroupPartInputs = {"LeftArm", "RightArm", "RightLeg", "LeftLeg", "Torso"}
+							local PartInputs = {"Head", "UpperTorso", "LowerTorso", "LeftUpperArm", "LeftLowerArm", "LeftHand", "RightUpperArm", "RightLowerArm", "RightHand", "LeftUpperLeg", "LeftLowerLeg", "LeftFoot", "RightUpperLeg", "RightLowerLeg", "RightFoot"}
+							
+							local usageText = "\nPossible inputs are: \n" ..
+								"R6: Head, LeftArm, RightArm, RightLeg, LeftLeg, Torso\n" ..
+								"R15: Head, UpperTorso, LowerTorso, LeftUpperArm, LeftLowerArm, LeftHand, RightUpperArm, RightLowerArm, RightHand, LeftUpperLeg, LeftLowerLeg, LeftFoot, RightUpperLeg, RightLowerLeg, RightFoot\n" ..
+								"\n"..
+								"If the input is 'LeftArm' on a R15 rig, it will select the entire Left Arm for R15.\n"..
+								"Special Inputs: all, accessories\n"..
+								"all: All limbs including accessories. If this is specified it will ignore all other specified parts.\n"..
+								"limbs: Changes the transparency of all limbs\n"..
+								"face: Changes the transparency of the face"..
+								"accessories: Changes transparency of accessories\n"
+
+							if not (args[2]) then
+								print(usageText)
+								assert(args[2], "No parts specified. See developer console for possible inputs.")
+							end
+							
+							local partInput = {}
+							local inputs = string.split(args[2], ",")
+							
+							for k,v in pairs(inputs) do
+								if (v ~= "") then
+									if (v == "all") then
+										partInput = "all"
+										break -- break if "all" is found.
+									end
+									
+									-- Validate inputs
+									if (v == "limbs" or v == "face" or v == "accessories") then
+										table.insert(partInput, v)
+									else
+										local found = false
+										while (found ~= true) do
+											for _,v2 in pairs(GroupPartInputs) do
+												if v == v2 then
+													table.insert(partInput, v)
+													found = true
+													break
+												end
+											end
+											
+											for _,v2 in pairs(PartInputs) do
+												if v == v2 then
+													table.insert(partInput, v)
+													found = true
+													break
+												end
+											end
+										
+											if not (found) then
+												assert(nil, "'"..v.."'".." is not a valid input. Run command with no arguments to see possible inputs.")
+											end	
+										end
+									end
+								else
+									assert(nil, "Part argument contains empty value.")
+								end
+							end
+							
+							
+							-- Check if partInput is a table
+							if (typeof(partInput) == "table") then
+								local hash = {}
+								
+								-- Check for duplicates
+								for i,v in pairs(partInput) do
+									if not (hash[v]) then
+										hash[v] = i -- Store into table to check for duplicates.
+									else
+										assert(nil, "Duplicate '"..v.."'".." found in input. Specify each input once only.")
+									end
+								end
+								
+								
+								-- Clean up the parts we don't need, depending on rigType, to allow this command to be more dynamic
+                                for i=#partInput,1,-1 do
+                                    if (partInput[i] == "RightArm") then
+                                        if (rigType == Enum.HumanoidRigType.R15) then
+                                            local foundKeys = {}
+                                            for k2,v2 in pairs(partInput) do
+                                                if (v2 == "RightUpperArm" or v2 == "RightLowerArm" or v2 == "RightHand") then
+                                                    table.insert(foundKeys, k2)
+                                                end
+                                            end
+                                            -- If not all 3 were found just remove all 3 and add them manually
+                                            if (#foundKeys ~= 3) then
+                                                for _,foundKey in pairs(foundKeys) do
+                                                    table.remove(partInput, foundKey)
+                                                end
+                                                table.insert(partInput, "RightUpperArm")
+                                                table.insert(partInput, "RightLowerArm")
+                                                table.insert(partInput, "RightHand")
+                                            end
+                                            table.remove(partInput, i) -- Remove the group part input
+                                            
+                                        elseif (rigType == Enum.HumanoidRigType.R6) then
+                                            for i=#partInput,1,-1 do
+                                                if (partInput[i] == "RightUpperArm" or partInput[i] == "RightLowerArm" or partInput[i] == "RightHand") then
+                                                    table.remove(partInput, i)
+                                                end
+                                            end
+                                        end
+                                    elseif (partInput[i] == "LeftArm") then
+                                        if (rigType == Enum.HumanoidRigType.R15) then
+                                            local foundKeys = {}
+                                            for k2,v2 in pairs(partInput) do
+                                                if (v2 == "LeftUpperArm" or v2 == "LeftLowerArm" or v2 == "LeftHand") then
+                                                    table.insert(foundKeys, k2)
+                                                end
+                                            end
+                                            -- If not all 3 were found just remove all 3 and add them manually
+                                            if (#foundKeys ~= 3) then
+                                                for _,foundKey in pairs(foundKeys) do
+                                                    table.remove(partInput, foundKey)
+                                                end
+                                                table.insert(partInput, "LeftUpperArm")
+                                                table.insert(partInput, "LeftLowerArm")
+                                                table.insert(partInput, "LeftHand")
+                                            end
+                                            table.remove(partInput, i) -- Remove the group part input
+                                            
+                                        elseif (rigType == Enum.HumanoidRigType.R6) then
+                                            for i=#partInput,1,-1 do
+                                                if (partInput[i] == "LeftUpperArm" or partInput[i] == "LeftLowerArm" or partInput[i] == "LeftHand") then
+                                                    table.remove(partInput, i)
+                                                end
+                                            end
+                                        end
+                                    elseif (partInput[i] == "RightLeg") then
+                                        if (rigType == Enum.HumanoidRigType.R15) then
+                                            local foundKeys = {}
+                                            for i=#partInput,1,-1 do
+                                                if (partInput[i] == "RightUpperLeg" or partInput[i] == "RightLowerLeg" or partInput[i] == "RightFoot") then
+                                                    table.insert(foundKeys, partInput[i])
+                                                end
+                                            end
+                                            -- If not all 3 were found just remove all 3 and add them manually
+                                            if (#foundKeys ~= 3) then
+                                                for _,foundKey in pairs(foundKeys) do
+                                                    table.remove(partInput, foundKey)
+                                                end
+                                                table.insert(partInput, "RightUpperLeg")
+                                                table.insert(partInput, "RightLowerLeg")
+                                                table.insert(partInput, "RightFoot")
+                                            end
+                                            table.remove(partInput, i) -- Remove the group part input
+ 
+                                        elseif (rigType == Enum.HumanoidRigType.R6) then
+                                            for i=#partInput,1,-1 do
+                                                if (partInput[i] == "RightUpperLeg" or partInput[i] == "RightLowerLeg" or partInput[i] == "RightFoot") then
+                                                    table.remove(partInput, i)
+                                                end
+                                            end
+                                        end
+                                    elseif (partInput[i] == "LeftLeg") then
+                                        if (rigType == Enum.HumanoidRigType.R15) then
+                                            local foundKeys = {}
+                                            for k2,v2 in pairs(partInput) do
+                                                if (v2 == "LeftUpperLeg" or v2 == "LeftLowerLeg" or v2 == "LeftFoot") then
+                                                    table.insert(foundKeys, k2)
+                                                end
+                                            end
+                                            -- If not all 3 were found just remove all 3 and add them manually
+                                            if (#foundKeys ~= 3) then
+                                                for _,foundKey in pairs(foundKeys) do
+                                                    table.remove(partInput, foundKey)
+                                                end
+                                                table.insert(partInput, "LeftUpperLeg")
+                                                table.insert(partInput, "LeftLowerLeg")
+                                                table.insert(partInput, "LeftFoot")
+                                            end
+                                            table.remove(partInput, i) -- Remove the group part input
+ 
+                                        elseif (rigType == Enum.HumanoidRigType.R6) then
+                                            for i=#partInput,1,-1 do
+                                                if (partInput[i] == "LeftUpperLeg" or partInput[i] == "LeftLowerLeg" or partInput[i] == "LeftFoot") then
+                                                    table.remove(partInput, i)
+                                                end
+                                            end
+                                        end
+                                    elseif (partInput[i] == "Torso") then
+                                        if (rigType == Enum.HumanoidRigType.R15) then
+                                            local foundKeys = {}
+                                            for k2,v2 in pairs(partInput) do
+                                                if (v2 == "UpperTorso" or v2 == "LowerTorso") then
+                                                    table.insert(foundKeys, k2)
+                                                end
+                                            end
+                                            -- If not all 2 were found just remove all 2 and add them manually
+                                            if (#foundKeys ~= 2) then
+                                                for _,foundKey in pairs(foundKeys) do
+                                                    table.remove(partInput, foundKey)
+                                                end
+                                                table.insert(partInput, "UpperTorso")
+                                                table.insert(partInput, "LowerTorso")
+                                            end
+                                            table.remove(partInput, i) -- Remove the group part input
+ 
+                                        elseif (rigType == Enum.HumanoidRigType.R6) then
+                                            for i=#partInput,1,-1 do
+                                                if (partInput[i] == "UpperTorso" or partInput[i] == "LowerTorso") then
+                                                    table.remove(partInput, i)
+                                                end
+                                            end
+                                        end
+                                    end
+								end
+								
+								
+								-- Make chosen parts transparent
+								for k,v in pairs(partInput) do
+									if (v ~= "limbs" or v ~= "face" or v ~= "accessories") then
+										local part = player.Character:FindFirstChild(v)
+										if (part ~= nil and part:IsA("BasePart")) then
+											part.Transparency = args[3]
+										end
+									
+									elseif (v == "limbs") then
+										for key, part in pairs(player.Character:GetChildren()) do
+											if part:IsA("BasePart") and part.Name ~= "HumanoidRootPart" then
+												part.Transparency = args[3]
+											end
+										end
+									
+									elseif (v == "face") then
+										local headPart = player.Character:FindFirstChild("Head")
+										for _, v2 in pairs(headPart:GetChildren()) do
+											if v2:IsA("Decal") then
+												v2.Transparency = args[3]
+											end
+										end
+									
+									elseif (v == "accessories") then
+										for key, part in pairs(player.Character:GetChildren()) do
+											if part:IsA("Accessory") then
+												for _, v2 in pairs(part:GetChildren()) do
+													if v2:IsA("BasePart") then
+														v2.Transparency = args[3]
+													end
+												end
+											end
+										end
+									end
+								end
+								
+
+							-- If "all" is specified
+							elseif (partInput == "all") then
+								for k, p in pairs(player.Character:GetChildren()) do
+									if p:IsA("BasePart") and p.Name ~= "HumanoidRootPart" then
+										p.Transparency = args[3]
+										if (p.Name == "Head") then
+											for _, v2 in pairs(p:GetChildren()) do
+												if v2:IsA("Decal") then
+													v2.Transparency = args[3]
+												end
+											end
+										end
+									elseif (p:IsA("Accessory") and #p:GetChildren() ~= 0) then
+										for _, v2 in pairs(p:GetChildren()) do
+											if v2:IsA("BasePart") then
+												v2.Transparency = args[3]
+											end
+										end
+									end
+								end
+							end
+						end
+					end
+				end
+			end
+		};
+		
 		MakeTalk = {
 			Prefix = Settings.Prefix;
 			Commands = {"talk", "maketalk"};


### PR DESCRIPTION
Added a command called "TransparentPart", which allows you to make individual parts including all accessories and the face.

I've tested the command, it works both on R15 and R6. I've also made it that if someone would be specifying "LeftArm" on a R15 model, that it would delete "LeftArm" from the given input and add "LeftUpperArm, LeftLowerLeg and LeftHand". And for R6 it does the opposite, it would keep "LeftArm" and remove the R15 ones.

However, the part at where I clean up the input, is actually not that optimal. I think I should just put a check if it is R15 and then R6 and then remove everything that would be from R15, and for removing the R6 things, convert them into R15.

Regarding this individual parts thing, I think whenever the actual function for it seems more optimal to keep as a function in Adonis, that it should be implemented, so that more commands can easily be created, without having to copy paste the entire part validations over and over again.