### PR TITLE
Disable Active when NotificationHolder is created

### DIFF
--- a/MainModule/Client/UI/Default/Notification.rbxmx
+++ b/MainModule/Client/UI/Default/Notification.rbxmx
@@ -118,6 +118,7 @@ return function(data)
 	if not holder then
 		client.UI.Make("NotificationHolder")
 		holder = client.UI.Get("NotificationHolder",nil,true)
+		holder.Object.ScrollingFrame.Active = false
 	end
 	
 	holder = holder.Object.ScrollingFrame


### PR DESCRIPTION
fixes scrollingframe being interactable when holding right click above a notification if that makes sense