### PR TITLE
Change "Transparency" command to make everything transparent

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -4337,6 +4337,19 @@ return function(Vargs, env)
 						for k, p in pairs(v.Character:GetChildren()) do
 							if p:IsA("BasePart") and p.Name ~= "HumanoidRootPart" then
 								p.Transparency = args[2]
+								if (p.Name == "Head") then
+									for _, v2 in pairs(p:GetChildren()) do
+										if v2:IsA("Decal") then
+											v2.Transparency = args[2]
+										end
+									end
+								end
+							elseif (p:IsA("Accessory") and #p:GetChildren() ~= 0) then
+								for _, v2 in pairs(p:GetChildren()) do
+									if v2:IsA("BasePart") then
+										v2.Transparency = args[2]
+									end
+								end
 							end
 						end
 					end


### PR DESCRIPTION
Mentioned in a pull request for "transparentpart" command, that I would consider making the "transparency" command make everything transparent by default, and allow the "transparentpart" command to be the more advanced version of the "transparency" command.

However, for now, I guess we can keep the "all" argument for "transparentpart" anyways.