### PR TITLE
UserPanel, "Admins" Command, server change

### DIFF
--- a/MainModule/Client/Client.lua
+++ b/MainModule/Client/Client.lua
@@ -445,7 +445,7 @@ return service.NewProxy({
 		log("Begin init");
 
 		local remoteName,depsName = string.match(data.Name, "(.*)\\(.*)")
-		Folder = service.Wrap(data.Folder or folder and folder:Clone() or Folder)
+		Folder = service.Wrap(data.Folder --[[or folder and folder:Clone()]] or Folder)
 
 		setfenv(1,setmetatable({}, {__metatable = unique}))
 		client.Folder = Folder;
@@ -458,11 +458,20 @@ return service.NewProxy({
 		client.LoadingTime = data.LoadingTime
 		client.RemoteName = remoteName
 
-		client.MatIcons = setmetatable({}, {
-			__index = function(t, k)
-				return "rbxassetid://"..require(client.Shared.MatIcons)[k]
-			end,
-		})
+		client.Changelog = oldReq(service_UnWrap(client.Shared.Changelog))
+		do
+			local MaterialIcons = oldReq(service_UnWrap(client.Shared.MatIcons))
+			client.MatIcons = setmetatable({}, {
+				__index = function(self, ind)
+					local materialIcon = MaterialIcons[ind]
+					if materialIcon then
+						self[ind] = string.format("rbxassetid://%d", materialIcon)
+						return self[ind]
+					end
+				end,
+				__metatable = "Adonis"
+			})
+		end
 
 		--// Toss deps into a table so we don't need to directly deal with the Folder instance they're in
 		log("Get dependencies")

--- a/MainModule/Client/Core/Core.lua
+++ b/MainModule/Client/Core/Core.lua
@@ -6,6 +6,7 @@ Routine = nil
 GetEnv = nil
 origEnv = nil
 logError = nil
+log = nil
 
 --// Core
 return function()
@@ -106,7 +107,7 @@ return function()
 	client.Core = {
 		Init = Init;
 		RunLast = RunLast;
-		RunAfterLoaded = RunAfterLoaded;
+		--RunAfterLoaded = RunAfterLoaded;
 		RunAfterPlugins = RunAfterPlugins;
 		Name = script.Name;
 		Special = script.Name;

--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -1035,7 +1035,7 @@ return function()
 			local keyVal = tonumber(keyVal);
 			if keyVal then
 				for i,e in ipairs(Enum.KeyCode:GetEnumItems()) do
-					if e.Value == tonumber(keyVal) then
+					if e.Value == keyVal then
 						return e.Name;
 					end
 				end

--- a/MainModule/Client/Core/Process.lua
+++ b/MainModule/Client/Core/Process.lua
@@ -6,6 +6,7 @@ Routine = nil
 GetEnv = nil
 origEnv = nil
 logError = nil
+log = nil
 
 --// Processing
 return function()

--- a/MainModule/Client/Core/Remote.lua
+++ b/MainModule/Client/Core/Remote.lua
@@ -6,6 +6,7 @@ Routine = nil
 GetEnv = nil
 origEnv = nil
 logError = nil
+log = nil
 
 --// Remote
 return function()

--- a/MainModule/Client/UI/Default/UserPanel.lua
+++ b/MainModule/Client/UI/Default/UserPanel.lua
@@ -1,7 +1,3 @@
-
-client = nil
-service = nil
-
 local canEditTables = {
 	Admins = true;
 	HeadAdmins = true;
@@ -26,7 +22,7 @@ local canEditTables = {
 local function tabToString(tab)
 	if type(tab) == "table" then
 		local str = ""
-		for i,v in next,tab do
+		for i,v in pairs(tab) do
 			if #str > 0 then
 				str = str.. "; "
 			end
@@ -40,6 +36,9 @@ local function tabToString(tab)
 end
 
 return function(data)
+	local client = client
+	local service = service
+
 	local gTable
 	local Functions = client.Functions;
 	local window = client.UI.Make("Window",{
@@ -82,7 +81,7 @@ return function(data)
 					selected = nil
 					items:ClearAllChildren();
 
-					for i,v in next,tab do
+					for i,v in ipairs(tab) do
 						items:Add("TextButton", {
 							Text = tabToString(v);
 							Size = UDim2.new(1, 0, 0, 25);
@@ -300,7 +299,7 @@ return function(data)
 					MouseButton1Down = function()
 						client.UI.Make("List", {
 							Title = "Changelog";
-							Table = require(client.Shared.Changelog);
+							Table = client.Changelog;
 						})
 					end
 				}
@@ -734,7 +733,7 @@ return function(data)
 				selected = nil
 				binds:ClearAllChildren();
 
-				for i,v in next,client.Variables.KeyBinds do
+				for i,v in pairs(client.Variables.KeyBinds) do
 					binds:Add("TextButton", {
 						Text = "Key: ".. string.upper(keyCodeToName(i)) .." | Command: "..v;
 						Size = UDim2.new(1, 0, 0, 25);
@@ -969,7 +968,7 @@ return function(data)
 				selected = nil
 				aliases:ClearAllChildren();
 
-				for i,v in next,client.Variables.Aliases do
+				for i,v in pairs(client.Variables.Aliases) do
 					aliases:Add("TextButton", {
 						Text = "Alias: ".. i .." | Command: "..v;
 						Size = UDim2.new(1, 0, 0, 25);
@@ -1294,7 +1293,7 @@ return function(data)
 					Entry = "DropDown";
 					Setting = "CustomTheme";
 					Value = client.Variables.CustomTheme or "Game Theme";
-					Options = (function() local themes = {"Game Theme"} for i,v in next,client.UIFolder:GetChildren() do if v.Name ~= "README" then table.insert(themes, v.Name) end end return themes end)();
+					Options = (function() local themes = {"Game Theme"} for i,v in ipairs(client.UIFolder:GetChildren()) do if v.Name ~= "README" then table.insert(themes, v.Name) end end return themes end)();
 					Function = function(selection)
 						if selection == "Game Theme" then
 							client.Variables.CustomTheme = nil
@@ -1316,7 +1315,7 @@ return function(data)
 				BackgroundTransparency = 1;
 			});]]
 
-			for i, setData in next,cliSettings do
+			for i, setData in ipairs(cliSettings) do
 				local label = clientTab:Add("TextLabel", {
 					Text = "  ".. setData.Text;
 					ToolTip = setData.Desc;
@@ -1398,7 +1397,7 @@ return function(data)
 				})
 
 				local i = 1;
-				for truei, setting in next,order do
+				for truei, setting in pairs(order) do
 					i = i+1;
 
 					local value = settings[setting]
@@ -1427,7 +1426,7 @@ return function(data)
 					elseif type(value) == "table" then
 						if setting == "Ranks" then
 							i = i-1;
-							for rank,data in next,value do
+							for rank,data in pairs(value) do
 								i = i+1;
 								if string.match(rank, "^[WebPanel]") or string.match(rank, "^[Trello]") or data.Level >= 900 then --// TODO: pull the associated level (Creators) and use it for comparison instead of a hardcoded '900'
 									gameTab:Add("TextLabel", {
@@ -1469,7 +1468,7 @@ return function(data)
 									})
 								end
 							end
-						elseif  not canEditTables[setting] then
+						elseif not canEditTables[setting] then
 							gameTab:Add("TextLabel", {
 								Text = "  "..setting..": ";
 								ToolTip = desc;

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1741,19 +1741,21 @@ return function(Vargs, env)
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
+				local RANK_DESCRIPTION_FORMAT = "Rank: %s; Level: %d"
+				local RANK_RICHTEXT = "<b><font color='rgb(77, 77, 255)'>%s (Level: %d)</font></b>"
+				local RANK_TEXT_FORMAT = "%s [%s]"
+
 				local temptable = {};
 				local unsorted = {};
-				local levelListCache = {}
 
 				table.insert(temptable, "<b><font color='rgb(60, 180, 0)'>==== Admins In-Game ====</font></b>")
 
-				for i, v in pairs(service.GetPlayers()) do
-					local data = Core.GetPlayer(v);
+				for i, v in ipairs(service.GetPlayers()) do
 					local level, rankName = Admin.GetLevel(v);
 					if level > 0 then
 						table.insert(unsorted, {
-							Text = v.Name .. " [".. (rankName or ("Level: ".. level)) .."]";
-							Desc = "Rank: ".. (rankName or (level >= 1000 and "Place Owner") or "Unknown") .."; Permission Level: ".. level;
+							Text = string.format(RANK_TEXT_FORMAT, v.Name, (rankName or ("Level: ".. level)));
+							Desc = string.format(RANK_DESCRIPTION_FORMAT, rankName or (level >= 1000 and "Place Owner") or "Unknown", level);
 							SortLevel = level;
 						})
 					end
@@ -1768,7 +1770,7 @@ return function(Vargs, env)
 					table.insert(temptable, v)
 				end
 
-				unsorted = {};
+				table.clear(unsorted)
 
 				table.insert(temptable, "")
 				table.insert(temptable, "<b><font color='rgb(180, 60, 0)'>==== All Admins ====</font></b>")
@@ -1776,7 +1778,7 @@ return function(Vargs, env)
 				for rank, data in pairs(Settings.Ranks) do
 					if not data.Hidden then
 						table.insert(unsorted, {
-							Text = "<b><font color='rgb(77, 77, 255)'>".. rank .." (Level: ".. data.Level ..")</font></b>";
+							Text = string.format(RANK_RICHTEXT, rank, data.Level);
 							Desc = "";
 							Level = data.Level;
 							Users = data.Users;
@@ -1789,7 +1791,7 @@ return function(Vargs, env)
 					return one.Level > two.Level;
 				end)
 
-				for i, v in ipairs(unsorted) do
+				for _, v in ipairs(unsorted) do
 					local Users = v.Users or {};
 					local Level = v.Level or 0;
 					local Rank = v.Rank or "Unknown";
@@ -1800,10 +1802,10 @@ return function(Vargs, env)
 
 					table.insert(temptable, v)
 
-					for i, user in ipairs(Users) do
+					for _, user in ipairs(Users) do
 						table.insert(temptable, {
 							Text = "  ".. user;
-							Desc = "Rank: ".. Rank .."; Level: ".. Level;
+							Desc = string.format(RANK_DESCRIPTION_FORMAT, Rank, Level);
 							--SortLevel = data.Level;
 						});
 					end

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -7,8 +7,8 @@ origEnv = nil
 logError = nil
 
 --// Admin
-return function(Vargs, envVars, GetEnv)
-	local env = GetEnv(getfenv(), envVars)
+return function(Vargs, GetEnv)
+	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
 
 	local server = Vargs.Server;
@@ -420,8 +420,8 @@ return function(Vargs, envVars, GetEnv)
 			data.LastLevelUpdate = os.time()
 
 			AddLog("Script", {
-				Text = "Updating cached level for ".. tostring(p);
-				Desc = "Updating the cached admin level for ".. tostring(p);
+				Text = "Updating cached level for ".. p.Name;
+				Desc = "Updating the cached admin level for ".. p.Name;
 				Player = p;
 			})
 
@@ -674,12 +674,12 @@ return function(Vargs, envVars, GetEnv)
 				return true
 			else
 				--if p.userId<0 or (tonumber(p.AccountAge) and tonumber(p.AccountAge)<0) then return false end
-				for ind,pass in pairs(Variables.DonorPass) do
+				for _, pass in ipairs(Variables.DonorPass) do
 					local ran, ret;
 					if type(pass) == "number" then
-						ran,ret = pcall(function() return service.MarketPlace:UserOwnsGamePassAsync(p.UserId, pass) end)
+						ran,ret = pcall(service.MarketPlace.UserOwnsGamePassAsync, service.MarketPlace, p.UserId, pass)
 					elseif type(pass) == "string" and tonumber(pass) then
-						ran,ret = pcall(function() return service.MarketPlace:PlayerOwnsAsset(p, tonumber(pass)) end)
+						ran,ret = pcall(service.MarketPlace.PlayerOwnsAsset, service.MarketPlace, p, tonumber(pass))
 					end
 
 					if ran and ret then
@@ -693,6 +693,7 @@ return function(Vargs, envVars, GetEnv)
 		CheckBan = function(p)
 			local doCheck = Admin.DoCheck
 			local banCheck = Admin.DoBanCheck
+
 			for ind,admin in pairs(Settings.Banned) do
 				if (type(admin) == "table" and ((admin.UserId and doCheck(p, admin.UserId, true)) or (admin.Name and not admin.UserId and doCheck(p, admin.Name, true)))) or doCheck(p, admin, true) then
 					return true, (type(admin) == "table" and admin.Reason)
@@ -740,12 +741,12 @@ return function(Vargs, envVars, GetEnv)
 					Value = value;
 				})
 
-				Core.CrossServer("Loadstring", [[
-					local player = game:GetService("Players"):FindFirstChild("]]..p.Name..[[")
+				Core.CrossServer("Loadstring", string.format([[
+					local player = game:GetService("Players"):FindFirstChild("%s")
 					if player then
-						player:Kick("]]..Variables.BanMessage..[[ | Reason: ]]..(value.Reason or "No reason provided")..[[")
+						player:Kick("%s | Reason: %s")
 					end
-				]])
+				]], p.Name, Variables.BanMessage, (string.gsub(reason, "\"", "\\%1") or "No reason provided")))
 			end
 
 			if type(p) ~= "table" then
@@ -809,11 +810,14 @@ return function(Vargs, envVars, GetEnv)
 			if com then
 				local cmdArgs = com.Args or com.Arguments
 				local args = Admin.GetArgs(coma,#cmdArgs,...)
+
 				--local task,ran,error = service.Threads.TimeoutRunTask("SERVER_COMMAND: "..coma,com.Function,60*5,false,args)
-				local ran, error = TrackTask("Command: ".. tostring(coma), com.Function, false, args)
+				--[[local ran, error = TrackTask("Command: ".. tostring(coma), com.Function, false, args)
 				if error then
 					--logError("SERVER","Command",error)
-				end
+				end]]
+
+				TrackTask("Command: ".. coma, com.Function, false, args)
 			end
 		end;
 
@@ -825,7 +829,7 @@ return function(Vargs, envVars, GetEnv)
 				local cmdArgs = com.Args or com.Arguments
 				local args = Admin.GetArgs(coma,#cmdArgs,...)
 
-				local ran, error = TrackTask(tostring(plr) .. ": ".. coma, com.Function, plr, args, {
+				local ran, error = TrackTask(plr.Name .. ": ".. coma, com.Function, plr, args, {
 					PlayerData = {
 						Player = plr;
 						Level = adminLvl;
@@ -833,7 +837,7 @@ return function(Vargs, envVars, GetEnv)
 					}
 				})
 
-				--local task,ran,error = service.Threads.TimeoutRunTask("COMMAND:"..tostring(plr)..": "..coma,com.Function,60*5,plr,args)
+				--local task,ran,error = service.Threads.TimeoutRunTask("COMMAND:"..plr.Name..": "..coma,com.Function,60*5,plr,args)
 				if error then
 					--logError(plr,"Command",error)
 					error = string.match(error, ":(.+)$") or "Unknown error"
@@ -852,14 +856,18 @@ return function(Vargs, envVars, GetEnv)
 			if com and com.AdminLevel == 0 then
 				local cmdArgs = com.Args or com.Arguments
 				local args = Admin.GetArgs(coma,#cmdArgs,...)
-				local ran, error = TrackTask(tostring(plr) ..": ".. coma, com.Function, plr, args, {PlayerData = {
+				local _, error = TrackTask(plr.Name ..": ".. coma, com.Function, plr, args, {PlayerData = {
 					Player = plr;
 					Level = 0;
 					isDonor = false;
 				}})
 				if error then
 					error = string.match(error, ":(.+)$") or "Unknown error"
-					Remote.MakeGui(plr,'Output',{Title = ''; Message = error; Color = Color3.new(1,0,0)})
+					Remote.MakeGui(plr, 'Output', {
+						Title = '';
+						Message = error;
+						Color = Color3.new(1,0,0)
+					})
 				end
 			end
 		end;

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -7,8 +7,8 @@ origEnv = nil
 logError = nil
 
 --// Anti-Exploit
-return function(Vargs, envVars, GetEnv)
-	local env = GetEnv(getfenv(), envVars)
+return function(Vargs, GetEnv)
+	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
 
 	local server = Vargs.Server;

--- a/MainModule/Server/Core/Commands.lua
+++ b/MainModule/Server/Core/Commands.lua
@@ -8,8 +8,8 @@ logError = nil
 
 --// Commands
 --// Highly recommended you disable Intellesense before editing this...
-return function(Vargs, envVars, GetEnv)
-	local env = GetEnv(getfenv(), envVars)
+return function(Vargs, GetEnv)
+	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
 
 	local server = Vargs.Server;

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -18,8 +18,8 @@ function disableAllGUIs(folder)
 end;
 
 --// Core
-return function(Vargs, envVars, GetEnv)
-	local env = GetEnv(getfenv(), envVars)
+return function(Vargs, GetEnv)
+	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
 
 	local server = Vargs.Server;

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -3,8 +3,8 @@ service = nil
 cPcall = nil
 
 --// Function stuff
-return function(Vargs, envVars, GetEnv)
-	local env = GetEnv(getfenv(), envVars)
+return function(Vargs, GetEnv)
+	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
 
 	local logError

--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -7,8 +7,8 @@ origEnv = nil
 logError = nil
 
 --// HTTP
-return function(Vargs, envVars, GetEnv)
-	local env = GetEnv(getfenv(), envVars)
+return function(Vargs, GetEnv)
+	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
 
 	local server = Vargs.Server;

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -7,8 +7,8 @@ origEnv = nil
 logError = nil
 
 --// Special Variables
-return function(Vargs, envVars, GetEnv)
-	local env = GetEnv(getfenv(), envVars)
+return function(Vargs, GetEnv)
+	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
 
 	local server = Vargs.Server;

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -7,8 +7,8 @@ origEnv = nil
 logError = nil
 
 --// Processing
-return function(Vargs, envVars, GetEnv)
-	local env = GetEnv(getfenv(), envVars)
+return function(Vargs, GetEnv)
+	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
 
 	local server = Vargs.Server;

--- a/MainModule/Server/Core/Remote.lua
+++ b/MainModule/Server/Core/Remote.lua
@@ -7,8 +7,8 @@ origEnv = nil
 logError = nil
 
 --// Remote
-return function(Vargs, envVars, GetEnv)
-	local env = GetEnv(getfenv(), envVars)
+return function(Vargs, GetEnv)
+	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
 
 	local server = Vargs.Server;

--- a/MainModule/Server/Core/Variables.lua
+++ b/MainModule/Server/Core/Variables.lua
@@ -7,8 +7,8 @@ origEnv = nil
 logError = nil
 
 --// Special Variables
-return function(Vargs, envVars, GetEnv)
-	local env = GetEnv(getfenv(), envVars)
+return function(Vargs, GetEnv)
+	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
 
 	local server = Vargs.Server;
@@ -30,10 +30,9 @@ return function(Vargs, envVars, GetEnv)
 		Variables.BanMessage = Settings.BanMessage
 		Variables.LockMessage = Settings.LockMessage
 
-
-		for ind, music in next, Settings.MusicList or {} do table.insert(Variables.MusicList, music) end
-		for ind, music in next, Settings.InsertList or {} do table.insert(Variables.InsertList, music) end
-		for ind, cape in next, Settings.CapeList or {} do table.insert(Variables.Capes, cape) end
+		for ind, music in ipairs(Settings.MusicList or {}) do table.insert(Variables.MusicList, music) end
+		for ind, music in ipairs(Settings.InsertList or {}) do table.insert(Variables.InsertList, music) end
+		for ind, cape in ipairs(Settings.CapeList or {}) do table.insert(Variables.Capes, cape) end
 
 		Variables.Init = nil;
 		Logs:AddLog("Script", "Variables Module Initialized")


### PR DESCRIPTION
`Server Core Modules`:
All environment info will be hardcoded instead of sent for convenience.
No more environment being given as Adonis shouldn't need globals inside the scripts environment.

`Variables`:
Switch from next to ipairs

`Commands.Moderators`:
Optimizations and string formatting used.

`Client`:
New table `Changelog`: Stores changelog module contents inside client to prevent table gc spam.
log set to nil to prevent intellisense warnings.

`Client.UI.UserPanel`:
next -> ipairs/pairs
Using new cached Changelog table