### PR TITLE
Add TrelloBan reason support.

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1134,9 +1134,16 @@ return function(Vargs, env)
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				Remote.MakeGui(plr , "List", {
+				local banned = {}
+				for i, banData in ipairs(HTTP.Trello.Bans) do
+					table.insert(banned, {
+						Text = banData.Name,
+						Desc = banData.Reason or "No reason specified",
+					})
+				end
+				Remote.MakeGui(plr ,"List", {
 					Title = "Synced Ban List";
-					Tab = HTTP.Trello.Bans;
+					Tab = banned;
 				})
 			end
 		};

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -712,7 +712,7 @@ return function(Vargs, GetEnv)
 
 			for ind,admin in pairs(HTTP.Trello.Bans) do
 				if doCheck(p, admin) or banCheck(p, admin) then
-					return true, (type(admin) == "table" and admin.Reason)
+					return true, (type(admin) == "table" and admin.Reason and service.Filter(admin.Reason, p, p))
 				end
 			end
 

--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -82,6 +82,7 @@ return function(Vargs, GetEnv)
 				if not HTTP.CheckHttp() then
 					--HTPP.Trello.Bans = {'Http is not enabled! Cannot connect to Trello!'}
 					warn('Http is not enabled! Cannot connect to Trello!')
+					return;
 				else
 					local admins, mods, HeadAdmins, creators = {}, {}, {}, {}
 					local bans = {}
@@ -129,7 +130,14 @@ return function(Vargs, GetEnv)
 							end
 						end
 
-						getNames(banList, bans);
+						-- Reasons will be filtered inside Admin.CheckBan
+						for i, cardData in ipairs(banList.cards or trello.getCards(banList.id)) do
+							table.insert(bans, {
+								Name = cardData.name,
+								Reason = cardData.desc,
+							})
+						end
+
 						getNames(creatorList , creators);
 						getNames(modList, mods);
 						getNames(adminList, admins)
@@ -277,8 +285,10 @@ return function(Vargs, GetEnv)
 					Variables.Whitelist.Lists.Trello = whitelist
 
 					for i, v in pairs(service.GetPlayers()) do
-						if Admin.CheckBan(v) then
-							v:Kick(Variables.BanMessage)
+						local isBanned, Reason = Admin.CheckBan(v)
+						if isBanned then
+							v:Kick(string.format("%s | Reason: %s", Variables.BanMessage, (Reason or "No reason provided")))
+							continue
 						end
 
 						if v and v.Parent then


### PR DESCRIPTION
`Moderators`:
Convert from new format to supported format.

`Admin`:
If a reason is found it will filter the message with the player itself. (tested and will filter)
 * This will expose the players name which banned the user.

`HTTP`:
Banned cards support new format to provide a reason.
Banned check on GetPlayers fixed and also continues if the user is banned in order to prevent code from being continued even though they've been kicked.
