### PR TITLE
Minor change to :reverb command

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6390,12 +6390,12 @@ return function(Vargs, env)
 				local reverbs = ReverbType:GetEnumItems()
 				if not rev or not ReverbType[rev] then
 
-					Functions.Hint("Argument 1 missing or nil. Opening Reverb List", {plr})
+					Functions.Hint("reverbType not specified or is invalid. Opening Reverb List", {plr})
 
 					local tab = {}
 					table.insert(tab, {Text = "Note: Argument is CASE SENSITIVE"})
 					for _, v in pairs(reverbs) do
-						table.insert(tab, {Text = v})
+						table.insert(tab, {Text = tostring(v):sub(17)})
 					end
 					Remote.MakeGui(plr, "List", {Title = "Reverbs"; Table = tab;})
 

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6390,12 +6390,12 @@ return function(Vargs, env)
 				local reverbs = ReverbType:GetEnumItems()
 				if not rev or not ReverbType[rev] then
 
-					Functions.Hint("reverbType not specified or is invalid. Opening Reverb List", {plr})
+					Functions.Hint("Reverb type was not specified or is invalid. Opening list of valid reverb types", {plr})
 
 					local tab = {}
 					table.insert(tab, {Text = "Note: Argument is CASE SENSITIVE"})
 					for _, v in pairs(reverbs) do
-						table.insert(tab, {Text = tostring(v):sub(17)})
+						table.insert(tab, {Text = v.Name})
 					end
 					Remote.MakeGui(plr, "List", {Title = "Reverbs"; Table = tab;})
 


### PR DESCRIPTION
1. Changed the feedback message if you don't specify a valid argument|
2. Updated the list so it shows just the name of the reverb type and not the full Enum Name
ie. Enum.ReverbType.NoReverb --> NoReverb (As the command says it is case sensitive, this change was made to clear up confusion)