### PR TITLE
Error catching on group API's to prevent errors.

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -36,7 +36,10 @@ return function(Vargs, GetEnv)
 
 		if not CreatorId then
 			TrackTask("Thread: GetGroupCreatorId", function()
-				CreatorId = service.GroupService:GetGroupInfoAsync(game.CreatorId).Owner.Id
+				local success, creator = pcall(service.GroupService, service.GroupService.GetGroupInfoAsync, game.CreatorId)
+				if success and type(creator) == "table" then
+					CreatorId = creator.Owner.Id
+				end
 			end)
 		end
 
@@ -244,6 +247,10 @@ return function(Vargs, GetEnv)
 		end;
 
 		GetPlayerGroup = function(p, group)
+			if not p or p.Parent ~= service.Players then
+				return
+			end
+
 			local groups;
 			do
 				local key = tostring(p.UserId)
@@ -255,9 +262,10 @@ return function(Vargs, GetEnv)
 
 				local groupInfo = groupTable and groupTable[group] or {}
 				if not groupInfo[1] or os.time() - groupInfo[1] < 30 then
+					local success, GroupInfo = pcall(service.GroupService, service.GroupService.GetGroupsAsync, p.UserId)
 					Admin.GroupsCache[key][group] = {
 						os.time(),
-						service.GroupService:GetGroupsAsync(p.UserId) or {}
+						success and GroupInfo or {}
 					}
 					groups = Admin.GroupsCache[key][group][2]
 				else
@@ -686,7 +694,12 @@ return function(Vargs, GetEnv)
 				return true
 			else
 				--if p.UserId<0 or (tonumber(p.AccountAge) and tonumber(p.AccountAge)<0) then return false end
+				local pGroup = Admin.GetPlayerGroup(p, 886423)
 				for _, pass in ipairs(Variables.DonorPass) do
+					if p.Parent ~= service.Players then
+						return false
+					end
+
 					local ran, ret
 					if type(pass) == "number" then
 						ran, ret = pcall(service.MarketPlace.UserOwnsGamePassAsync, service.MarketPlace, p.UserId, pass)
@@ -694,7 +707,7 @@ return function(Vargs, GetEnv)
 						ran, ret = pcall(service.MarketPlace.PlayerOwnsAsset, service.MarketPlace, p, tonumber(pass))
 					end
 
-					if (ran and ret) or p:GetRankInGroup(886423) >= 10 then --// Complimentary donor access is given to Adonis contributors & developers.
+					if (ran and ret) or (pGroup and pGroup.Rank >= 10) then --// Complimentary donor access is given to Adonis contributors & developers.
 						Variables.CachedDonors[key] = os.time()
 						return true
 					end

--- a/WebPanel.lua
+++ b/WebPanel.lua
@@ -29,7 +29,13 @@ return function(Vargs)
 
 	local WebPanel = HTTP.WebPanel
 
-	local ownerId = game.CreatorType == Enum.CreatorType.User and game.CreatorId or service.GroupService:GetGroupInfoAsync(game.CreatorId).Owner.Id
+	local ownerId = game.CreatorType == Enum.CreatorType.User and game.CreatorId
+	if not ownerId then
+		local success, creator = pcall(service.GroupService, service.GroupService.GetGroupInfoAsync, game.CreatorId)
+		if success and type(creator) == "table" then
+			ownerId = creator.Owner.Id
+		end
+	end
 
 	local FoundCustomCommands = {}
 	local CachedAliases = {}
@@ -51,12 +57,12 @@ return function(Vargs)
 		Backpack = Instance.new("Folder");
 		PlayerGui = Instance.new("Folder");
 		PlayerScripts = Instance.new("Folder");
-		Kick = function() 
-			fakePlayer:Destroy() 
-			fakePlayer:SetSpecial("Parent", nil) 
+		Kick = function()
+			fakePlayer:Destroy()
+			fakePlayer:SetSpecial("Parent", nil)
 		end;
 		IsA = function(_, arg) if arg == "Player" then return true end end;
-	}) do 
+	}) do
 		fakePlayer:SetSpecial(i, v)
 	end
 
@@ -227,7 +233,7 @@ return function(Vargs)
 			didrun = true
 
 			local index, command = Admin.GetCommand(Settings.Prefix..i)
-			if not index or not command then 
+			if not index or not command then
 				index,command = Admin.GetCommand(Settings.PlayerPrefix..i)
 			end
 
@@ -401,10 +407,10 @@ return function(Vargs)
 
 			--// Handle queue items
 			for _, v in pairs(data.Queue) do
-				if typeof(v.action) ~= "string" then 
+				if typeof(v.action) ~= "string" then
 					v.action = tostring(v.action)
 				end
-				if typeof(v.server) ~= "string" then 
+				if typeof(v.server) ~= "string" then
 					v.server = tostring(v.server)
 				end
 
@@ -434,10 +440,10 @@ return function(Vargs)
 						if typeof(v.command) ~= "string" then
 							v.command = tostring(v.command)
 						end
-						
+
 						warn("WebPanel executed command from Web Panel: " .. tostring(v.command))
 						Logs:AddLog("Script", "WebPanel Executed command: " .. tostring(v.command))
-						
+
 						Process.Command(fakePlayer, v.command, {
 							AdminLevel = 900,
 							DontLog = true,


### PR DESCRIPTION
`Admin + WebPanel`:
More error catching techniques have been attempted to prevent Roblox from erroring due to the API limit.
Changed from `GetRankInGroup` to use `Admin.GetPlayerGroup` for fetching >30 second cached group info to prevent the API limit