### PR TITLE
Remove the nolint from plugins

### DIFF
--- a/Loader/Config/Plugins/Client-Example Plugin.lua
+++ b/Loader/Config/Plugins/Client-Example Plugin.lua
@@ -1,5 +1,6 @@
---!nolint UnknownGlobal
-return function()
+return function(Vargs)
+	local client, service = Vargs.Client, Vargs.Service
+
 	--Acts the same as a server plugin but with client functions instead of server.
 	--[[
 	local window = client.UI.Make("Window",{

--- a/Loader/Config/Plugins/Server-Example Plugin.lua
+++ b/Loader/Config/Plugins/Server-Example Plugin.lua
@@ -1,4 +1,3 @@
---!nolint UnknownGlobal
 --[[
 	SERVER PLUGINS' NAMES MUST START WITH "Server:" OR "Server-"
 	CLIENT PLUGINS' NAMES MUST START WITH "Client:" OR "Client-"


### PR DESCRIPTION
It should have already been removed because vargs return the values.
And it may cause issues with debugging because you dont see if a variable is never defined