### PR TITLE
Update FormatTime for timeban date strings

### DIFF
--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -60,7 +60,7 @@ return function(Vargs, env)
 						table.insert(timebans, data)
 
 						-- Please make a Admin.AddTimeBan function like Admin.AddBan
-						v:Kick("\n Reason: "..reason.."\nBanned until ".. service.FormatTime(endTime, true))
+						v:Kick("\n Reason: "..reason.."\nBanned until ".. service.FormatTime(endTime, {WithWrittenDate = true}))
 						Functions.Hint("Saving timeban for ".. tostring(v.Name) .."...", {plr})
 
 						Core.DoSave({

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -534,7 +534,7 @@ return function(Vargs, env)
 
 					if data.Warnings then
 						for k, m in pairs(data.Warnings) do
-							table.insert(tab, {Text = "["..k.."] "..m.Message, Desc = "[".. service.FormatTime(m.Time, true) .."] Given by: "..m.From.."; "..m.Message})
+							table.insert(tab, {Text = "["..k.."] "..m.Message, Desc = "[".. service.FormatTime(m.Time, {WithDate = true}) .."] Given by: "..m.From.."; "..m.Message})
 						end
 					end
 

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -717,7 +717,7 @@ return function(Vargs, GetEnv)
 					if ban.EndTime-os.time() <= 0 then
 						table.remove(Core.Variables.TimeBans, ind)
 					else
-						return true, "\n Reason: "..(ban.Reason or "(No reason provided.)").."\n Banned until ".. service.FormatTime(ban.EndTime, true)
+						return true, "\n Reason: "..(ban.Reason or "(No reason provided.)").."\n Banned until ".. service.FormatTime(ban.EndTime, {WithWrittenDate = true})
 					end
 				end
 			end

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -975,17 +975,24 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 			return os.time();
 		end;
 
-		FormatTime = function(optTime, withDate)
-			local formatString = withDate and "L LT" or "LT"
+		FormatTime = function(optTime, options)
+			if not options then options = {} end
+					
+			local formatString = options.FormatString 
+			if not formatString then 
+				formatString = options.WithWrittenDate and "LL LT" or (options.WithDate and "L LT" or "LT") 
+			end
+					
 			local tim = DateTime.fromUnixTimestamp(optTime or service.GetTime())
+					
 			if service.RunService:IsServer() then
 				return tim:FormatUniversalTime(formatString, "en-gb") -- Always show UTC in 24 hour format
 			else
 				local locale = service.Players.LocalPlayer.LocaleId
-				local succes,err = pcall(function()
+				local success = pcall(function()
 					return tim:FormatLocalTime(formatString, locale) -- Show in player's local timezone and format
 				end)
-				if err then
+				if not success then
 					return tim:FormatLocalTime(formatString, "en-gb") -- show UTC in 24 hour format because player's local timezone is not available in DateTimeLocaleConfigs
 				end
 			end

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -977,24 +977,22 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 
 		FormatTime = function(optTime, options)
 			if not options then options = {} end
-					
+			
 			local formatString = options.FormatString 
 			if not formatString then 
-				formatString = options.WithWrittenDate and "LL LT" or (options.WithDate and "L LT" or "LT") 
+				formatString = options.WithWrittenDate and "LL HH:mm" or (options.WithDate and "L HH:mm" or "HH:mm") 
 			end
-					
+			
 			local tim = DateTime.fromUnixTimestamp(optTime or service.GetTime())
 					
 			if service.RunService:IsServer() then
-				return tim:FormatUniversalTime(formatString, "en-gb") -- Always show UTC in 24 hour format
+				return tim:FormatUniversalTime(formatString, "en-us")
 			else
 				local locale = service.Players.LocalPlayer.LocaleId
-				local success = pcall(function()
+				local success, str = pcall(function()
 					return tim:FormatLocalTime(formatString, locale) -- Show in player's local timezone and format
 				end)
-				if not success then
-					return tim:FormatLocalTime(formatString, "en-gb") -- show UTC in 24 hour format because player's local timezone is not available in DateTimeLocaleConfigs
-				end
+				return success and str or tim:FormatLocalTime(formatString, "en-us") -- Fallback if locale is not supported by DateTime
 			end
 		end;
 	


### PR DESCRIPTION
FormatTime now accepts an options table as the second argument, with `FormatString`, `WithDate`, and `WithWrittenDate` arguments.