### PR TITLE
Mark `:trigger` as a fun command

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -232,6 +232,7 @@ return function(Vargs, env)
 			Prefix = Settings.Prefix;
 			Commands = {"trigger"};
 			Args = {"player"};
+			Fun = true;
 			Description = "Makes the target player really angry";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})


### PR DESCRIPTION
Makes it so that disabling `settings.FunCommands` (in settings module) will disable `:trigger`