### PR TITLE
Fixed anti-idle and anti-kick once and for all

### DIFF
--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -112,6 +112,14 @@ return function()
 	end
 
 	coroutine.wrap(function()
+		if not game:IsLoaded() then
+			game.Loaded:Wait()
+		end
+
+		if not service.UnWrap(Player).Character and service.UnWrap(game):GetService("Players").CharacterAutoLoads then
+			service.UnWrap(Player).CharacterAdded:Wait()
+		end
+
 		local RunService = service.RunService
 		if
 			RunService:IsStudio() == true and
@@ -203,7 +211,9 @@ return function()
 
 					if #service.Players:GetPlayers() > 1 then
 						for _, v in ipairs(service.Players:GetPlayers()) do
-							if service.UnWrap(v) and service.UnWrap(v) ~= LocalPlayer then
+							local otherPlayer = service.UnWrap(v)
+
+							if otherPlayer and otherPlayer.Parent and otherPlayer ~= LocalPlayer then
 								local success, err = pcall(LocalPlayer.Kick, service.UnWrap(v), "If this appears, you have a glitch. Method 2")
 								if success or err ~= "Cannot kick a non-local Player from a LocalScript" then
 									Detected("kick", "Anti kick found! Method 2")


### PR DESCRIPTION
Roblox is really weird and has some edge cases but I fixed it now.

Unless there are other edge cases that this doesn't handle :/

- Fixed a bug where Roblox doesn't produce a proper error message because player is wrongly parented.
- Fixed a potential bug relating to .Idled event (Not sure if this is actually the cause)

Anyways it's really weird how Roblox does this internally so there might be other edge cases. I'm not sure but if you know one you are free to make a pull to fix it.