### PR TITLE
Update `Functions.Notification` to use `server.MatIcons`, allow player command notifications to be disabled

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -288,6 +288,7 @@ local descs = {};			--// Contains settings descriptions
 
 	settings.FunCommands = true			-- Are fun commands enabled?
 	settings.PlayerCommands = true 	-- Are players commands enabled?
+	settings.PlayerCommandFeedback = true -- Should players be notified when commands with non-obvious effects are run on them?
 	settings.CrossServerCommands = true -- Are commands which affect more than one server enabled?
 	settings.ChatCommands = true 		-- If false you will not be able to run commands via the chat; Instead you MUST use the console or you will be unable to run commands
 	settings.CreatorPowers = true		-- Gives me creator level admin; This is strictly used for debugging; I can't debug without full access to the script
@@ -399,6 +400,7 @@ local descs = {};			--// Contains settings descriptions
 
 	descs.FunCommands = [[ Are fun commands enabled? ]]
 	descs.PlayerCommands = [[ Are players commands enabled? ]]
+	descs.PlayerCommandFeedback = [[ Should players be notified when commands with non-obvious effects are run on them? ]]
 	descs.CrossServerCommands = [[ Are commands which affect more than one server enabled? ]]
 	descs.ChatCommands = [[ If false you will not be able to run commands via the chat; Instead you MUST use the console or you will be unable to run commands ]]
 
@@ -495,6 +497,7 @@ local descs = {};			--// Contains settings descriptions
 		" ";
 		"FunCommands";
 		"PlayerCommands";
+		"PlayerCommandFeedback";
 		"CrossServerCommands";
 		"ChatCommands";
 		"CreatorPowers";

--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -288,7 +288,7 @@ local descs = {};			--// Contains settings descriptions
 
 	settings.FunCommands = true			-- Are fun commands enabled?
 	settings.PlayerCommands = true 	-- Are players commands enabled?
-	settings.PlayerCommandFeedback = true -- Should players be notified when commands with non-obvious effects are run on them?
+	settings.PlayerCommandFeedback = false -- Should players be notified when commands with non-obvious effects are run on them?
 	settings.CrossServerCommands = true -- Are commands which affect more than one server enabled?
 	settings.ChatCommands = true 		-- If false you will not be able to run commands via the chat; Instead you MUST use the console or you will be unable to run commands
 	settings.CreatorPowers = true		-- Gives me creator level admin; This is strictly used for debugging; I can't debug without full access to the script

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -779,7 +779,7 @@ return function(Vargs, env)
 						Humanoid.MaxHealth = math.huge
 						Humanoid.Health = 9e9
 						if Settings.PlayerCommandFeedback then
-							Functions.Hint("Character God mode has been enabled.", {v})
+							Functions.Notification("God mode", "Character God mode has been enabled. You will not take damage from non-explosive weapons.", {v}, 15, "Info")
 						end
 					end
 				end
@@ -802,7 +802,7 @@ return function(Vargs, env)
 						Humanoid.MaxHealth = 100
 						Humanoid.Health = Humanoid.MaxHealth
 						if Settings.PlayerCommandFeedback then
-							Functions.Hint("Character God mode has been disabled.", {v})
+							Functions.Notification("God mode", "Character God mode has been disabled.", {v}, 15, "Info")
 						end
 					end
 				end
@@ -2380,7 +2380,7 @@ return function(Vargs, env)
 					new.Parent = p.Character.Humanoid
 					new.Disabled = false
 					if Settings.PlayerCommandFeedback then
