### PR TITLE
Clean up issues caused by recent pull requests

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -5207,6 +5207,47 @@ return function(Vargs, env)
 			end
 		};
 
+		Hat = {
+			Prefix = Settings.Prefix;
+			Commands = {"hat", "givehat"};
+			Args = {"player", "id"};
+			Hidden = false;
+			Description = "Gives the target player(s) a hat based on the ID you supply";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				if not args[2] then error("Need to supply hat ID") end
+
+				local id = args[2]
+
+				if not tonumber(id) then
+					local built = {
+						teapot = 1055299;
+					}
+
+					if built[string.lower(args[2])] then
+						id = built[string.lower(args[2])]
+					end
+				end
+
+				if not tonumber(id) then error("Invalid ID") end
+
+				local market = service.MarketPlace
+				local info = market:GetProductInfo(id)
+
+				if info.AssetTypeId == 8 or (info.AssetTypeId >= 41 and info.AssetTypeId <= 47) then
+					local hat = service.Insert(id)
+					assert(hat, "Invalid ID")
+
+					for i, v in pairs(service.GetPlayers(plr, args[1])) do
+						if v.Character and hat then
+							hat:Clone().Parent = v.Character
+						end
+					end
+				end
+			end
+		};
+
 		Slippery = {
 			Prefix = Settings.Prefix;
 			Commands = {"slippery", "iceskate", "icewalk", "slide"};

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -5297,13 +5297,65 @@ return function(Vargs, env)
 				end
 			end
 		};
+		
+		--[[CharacterBodySwap = {
+			Prefix = Settings.Prefix;
+			Commands = {"characterbodyswap", "charbodyswap"};
+			Args = {"player1", "player2"};
+			Hidden = false;
+			Description = "Swaps player1's and player2's bodies and tools";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					for i2, v2 in pairs(service.GetPlayers(plr, args[2])) do
+						local temptools = service.New("Model")
+						local tempcloths = service.New("Model")
+						local vpos = v.Character.HumanoidRootPart.CFrame
+						local v2pos = v2.Character.HumanoidRootPart.CFrame
+						local vface = v.Character.Head.face
+						local v2face = v2.Character.Head.face
+						vface.Parent = v2.Character.Head
+						v2face.Parent = v.Character.Head
+						for k, p in pairs(v.Character:GetChildren()) do
+							if p:IsA("BodyColors") or p:IsA("CharacterMesh") or p:IsA("Pants") or p:IsA("Shirt") or p:IsA("Accessory") then
+								p.Parent = tempcloths
+							elseif p:IsA("Tool") then
+								p.Parent = temptools
+							end
+						end
+						for k, p in pairs(v.Backpack:GetChildren()) do
+							p.Parent = temptools
+						end
+						for k, p in pairs(v2.Character:GetChildren()) do
+							if p:IsA("BodyColors") or p:IsA("CharacterMesh") or p:IsA("Pants") or p:IsA("Shirt") or p:IsA("Accessory") then
+								p.Parent = v.Character
+							elseif p:IsA("Tool") then
+								p.Parent = v.Backpack
+							end
+						end
+						for k, p in pairs(tempcloths:GetChildren()) do
+							p.Parent = v2.Character
+						end
+						for k, p in pairs(v2.Backpack:GetChildren()) do
+							p.Parent = v.Backpack
+						end
+						for k, p in pairs(temptools:GetChildren()) do
+							p.Parent = v2.Backpack
+						end
+						v2.Character.HumanoidRootPart.CFrame = vpos
+						v.Character.HumanoidRootPart.CFrame = v2pos
+					end
+				end
+			end
+		};]]
 
 		BodySwap = {
 			Prefix = Settings.Prefix;
 			Commands = {"bodyswap", "bodysteal", "bswap"};
 			Args = {"player1", "player2"};
 			Hidden = false;
-			Description = "Swaps player1's and player2's bodies and tools";
+			Description = "Swaps player1's and player2's avatars, bodies and tools";
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -5298,7 +5298,7 @@ return function(Vargs, env)
 			end
 		};
 		
