### PR TITLE
Fix head size multiplying twice on R6 characters

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -3797,7 +3797,7 @@ return function(Vargs, env)
 								if mesh then
 									mesh.Scale *= num
 								end
-							elseif v:IsA("SpecialMesh") and v.Parent.Name ~= "Handle" then
+							elseif v:IsA("SpecialMesh") and v.Parent.Name ~= "Handle" and v.Parent.Name ~= "Head" then
 								v.Scale *= num
 							end
 						end


### PR DESCRIPTION
When using the :resize command, the user's head mesh is also resized along with the part, causing the head to either be way too large or way too small. This PR fixes this issue by checking if the parent of the mesh's name isn't "Head" before resizing the mesh too.

Co-Authored-By: LykaonBotkin <65002282+LykaonBotkin@users.noreply.github.com>

Closes #663