-						Functions.Hint("Character noclip has been enabled.", {p})
+						Functions.Notification("Noclip", "Character noclip has been enabled. You will now be able to walk though walls.", {p}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
 					end
 				end
 			end
@@ -2422,7 +2422,7 @@ return function(Vargs, env)
 						wait(0.5)
 						old:Destroy()
 						if Settings.PlayerCommandFeedback then
-							Functions.Hint("Character noclip has been disabled.", {p})
+							Functions.Notification("Noclip", "Character noclip has been disabled. You will no longer be able to walk though walls.", {p}, 15, "Info") -- Functions.Notification(title,message,player,time,icon)
 						end 
 					end
 				end
@@ -3951,7 +3951,11 @@ return function(Vargs, env)
 					if Humanoid then
 						Humanoid.WalkSpeed = args[2] or 16
 						if Settings.PlayerCommandFeedback then
-							Functions.Hint("Character walk speed has been set to ".. (args[2] or 16), {v})
+							Remote.MakeGui(v, "Notification", {
+								Title = "Notification";
+								Message = "Character walk speed has been set to ".. (args[2] or 16);
+								Time = 15;
+							})
 						end
 					end
 				end
@@ -3974,7 +3978,7 @@ return function(Vargs, env)
 						if string.sub(string.lower(tm.Name), 1,#args[2]) == string.lower(args[2]) then
 							v.Team = tm
 							if Settings.PlayerCommandFeedback then
-								Functions.Hint("You are now on the '"..tm.Name.."' team.", {v})
+								Functions.Notification("Team", "You are now on the '"..tm.Name.."' team.", {v}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
 							end
 						end
 					end
@@ -4056,7 +4060,7 @@ return function(Vargs, env)
 					player.Team = nil
 					player.TeamColor = BrickColor.new(194) -- Neutral Team
 					if Settings.PlayerCommandFeedback then
-						Functions.Hint("Your team has been reset and you are now on the Neutral team.", {player})
+						Functions.Notification("Team", "Your team has been reset and you are now on the Neutral team.", {player}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
 					end
 				end
 			end
@@ -5118,7 +5122,11 @@ return function(Vargs, env)
 							if sVal then
 								sVal.Value = speed
 								if Settings.PlayerCommandFeedback then
-									Functions.Hint("Character fly speed has been set to "..speed, {v})
+									Remote.MakeGui(v, "Notification", {
+										Title = "Notification";
+										Message = "Character fly speed has been set to "..speed;
+										Time = 15;
+									})
 								end
 							end
 						end
@@ -5943,7 +5951,11 @@ return function(Vargs, env)
 					freecam.Freecam.Disabled = false
 					freecam.Parent = plrgui
 					if Settings.PlayerCommandFeedback then
-						Functions.Hint("Freecam has been enabled. Press Shift+P to toggle freecam on or off.", {v})
+						Remote.MakeGui(v, "Notification", {
+							Title = "Notification";
+							Message = "Freecam has been enabled. Press Shift+P to toggle freecam on or off.";
+							Time = 15;
+						})
 					end
 				end
 			end
@@ -5972,7 +5984,11 @@ return function(Vargs, env)
 						service.Debris:AddItem(freecam, 2)
 
 						if Settings.PlayerCommandFeedback then
-							Functions.Hint("Freecam has been disabled.", {v})
+							Remote.MakeGui(v, "Notification", {
+								Title = "Notification";
+								Message = "Freecam has been disabled.";
+								Time = 15;
+							})
 						end
 					end
 				end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -778,7 +778,7 @@ return function(Vargs, env)
 					if Humanoid then
 						Humanoid.MaxHealth = math.huge
 						Humanoid.Health = 9e9
-						Functions.Notification("God mode", "Character God mode has been enabled. You will not take damage from non-explosive weapons.", {v}, 15, 7510999669)
+						Functions.Notification("God mode", "Character God mode has been enabled. You will not take damage from non-explosive weapons.", {v}, 15, "Info")
 					end
 				end
 			end
@@ -799,7 +799,7 @@ return function(Vargs, env)
 					if Humanoid then
 						Humanoid.MaxHealth = 100
 						Humanoid.Health = Humanoid.MaxHealth
-						Functions.Notification("God mode", "Character God mode has been disabled.", {v}, 15, 7510999669)
+						Functions.Notification("God mode", "Character God mode has been disabled.", {v}, 15, "Info")
 					end
 				end
 			end
@@ -2375,7 +2375,7 @@ return function(Vargs, env)
 					local new = clipper:Clone()
 					new.Parent = p.Character.Humanoid
 					new.Disabled = false
-					Functions.Notification("Noclip", "Character noclip has been enabled. You will now be able to walk though walls.", {p}, 15, 7510999669) -- Functions.Notification(title,message,player,time,icon) - note that icon is the AssetId without "rbxassetid://" at the start
+					Functions.Notification("Noclip", "Character noclip has been enabled. You will now be able to walk though walls.", {p}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
 				end
 			end
 		};
@@ -2415,7 +2415,7 @@ return function(Vargs, env)
 						old.Parent = nil
 						wait(0.5)
 						old:Destroy()
-						Functions.Notification("Noclip", "Character noclip has been disabled. You will no longer be able to walk though walls.", {p}, 15, 7510999669) -- Functions.Notification(title,message,player,time,icon) - note that icon is the AssetId without "rbxassetid://" at the start
+						Functions.Notification("Noclip", "Character noclip has been disabled. You will no longer be able to walk though walls.", {p}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
 					end
 				end
 			end
@@ -3967,7 +3967,7 @@ return function(Vargs, env)
 					for a, tm in ipairs(service.Teams:GetChildren()) do
 						if string.sub(string.lower(tm.Name), 1,#args[2]) == string.lower(args[2]) then
 							v.Team = tm
-							Functions.Notification("Team", "You are now on the '"..tm.Name.."' team.", {v}, 15, 7510999669) -- Functions.Notification(title,message,player,time,icon) - note that icon is the AssetId without "rbxassetid://" at the start
+							Functions.Notification("Team", "You are now on the '"..tm.Name.."' team.", {v}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
 						end
 					end
 				end
@@ -4047,7 +4047,7 @@ return function(Vargs, env)
 					player.Neutral = true
 					player.Team = nil
 					player.TeamColor = BrickColor.new(194) -- Neutral Team
-					Functions.Notification("Team", "Your team has been reset and you are now on the Neutral team.", {player}, 15, 7510999669) -- Functions.Notification(title,message,player,time,icon) - note that icon is the AssetId without "rbxassetid://" at the start
+					Functions.Notification("Team", "Your team has been reset and you are now on the Neutral team.", {player}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
 				end
 			end
 		};

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -778,7 +778,9 @@ return function(Vargs, env)
 					if Humanoid then
 						Humanoid.MaxHealth = math.huge
 						Humanoid.Health = 9e9
-						Functions.Notification("God mode", "Character God mode has been enabled. You will not take damage from non-explosive weapons.", {v}, 15, "Info")
+						if Settings.PlayerCommandFeedback then
+							Functions.Notification("God mode", "Character God mode has been enabled. You will not take damage from non-explosive weapons.", {v}, 15, "Info")
+						end
 					end
 				end
 			end
@@ -799,7 +801,9 @@ return function(Vargs, env)
 					if Humanoid then
 						Humanoid.MaxHealth = 100
 						Humanoid.Health = Humanoid.MaxHealth
-						Functions.Notification("God mode", "Character God mode has been disabled.", {v}, 15, "Info")
+						if Settings.PlayerCommandFeedback then
+							Functions.Notification("God mode", "Character God mode has been disabled.", {v}, 15, "Info")
+						end
 					end
 				end
 			end
@@ -2375,7 +2379,9 @@ return function(Vargs, env)
 					local new = clipper:Clone()
 					new.Parent = p.Character.Humanoid
 					new.Disabled = false
-					Functions.Notification("Noclip", "Character noclip has been enabled. You will now be able to walk though walls.", {p}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
+					if Settings.PlayerCommandFeedback then
+						Functions.Notification("Noclip", "Character noclip has been enabled. You will now be able to walk though walls.", {p}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
+					end
 				end
 			end
 		};
@@ -2415,7 +2421,9 @@ return function(Vargs, env)
 						old.Parent = nil
 						wait(0.5)
 						old:Destroy()
-						Functions.Notification("Noclip", "Character noclip has been disabled. You will no longer be able to walk though walls.", {p}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
+						if Settings.PlayerCommandFeedback then
+							Functions.Notification("Noclip", "Character noclip has been disabled. You will no longer be able to walk though walls.", {p}, 15, "Info") -- Functions.Notification(title,message,player,time,icon)
+						end 
 					end
 				end
 			end
@@ -3942,11 +3950,13 @@ return function(Vargs, env)
 
 					if Humanoid then
 						Humanoid.WalkSpeed = args[2] or 16
-						Remote.MakeGui(v, "Notification", {
-							Title = "Notification";
-							Message = "Character walk speed has been set to ".. (args[2] or 16);
-							Time = 15;
-						})
+						if Settings.PlayerCommandFeedback then
+							Remote.MakeGui(v, "Notification", {
+								Title = "Notification";
+								Message = "Character walk speed has been set to ".. (args[2] or 16);
+								Time = 15;
+							})
+						end
 					end
 				end
 			end
@@ -3967,7 +3977,9 @@ return function(Vargs, env)
 					for a, tm in ipairs(service.Teams:GetChildren()) do
 						if string.sub(string.lower(tm.Name), 1,#args[2]) == string.lower(args[2]) then
 							v.Team = tm
-							Functions.Notification("Team", "You are now on the '"..tm.Name.."' team.", {v}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
+							if Settings.PlayerCommandFeedback then
+								Functions.Notification("Team", "You are now on the '"..tm.Name.."' team.", {v}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
+							end
 						end
 					end
 				end
@@ -4047,7 +4059,9 @@ return function(Vargs, env)
 					player.Neutral = true
 					player.Team = nil
 					player.TeamColor = BrickColor.new(194) -- Neutral Team
-					Functions.Notification("Team", "Your team has been reset and you are now on the Neutral team.", {player}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
+					if Settings.PlayerCommandFeedback then
+						Functions.Notification("Team", "Your team has been reset and you are now on the Neutral team.", {player}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
+					end
 				end
 			end
 		};
@@ -5107,11 +5121,13 @@ return function(Vargs, env)
 							local sVal = scr:FindFirstChild("Speed")
 							if sVal then
 								sVal.Value = speed
-								Remote.MakeGui(v, "Notification", {
-									Title = "Notification";
-									Message = "Character fly speed has been set to "..speed;
-									Time = 15;
-								})
+								if Settings.PlayerCommandFeedback then
+									Remote.MakeGui(v, "Notification", {
+										Title = "Notification";
+										Message = "Character fly speed has been set to "..speed;
+										Time = 15;
+									})
+								end
 							end
 						end
 					end
@@ -5934,11 +5950,13 @@ return function(Vargs, env)
 					freecam.ResetOnSpawn = false
 					freecam.Freecam.Disabled = false
 					freecam.Parent = plrgui
-					Remote.MakeGui(v, "Notification", {
-						Title = "Notification";
-						Message = "Freecam has been enabled. Press Shift+P to toggle freecam on or off.";
-						Time = 15;
-					})
+					if Settings.PlayerCommandFeedback then
+						Remote.MakeGui(v, "Notification", {
+							Title = "Notification";
+							Message = "Freecam has been enabled. Press Shift+P to toggle freecam on or off.";
+							Time = 15;
+						})
+					end
 				end
 			end
 		};
@@ -5965,11 +5983,13 @@ return function(Vargs, env)
 						Remote.Send(v, "Function", "SetView", "reset")
 						service.Debris:AddItem(freecam, 2)
 
-						Remote.MakeGui(v, "Notification", {
-							Title = "Notification";
-							Message = "Freecam has been disabled.";
-							Time = 15;
-						})
+						if Settings.PlayerCommandFeedback then
+							Remote.MakeGui(v, "Notification", {
+								Title = "Notification";
+								Message = "Freecam has been disabled.";
+								Time = 15;
+							})
+						end
 					end
 				end
 			end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -155,7 +155,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing player name")
-				assert(args[2], "You need to provide a message to the player")
+				assert(args[2], "Missing message")
 
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
 					Remote.MakeGui(v, "Notification", {
@@ -193,7 +193,7 @@ return function(Vargs, env)
 			Description = "Countdown";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				local num = assert(tonumber(args[1]), "Enter a time for countdown")
+				local num = assert(tonumber(args[1]), "Missing or invalid time value (must be a number)")
 
 				for _, v in ipairs(service.GetPlayers()) do
 					Remote.MakeGui(v, "Countdown", {
@@ -269,8 +269,8 @@ return function(Vargs, env)
 			Description = "Make a message and makes it stay for the amount of time (in seconds) you supply";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				assert(args[1], "You need to specify the amount of time")
-				assert(args[2], "You forgot to supply a message!")
+				assert(args[1], "Missing or invalid time amount")
+				assert(args[2], "Missing message")
 				local messageRecipient = string.format("Message from %s (@%s)", plr.DisplayName, plr.Name)
 				for _, v in ipairs(service.GetPlayers()) do
 					Remote.RemoveGui(v, "Message")

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -779,7 +779,7 @@ return function(Vargs, env)
 						Humanoid.MaxHealth = math.huge
 						Humanoid.Health = 9e9
 						if Settings.PlayerCommandFeedback then
-							Functions.Notification("God mode", "Character God mode has been enabled. You will not take damage from non-explosive weapons.", {v}, 15, "Info")
+							Functions.Hint("Character God mode has been enabled.", {v})
 						end
 					end
 				end
@@ -802,7 +802,7 @@ return function(Vargs, env)
 						Humanoid.MaxHealth = 100
 						Humanoid.Health = Humanoid.MaxHealth
 						if Settings.PlayerCommandFeedback then
-							Functions.Notification("God mode", "Character God mode has been disabled.", {v}, 15, "Info")
+							Functions.Hint("Character God mode has been disabled.", {v})
 						end
 					end
 				end
@@ -2380,7 +2380,7 @@ return function(Vargs, env)
 					new.Parent = p.Character.Humanoid
 					new.Disabled = false
 					if Settings.PlayerCommandFeedback then
-						Functions.Notification("Noclip", "Character noclip has been enabled. You will now be able to walk though walls.", {p}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
+						Functions.Hint("Character noclip has been enabled.", {p})
 					end
 				end
 			end
@@ -2422,7 +2422,7 @@ return function(Vargs, env)
 						wait(0.5)
 						old:Destroy()
 						if Settings.PlayerCommandFeedback then
-							Functions.Notification("Noclip", "Character noclip has been disabled. You will no longer be able to walk though walls.", {p}, 15, "Info") -- Functions.Notification(title,message,player,time,icon)
+							Functions.Hint("Character noclip has been disabled.", {p})
 						end 
 					end
 				end
@@ -3951,11 +3951,7 @@ return function(Vargs, env)
 					if Humanoid then
 						Humanoid.WalkSpeed = args[2] or 16
 						if Settings.PlayerCommandFeedback then
-							Remote.MakeGui(v, "Notification", {
-								Title = "Notification";
-								Message = "Character walk speed has been set to ".. (args[2] or 16);
-								Time = 15;
-							})
+							Functions.Hint("Character walk speed has been set to ".. (args[2] or 16), {v})
 						end
 					end
 				end
@@ -3978,7 +3974,7 @@ return function(Vargs, env)
 						if string.sub(string.lower(tm.Name), 1,#args[2]) == string.lower(args[2]) then
 							v.Team = tm
 							if Settings.PlayerCommandFeedback then
-								Functions.Notification("Team", "You are now on the '"..tm.Name.."' team.", {v}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
+								Functions.Hint("You are now on the '"..tm.Name.."' team.", {v})
 							end
 						end
 					end
@@ -4060,7 +4056,7 @@ return function(Vargs, env)
 					player.Team = nil
 					player.TeamColor = BrickColor.new(194) -- Neutral Team
 					if Settings.PlayerCommandFeedback then
-						Functions.Notification("Team", "Your team has been reset and you are now on the Neutral team.", {player}, 15, "Info") -- Functions.Notification(title,message,player,time,icon) 
+						Functions.Hint("Your team has been reset and you are now on the Neutral team.", {player})
 					end
 				end
 			end
@@ -5122,11 +5118,7 @@ return function(Vargs, env)
 							if sVal then
 								sVal.Value = speed
 								if Settings.PlayerCommandFeedback then
-									Remote.MakeGui(v, "Notification", {
-										Title = "Notification";
-										Message = "Character fly speed has been set to "..speed;
-										Time = 15;
-									})
+									Functions.Hint("Character fly speed has been set to "..speed, {v})
 								end
 							end
 						end
@@ -5951,11 +5943,7 @@ return function(Vargs, env)
 					freecam.Freecam.Disabled = false
 					freecam.Parent = plrgui
 					if Settings.PlayerCommandFeedback then
-						Remote.MakeGui(v, "Notification", {
-							Title = "Notification";
-							Message = "Freecam has been enabled. Press Shift+P to toggle freecam on or off.";
-							Time = 15;
-						})
+						Functions.Hint("Freecam has been enabled. Press Shift+P to toggle freecam on or off.", {v})
 					end
 				end
 			end
@@ -5984,11 +5972,7 @@ return function(Vargs, env)
 						service.Debris:AddItem(freecam, 2)
 
 						if Settings.PlayerCommandFeedback then
-							Remote.MakeGui(v, "Notification", {
-								Title = "Notification";
-								Message = "Freecam has been disabled.";
-								Time = 15;
-							})
+							Functions.Hint("Freecam has been disabled.", {v})
 						end
 					end
 				end

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -810,13 +810,13 @@ return function(Vargs, GetEnv)
 			end
 		end;
 
-		Notification = function(title,message,players,tim,icon) -- note that icon is the AssetId without "rbxassetid://" at the start
+		Notification = function(title,message,players,tim,icon)
 			for i,v in pairs(players) do
 				Remote.MakeGui(v,"Notification",{
 					Title = title;
 					Message = message;
 					Time = tim;
-					Icon = string.format("rbxassetid://%d", icon or "7510999669") -- use default 'i' icon if icon argument is missing
+					Icon = server.MatIcons[icon or "Info"]  -- use default 'i' icon if icon argument is missing
 				})
 			end
 		end;

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -288,6 +288,7 @@ local descs = {};			--// Contains settings descriptions
 
 	settings.FunCommands = true			-- Are fun commands enabled?
 	settings.PlayerCommands = true 	-- Are players commands enabled?
+	settings.PlayerCommandFeedback = true -- Should players be notified when commands with non-obvious effects are run on them?
 	settings.CrossServerCommands = true -- Are commands which affect more than one server enabled?
 	settings.ChatCommands = true 		-- If false you will not be able to run commands via the chat; Instead you MUST use the console or you will be unable to run commands
 	settings.CreatorPowers = true		-- Gives me creator level admin; This is strictly used for debugging; I can't debug without full access to the script
@@ -399,6 +400,7 @@ local descs = {};			--// Contains settings descriptions
 
 	descs.FunCommands = [[ Are fun commands enabled? ]]
 	descs.PlayerCommands = [[ Are players commands enabled? ]]
+	descs.PlayerCommandFeedback = [[ Should players be notified when commands with non-obvious effects are run on them? ]]
 	descs.CrossServerCommands = [[ Are commands which affect more than one server enabled? ]]
 	descs.ChatCommands = [[ If false you will not be able to run commands via the chat; Instead you MUST use the console or you will be unable to run commands ]]
 
@@ -495,6 +497,7 @@ local descs = {};			--// Contains settings descriptions
 		" ";
 		"FunCommands";
 		"PlayerCommands";
+		"PlayerCommandFeedback";
 		"CrossServerCommands";
 		"ChatCommands";
 		"CreatorPowers";

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -288,7 +288,7 @@ local descs = {};			--// Contains settings descriptions
 
 	settings.FunCommands = true			-- Are fun commands enabled?
 	settings.PlayerCommands = true 	-- Are players commands enabled?
-	settings.PlayerCommandFeedback = true -- Should players be notified when commands with non-obvious effects are run on them?
+	settings.PlayerCommandFeedback = false -- Should players be notified when commands with non-obvious effects are run on them?
 	settings.CrossServerCommands = true -- Are commands which affect more than one server enabled?
 	settings.ChatCommands = true 		-- If false you will not be able to run commands via the chat; Instead you MUST use the console or you will be unable to run commands
 	settings.CreatorPowers = true		-- Gives me creator level admin; This is strictly used for debugging; I can't debug without full access to the script


### PR DESCRIPTION
- Update `Functions.Notification` to use the icon system introduced in #533 
- Shortened some assert messages in `moderators.lua`
- Allows the player command notifications introduced in #513 to be disabled (set `settings.PlayerCommandFeedback` to `false`)
This was done due to the notifications getting spammy and not everyone wants to hear notification sounds whenever someone runs a command on them.