-		--[[CharacterBodySwap = {
+		CharacterBodySwap = {
 			Prefix = Settings.Prefix;
 			Commands = {"characterbodyswap", "charbodyswap"};
 			Args = {"player1", "player2"};
@@ -5348,7 +5348,7 @@ return function(Vargs, env)
 					end
 				end
 			end
-		};]]
+		};
 
 		BodySwap = {
 			Prefix = Settings.Prefix;

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -3855,6 +3855,150 @@ return function(Vargs, env)
 			end
 		};
 
+		RightLeg = {
+			Prefix = Settings.Prefix;
+			Commands = {"rleg", "rightleg", "rightlegpackage"};
+			Args = {"player", "id"};
+			Hidden = false;
+			Description = "Change the target player(s)'s Right Leg package";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local id = service.MarketPlace:GetProductInfo(args[2]).AssetTypeId
+				assert(id == 31, "ID is not a right leg!")
+
+				local model = service.Insert(args[2], true)
+
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						Functions.ApplyBodyPart(v.Character, model)
+					end
+				end
+
+				model:Destroy()
+			end
+		};
+
+		LeftLeg = {
+			Prefix = Settings.Prefix;
+			Commands = {"lleg", "leftleg", "leftlegpackage"};
+			Args = {"player", "id"};
+			Hidden = false;
+			Description = "Change the target player(s)'s Left Leg package";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local id = service.MarketPlace:GetProductInfo(args[2]).AssetTypeId
+				assert(id == 30, "ID is not a left leg!")
+
+				local model = service.Insert(args[2], true)
+
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						Functions.ApplyBodyPart(v.Character, model)
+					end
+				end
+
+				model:Destroy()
+			end
+		};
+
+		RightArm = {
+			Prefix = Settings.Prefix;
+			Commands = {"rarm", "rightarm", "rightarmpackage"};
+			Args = {"player", "id"};
+			Hidden = false;
+			Description = "Change the target player(s)'s Right Arm package";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local id = service.MarketPlace:GetProductInfo(args[2]).AssetTypeId
+				assert(id == 28, "ID is not a right arm!")
+
+				local model = service.Insert(args[2], true)
+
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						Functions.ApplyBodyPart(v.Character, model)
+					end
+				end
+
+				model:Destroy()
+			end
+		};
+
+		LeftArm = {
+			Prefix = Settings.Prefix;
+			Commands = {"larm", "leftarm", "leftarmpackage"};
+			Args = {"player", "id"};
+			Hidden = false;
+			Description = "Change the target player(s)'s Left Arm package";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local id = service.MarketPlace:GetProductInfo(args[2]).AssetTypeId
+				assert(id == 29, "ID is not a left arm!")
+
+				local model = service.Insert(args[2], true)
+
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						Functions.ApplyBodyPart(v.Character, model)
+					end
+				end
+
+				model:Destroy()
+			end
+		};
+
+		Torso = {
+			Prefix = Settings.Prefix;
+			Commands = {"torso", "torsopackage"};
+			Args = {"player", "id"};
+			Hidden = false;
+			Description = "Change the target player(s)'s Torso package";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local id = service.MarketPlace:GetProductInfo(args[2]).AssetTypeId
+				assert(id == 27, "ID is not a torso!")
+
+				local model = service.Insert(args[2], true)
+
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						Functions.ApplyBodyPart(v.Character, model)
+					end
+				end
+
+				model:Destroy()
+			end
+		};
+
+		HeadPackage = {
+			Prefix = Settings.Prefix;
+			Commands = {"head", "headpackage"};
+			Args = {"player", "id"};
+			Hidden = false;
+			Description = "Change the target player(s)'s Head package";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				if (args[2] ~= "0") then
+					local id = service.MarketPlace:GetProductInfo(args[2]).AssetTypeId
+					assert(id == 17, "ID is not a head!")
+				end
+
+				local target = service.GetPlayers(plr, args[1])[1]
+				local target_humanoid = target.Character and target.Character:FindFirstChildOfClass("Humanoid")
+
+				local descriptionClone = target_humanoid:GetAppliedDescription()
+				descriptionClone.Head = args[2]
+
+				target_humanoid:ApplyDescription(descriptionClone)
+			end
+		};		
+
 		LoopFling = {
 			Prefix = Settings.Prefix;
 			Commands = {"loopfling"};

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -901,7 +901,7 @@ return function(Vargs, env)
 			Commands = {"removeavataritems", "noavataritems", "removecatalogitems", "clearavataritems"};
 			Args = {"player"};
 			Hidden = false;
-			Description = "Removes any hats the target is currently wearing";
+			Description = "Removes any catalog items that the target currently has and from their HumanoidDescription.";
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
@@ -4732,7 +4732,7 @@ return function(Vargs, env)
 			Prefix = Settings.Prefix;
 			Commands = {"avataritem", "catalogitem", "givecatalogitem", "avatarpackage"};
 			Args = {"player", "ID"};
-			Description = "Give the target player(s) the avatar catalog item matching catalog <ID>-";
+			Description = "Gives the target player(s) the avatar catalog item matching catalog <ID> and adds it to their HumanoidDescription.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})
 				local itemId = assert(tonumber(args[2]), "Argument 2 missing or invalid")
@@ -4814,13 +4814,61 @@ return function(Vargs, env)
 				end
 			end
 		};
