### PR TITLE
Enhanced the "CharacterAudio" command

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -4673,14 +4673,31 @@ return function(Vargs, env)
 		CharacterAudio = {
 			Prefix = Settings.Prefix;
 			Commands = {"charaudio", "charactermusic", "charmusic"};
-			Args = {"player", "audioId"};
+			Args = {"player", "audioId", "volume", "loop(true/false)", "pitch"};
 			Description = "Lets you place an audio in the target's character";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing player name")
 				assert(args[2] and tonumber(args[2]), "Missing or invalid AudioId")
+				
+				local volume = tonumber(args[3]) or 1
+				local looped = args[4]
+				local pitch = tonumber(args[5]) or 1
+				
+				if (looped) then
+					if looped == "true" or looped == "1" then
+						looped = true
+					else
+						looped = false
+					end
+				else
+					looped = true -- should be on by default
+				end
+				
 				local audio = service.New("Sound", {
-					Looped = true;
+					Volume = volume;
+					Looped = looped;
+					Pitch = pitch;
 					Name = "ADONIS_AUDIO";
 					SoundId = "rbxassetid://"..args[2];
 				})
@@ -4690,6 +4707,13 @@ return function(Vargs, env)
 					local rootPart = char and char:FindFirstChild("HumanoidRootPart")
 					if rootPart then
 						local new = audio:Clone()
+						print(new.TimeLength)
+						if (looped == false) then
+							new.Ended:Connect(function() 
+								new:Destroy() -- Destroy character audio after sound is finished if loop is off.
+							end)
+						end
+
 						new.Parent = rootPart
 						new:Play()
 					end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -4707,7 +4707,7 @@ return function(Vargs, env)
 					local rootPart = char and char:FindFirstChild("HumanoidRootPart")
 					if rootPart then
 						local new = audio:Clone()
-						print(new.TimeLength)
+
 						if (looped == false) then
 							new.Ended:Connect(function() 
 								new:Destroy() -- Destroy character audio after sound is finished if loop is off.


### PR DESCRIPTION
It now has additional arguments for "volume", "looped" and "pitch"

Another thing is that if the loop is disabled, that it will delete the sound once it has finished playing.

I used ``:Connect()`` for that and then it destroys itself. Not sure if "Debris" should be used, but I tried it as well, both worked alright.