### PR TITLE
Only deploy Nightly MainModule on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
         run: rojo build .github/build.project.json -o Adonis_Nightly_${{ steps.date.outputs.date }}.rbxm
 
       - name: Deploy Nightly MainModule
+        if: github.event_name == 'push'
         run: rojo upload --cookie "${{ secrets.ROBLOSECURITY }}" --asset_id "${{ secrets.NIGHTLY_MODULE_ID }}" .github/module.deploy.project.json
 
       - uses: actions/upload-artifact@v2
@@ -34,7 +35,7 @@ jobs:
 
       - name: Send file nightly build to Discord channel
         uses: tsickert/discord-webhook@v3.0.0
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         with:
           webhook-url: ${{ secrets.NIGHTLY_WEBHOOK }}
           filename: Adonis_Nightly_${{ steps.date.outputs.date }}.rbxm


### PR DESCRIPTION
When the nightly main module was added, it did not check if it was a pull request to update the main module. This would be unexpected behavior, however, the pull request actions failed, as the pull_request event doesn't have access to secrets.