-
+		
 		RemoveTShirt = {
 			Prefix = Settings.Prefix;
 			Commands = {"removetshirt", "untshirt", "notshirt"};
 			Args = {"player"};
 			Hidden = false;
 			Description = "Remove any t-shirt(s) worn by the target player(s)";
+			Fun = false;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {[number]:string})
+				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						for g, k in pairs(v.Character:GetChildren()) do
+							if k:IsA("ShirtGraphic") then k:Destroy() end
+						end
+						local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
+						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
+						if humandescrip then
+							humandescrip.GraphicTShirt = 0
+						end
+					end
+				end
+			end
+		};
+		
+		RemoveShirt = {
+			Prefix = Settings.Prefix;
+			Commands = {"removeshirt", "unshirt", "noshirt"};
+			Args = {"player"};
+			Hidden = false;
+			Description = "Remove any shirt(s) worn by the target player(s) and removes it from their HumanoidDescription";
+			Fun = false;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {[number]:string})
+				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						for g, k in pairs(v.Character:GetChildren()) do
+							if k:IsA("ShirtGraphic") then k:Destroy() end
+						end
+						local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
+						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
+						if humandescrip then
+							humandescrip.Shirt = 0
+						end
+					end
+				end
+			end
+		};
+
+		RemoveCatalogTShirt = {
+			Prefix = Settings.Prefix;
+			Commands = {"removecatalogtshirt", "removeavatartshirt"};
+			Args = {"player"};
+			Hidden = false;
+			Description = "Remove any t-shirt(s) worn by the target player(s) and removes it from their HumanoidDescription.";
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})
@@ -4835,12 +4883,12 @@ return function(Vargs, env)
 			end
 		};
 
