### PR TITLE
Made urgentmessages only require when needed

### DIFF
--- a/MainModule/Server/Plugins/Urgent_Messages.lua
+++ b/MainModule/Server/Plugins/Urgent_Messages.lua
@@ -11,9 +11,26 @@ return function(Vargs)
 
 	warn("Requiring Alerts Module by ID; Expand for module URL > ", {URL = "https://www.roblox.com/library/8096250407/Adonis-Alerts-Module"})
 
-	local r, AlertTab = xpcall(require, function()
-		warn("Something went wrong while requiring the urgent messages module");
-	end, 8096250407)
+	local r, AlertTab
+	local LastUpdated = "2021-11-25T17:34:12.06Z"
+	local CurrentUpdated
+	local Success, _, ReturnedDate = xpcall(function()
+		CurrentUpdated = service.MarketplaceService:GetProductInfo(8096250407).Updated
+	end, function(err)
+		warn("An error occured while trying to get data of Adonis alerts module. Reason:", err)
+	end)
+
+	if LastUpdated ~= CurrentUpdated then
+		Logs:AddLog("Script", "A new version of the Adonis alerts was found, requiring cloud module. Last update:"..LastUpdated)
+		warn("A new version of the Adonis alerts was found, requiring cloud module. Last update:"..LastUpdated)
+		warn("Requiring Alerts Module by ID; URL > https://www.roblox.com/library/8096250407/Adonis-Alerts-Module")
+
+		r, AlertTab = xpcall(require, function(err)
+			warn("An error occured while requiring the urgent messages module. Reason:", err)
+		end, 8096250407)
+	else
+		Logs:AddLog("Script", "Adonis alerts module was required in offline mode because the version hasn't updated. Last update:"..LastUpdated)
+	end
 
 	local Alerts = (r and AlertTab) or require(Deps.__URGENT_MESSAGES)
 


### PR DESCRIPTION
This makes the urgent messages module only require the cloud version when out of date. So there won't be an annoying message in output anymore.

It also fixes a bug where the URL doesn't appear.
First on all non-studio instances the URL won't be shown, but also if you have logmode (which is on by default on studio), the URL won't appear either.

### Remember that you have to manually update the time inside the plugin for it to work offline when it can.