### PR TITLE
Update Moderators.lua

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -16,7 +16,7 @@ return function(Vargs, env)
 		AudioPlayer = {
 			Prefix = Settings.Prefix;
 			Commands = {"audioplayer", "mediaplayer", "musicplayer", "soundplayer", "player", "ap"};
-			Args = {"time"};
+			Args = {"player"};
 			Description = "Opens an audio player window";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})


### PR DESCRIPTION
changed AudioPlayer argument 1 from 'time' to 'player' because it has nothing to do with time (it's a getPlayers in the command function)