### PR TITLE
Feat: Added leave logs

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -5833,6 +5833,29 @@ return function(Vargs, env)
 				})
 			end
 		};
+		
+		LeaveLogs = {
+			Prefix = Settings.Prefix;
+			Commands = {"leavelogs", "leaves", "leavehistory"};
+			Args = {"autoupdate"};
+			Hidden = false;
+			Description = "Displays the current leave logs for the server";
+			Fun = false;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local auto
+				if args[1] and type(args[1]) == "string" and (string.lower(args[1]) == "yes" or string.lower(args[1]) == "true") then
+					auto = 1
+				end
+				Remote.MakeGui(plr, "List", {
+					Title = "Leave Logs";
+					Tab = Logs.Leaves;
+					Dots = true;
+					Update = "LeaveLogs";
+					AutoUpdate = auto;
+				})
+			end
+		};
 
 		ChatLogs = {
 			Prefix = Settings.Prefix;

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -268,6 +268,12 @@ return function(Vargs, GetEnv)
 					return Logs.Joins
 				end
 			end;
+			
+			LeaveLogs = function(plr)
+				if not plr or Admin.CheckAdmin(plr) then
+					return Logs.Leaves
+				end
+			end;
 
 			PlayerList = function(p)
 				if not p or Admin.CheckAdmin(p) then

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -40,6 +40,7 @@ return function(Vargs, GetEnv)
 		Init = Init;
 		Chats = {};
 		Joins = {};
+                Leaves = {};
 		Script = {};
 		RemoteFires = {};
 		Commands = {};
@@ -54,6 +55,7 @@ return function(Vargs, GetEnv)
 			local indToName = {
 				Chats = "Chat";
 				Joins = "Join";
+                                Leaves = "Leave"
 				Script = "Script";
 				RemoteFires = "RemoteFire";
 				Commands = "Command";

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -678,6 +678,12 @@ return function(Vargs, GetEnv)
 				Desc = "Player left the game (PlayerRemoving)";
 				Player = p;
 			})
+			
+			AddLog("Leaves",{
+				Text = p.Name;
+				Desc = p.Name.." left the server";
+				Player = p;
+			})
 
 			Core.SavePlayerData(p, data)
 			return;


### PR DESCRIPTION
New command for moderators: `:leavelogs`, `:leaves` or `:leavehistory`. These logs (as the name suggests) logs the players who leave the game. 