-		RemoveShirt = {
+		RemoveCatalogShirt = {
 			Prefix = Settings.Prefix;
-			Commands = {"removeshirt", "unshirt", "noshirt"};
+			Commands = {"removecatalogshirt", "removeavatarshirt"};
 			Args = {"player"};
 			Hidden = false;
-			Description = "Remove any shirt(s) worn by the target player(s)";
+			Description = "Remove any shirt(s) worn by the target player(s) and removes it from their HumanoidDescription";
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -901,7 +901,7 @@ return function(Vargs, env)
 			Commands = {"removeavataritems", "noavataritems", "removecatalogitems", "clearavataritems"};
 			Args = {"player"};
 			Hidden = false;
-			Description = "Removes any catalog items that the target currently has and from their HumanoidDescription.";
+			Description = "Removes any catalog items that the target currently has and from their HumanoidDescription, except the packages.";
 			Fun = false;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -4728,9 +4728,178 @@ return function(Vargs, env)
 			end
 		};
 
+		TShirt = {
+			Prefix = Settings.Prefix;
+			Commands = {"tshirt", "givetshirt"};
+			Args = {"player", "ID"};
+			Hidden = false;
+			Description = "Give the target player(s) the t-shirt that belongs to <ID>";
+			Fun = false;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {[number]:string})
+				local ClothingId = tonumber(args[2])
+				local AssetIdType = service.MarketPlace:GetProductInfo(ClothingId).AssetTypeId
+				local Shirt = ((AssetIdType == 11 or AssetIdType == 2) and service.Insert(ClothingId)) or (AssetIdType == 1 and Functions.CreateClothingFromImageId("ShirtGraphic", ClothingId)) or error("Item ID passed has invalid item type")
+
+				assert(Shirt, "Could not retrieve shirt asset for the supplied ID")
+
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						for g, k in pairs(v.Character:GetChildren()) do
+							if k:IsA("ShirtGraphic") then k:Destroy() end
+						end
+
+						local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
+						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
+
+						if humandescrip then
+							humandescrip.GraphicTShirt = ClothingId
+						end
+
+						if Shirt:IsA("Model") then
+							Shirt = thirt:FindFirstChildOfClass("ShirtGraphic")
+						end
+
+						Shirt:Clone().Parent = v.Character
+					end
+				end
+			end
+		};
+
+		RemoveTShirt = {
+			Prefix = Settings.Prefix;
+			Commands = {"removetshirt", "untshirt", "notshirt"};
+			Args = {"player"};
+			Hidden = false;
+			Description = "Remove any t-shirt(s) worn by the target player(s)";
+			Fun = false;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {[number]:string})
+				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						for g, k in pairs(v.Character:GetChildren()) do
+							if k:IsA("ShirtGraphic") then k:Destroy() end
+						end
+						local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
+						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
+						if humandescrip then
+							humandescrip.GraphicTShirt = 0
+						end
+					end
+				end
+			end
+		};
+
+		Shirt = {
+			Prefix = Settings.Prefix;
+			Commands = {"shirt", "giveshirt"};
+			Args = {"player", "ID"};
+			Hidden = false;
+			Description = "Give the target player(s) the shirt that belongs to <ID>";
+			Fun = false;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local ClothingId = tonumber(args[2])
+				local AssetIdType = service.MarketPlace:GetProductInfo(ClothingId).AssetTypeId
+				local Shirt = AssetIdType == 11 and service.Insert(ClothingId) or AssetIdType == 1 and Functions.CreateClothingFromImageId("Shirt", ClothingId) or error("Item ID passed has invalid item type")
+				assert(Shirt, "Unexpected error occured; clothing is missing")
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						for g, k in pairs(v.Character:GetChildren()) do
+							if k:IsA("Shirt") then k:Destroy() end
+						end
+						local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
+						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
+
+						if humandescrip then
+							humandescrip.Shirt = ClothingId
+						end
+						Shirt:Clone().Parent = v.Character
+					end
+				end
+			end
+		};
+
+		Pants = {
+			Prefix = Settings.Prefix;
+			Commands = {"pants", "givepants"};
+			Args = {"player", "id"};
+			Hidden = false;
+			Description = "Give the target player(s) the pants that belongs to <id>";
+			Fun = false;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local ClothingId = tonumber(args[2])
+				local AssetIdType = service.MarketPlace:GetProductInfo(ClothingId).AssetTypeId
+				local Pants = AssetIdType == 12 and service.Insert(ClothingId) or AssetIdType == 1 and Functions.CreateClothingFromImageId("Pants", ClothingId) or error("Item ID passed has invalid item type")
+				assert(Pants, "Unexpected error occured; clothing is missing")
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					if v.Character then
+						for g, k in pairs(v.Character:GetChildren()) do
+							if k:IsA("Pants") then k:Destroy() end
+						end
+						local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
+						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
+
+						if humandescrip then
+							humandescrip.Pants = ClothingId
+						end
+						Pants:Clone().Parent = v.Character
+					end
+				end
+			end
+		};
+
+		Face = {
+			Prefix = Settings.Prefix;
+			Commands = {"face", "giveface"};
+			Args = {"player", "id"};
+			Hidden = false;
+			Description = "Give the target player(s) the face that belongs to <id>";
+			Fun = false;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local faceId = assert(tonumber(args[2]), "Invalid asset ID provided")
+				local faceAssetTypeId = service.MarketPlace:GetProductInfo(tonumber(args[2])).AssetTypeId
+				local asset;
+
+				if faceAssetTypeId == 1 then
+					asset = service.New("Decal", {
+						Name = "face";
+						Face = "Front";
+						Texture = "rbxassetid://" .. args[2];
+					});
+				elseif faceAssetTypeId == 13 and Functions.GetTexture(faceId) ~= 6825455804 then -- just incase GetTexture actually works?
+					asset = service.New("Decal", {
+						Name = "face";
+						Face = "Front";
+						Texture = "rbxassetid://" .. tostring(Functions.GetTexture(faceId));
+					});
+				elseif faceAssetTypeId == 18 then
+					asset = service.Insert(faceId)
+				else
+					error("Invalid face(Image/robloxFace)", 0)
+				end
+
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					local Head = v.Character and v.Character:FindFirstChild("Head")
+					local face = Head and Head:FindFirstChild("face")
+
+					if Head then
+						if face then
+							face:Destroy()--.Texture = "http://www.roblox.com/asset/?id=" .. args[2]
+						end
+
+						local clone = asset:Clone();
+						clone.Parent = v.Character:FindFirstChild("Head")
+					end
+				end
+			end
+		};
+
 		AvatarItem = {
 			Prefix = Settings.Prefix;
-			Commands = {"avataritem", "catalogitem", "givecatalogitem", "avatarpackage"};
+			Commands = {"avataritem", "accessory", "catalogitem", "giveavataritem", "givecatalogitem", "avatarpackage", "catalogemote", "cataloganim", "cataloganimation"};
 			Args = {"player", "ID"};
 			Description = "Gives the target player(s) the avatar catalog item matching catalog <ID> and adds it to their HumanoidDescription.";
 			AdminLevel = "Moderators";
@@ -4810,30 +4979,6 @@ return function(Vargs, env)
 						end
 						
 						task.defer(function() humanoid:ApplyDescription(humanoidDesc) end)
-					end
-				end
-			end
-		};
-		
-		RemoveTShirt = {
-			Prefix = Settings.Prefix;
-			Commands = {"removetshirt", "untshirt", "notshirt"};
-			Args = {"player"};
-			Hidden = false;
-			Description = "Remove any t-shirt(s) worn by the target player(s)";
-			Fun = false;
-			AdminLevel = "Moderators";
-			Function = function(plr: Player, args: {[number]:string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
-					if v.Character then
-						for g, k in pairs(v.Character:GetChildren()) do
-							if k:IsA("ShirtGraphic") then k:Destroy() end
-						end
-						local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
-						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
-						if humandescrip then
-							humandescrip.GraphicTShirt = 0
-						end
 					end
 				end
 			end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -4711,10 +4711,9 @@ return function(Vargs, env)
 
 		AvatarItem = {
 			Prefix = Settings.Prefix;
-			Commands = {"avataritem", "accessory", "hat", "tshirt", "givetshirt", "shirt", "giveshirt", "pants", "givepants", "face", "anim",
-				"torso", "larm", "leftarm", "rarm", "rightarm", "lleg", "leftleg", "rleg", "rightleg", "head"}; -- Legacy aliases from old commands
+			Commands = {"avataritem", "catalogitem", "givecatalogitem", "avatarpackage"};
 			Args = {"player", "ID"};
-			Description = "Give the target player(s) the avatar item matching <ID>";
+			Description = "Give the target player(s) the avatar catalog item matching catalog <ID>-";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})
 				local itemId = assert(tonumber(args[2]), "Argument 2 missing or invalid")


### PR DESCRIPTION
I added the commands back that were removed when "AvatarItem" was added. The reason for that is, it caused issues, the previous commands were able to also apply Images that are not Catalog Items to the player, which "AvatarItem" does not. "AvatarItem" is a command specifically for catalog items, and also applies to the HumanoidDescription.

Applying things to the HumanoidDescription may not be ideal for anyone that uses Adonis, perhaps it could break other games, if the previous commands didn't work like how they did before, in terms of what they did.

The previous "hat" command as example, did not apply to the HumanoidDescription, and I think that's fine so. Let "AvatarItem" be the one that makes changes to the HumanoidDescription, also because the HumanoidDescription mostly accepts catalog items anyway.