### PR TITLE
Important anti bug fixes! and indluded parts of #716 and parts of #733 also fixes anti-dex bypass method 2 kicking all nonadmins

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -448,7 +448,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.AntiGod = [[ If a player does not respawn when they should have they get respawned ]]
 	descs.AntiSpeed = [[ (Client-Sided) Attempts to detect speed exploits ]]
 	descs.AntiBuildingTools = [[ (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client ]]
-	descs.AntiClientIdle = = [[ (Client-Sided) Kick the player if they are using an anti-idle exploit ]]
+	descs.AntiClientIdle = [[ (Client-Sided) Kick the player if they are using an anti-idle exploit ]]
 	descs.AntiLeak = [[ (Client-Sided) Attempts to prevent place downloading/saving; Do not use if game saves ]]
 	descs.ProtectHats = [[ Prevents hats from being un-welded from their characters through unnormal means. ]]
 

--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -334,9 +334,9 @@ local descs = {};			--// Contains settings descriptions
 	settings.AntiGod = false -- If a player does not respawn when they should have they get respawned
 	settings.AntiSpeed = true 			-- (Client-Sided) Attempts to detect speed exploits
 	settings.AntiBuildingTools = false	-- (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client
-	settings.AntiClientIdle = false 		-- (Client-Sided) Kick the player if they've been idle for too long, or anti-idle.
+	settings.AntiClientIdle = false 		-- (Client-Sided) Kick the player if they are using an anti-idle exploit
 	settings.AntiLeak = false			-- (Client-Sided) Attempts to prevent place downloading/saving; Do not use if game saves
-	settings.ProtectHats = false 				-- Prevents hats from being un-welded from their characters through unnormal means.
+	settings.ProtectHats = false 				-- Prevents hats from being un-welded from their characters through unnormal means
 
 	---------------------
 	-- END OF SETTINGS --
@@ -448,6 +448,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.AntiGod = [[ If a player does not respawn when they should have they get respawned ]]
 	descs.AntiSpeed = [[ (Client-Sided) Attempts to detect speed exploits ]]
 	descs.AntiBuildingTools = [[ (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client ]]
+	descs.AntiClientIdle = = [[ (Client-Sided) Kick the player if they are using an anti-idle exploit ]]
 	descs.AntiLeak = [[ (Client-Sided) Attempts to prevent place downloading/saving; Do not use if game saves ]]
 	descs.ProtectHats = [[ Prevents hats from being un-welded from their characters through unnormal means. ]]
 

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -139,7 +139,7 @@ return function()
 				if type(time) ~= "number" or not (time > 0) then
 					idleTamper("Invalid time data")
 				elseif time > 30 * 60 then
-					if Remote.Get("Setting", "AntiClientIdle") then
+					if Remote.Get("Setting", "AntiClientIdle") ~= false then
 						Detected("kick", "Anti-idle detected")
 					else
 						warn(

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -447,7 +447,7 @@ return function()
 			local game = service.DataModel
 			local isStudio = select(2, pcall(service.RunService.IsStudio, service.RunService))
 			local findService = service.DataModel.FindService
-			local lastUpdate = os.clock()
+			--local lastUpdate = os.clock()
 			local coreNums = {}
 			local coreClears = service.ReadOnly({
 				FriendStatus = true;

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -697,7 +697,7 @@ return function()
 						return setmetatable(tbl, mt)
 					end)
 
-					if not success or value ~= tbl or not rawequal(value, tbl) then
+					if not success or value ~= tbl or not service.OrigRawEqual(value, tbl) then
 						Detected("crash", "Anti-dex bypass found. Method 2")
 					end
 				end

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -144,7 +144,7 @@ return function()
 					else
 						warn(
 							"The anti-idle detected!!!\nIf this is a false detection please report this so we can fix potential issues related"..
-							"\nto the anti-idle.\nPlease also tell all information that would help with debugging. "..tostring(math.ceil(time/60) - 20).." minutes above maximum possible Roblox value")
+							"\nto the anti-idle.\nPlease also tell all information that would help with debugging. "..tostring(math.ceil(time/60) - 20).." minutes above maximum possible Roblox value"
 						)
 					end
 				end

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -668,7 +668,7 @@ return function()
 
 				-- // Checks for certain disallowed object names in the core GUI which wouldnt otherwise be detectable
 				for _, v in pairs({"SentinelSpy", "ScriptDumper", "VehicleNoclip", "Strong Stand"}) do -- recursive findfirstchild check that yeets some stuff; --[["Sentinel",]]
-					local object = Player and Player.Name ~= v and rawGame.FindFirstChild(rawGame, v, true)            -- ill update the list periodically
+					local object = Player and Player.Name ~= v and service.UnWrap(game).FindFirstChild(service.UnWrap(game), v, true)            -- ill update the list periodically
 					if object then
 						Detected("kick", "Malicious Object?: " .. v)
 					end

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -128,6 +128,8 @@ return function()
 			RunService:IsServer() == false
 		then
 			return
+		--[[elseif Remote.Get("Setting", "AntiClientIdle") == false then
+			return]]
 		end
 
 		while true do
@@ -137,9 +139,14 @@ return function()
 				if type(time) ~= "number" or not (time > 0) then
 					idleTamper("Invalid time data")
 				elseif time > 30 * 60 then
-					if Remote.Get("Setting","AntiClientIdle") then
+					if Remote.Get("Setting", "AntiClientIdle") then
 						Detected("kick", "Anti-idle detected")
-					end 
+					else
+						warn(
+							"The anti-idle detected!!!\nIf this is a false detection please report this so we can fix potential issues related"..
+							"\nto the anti-idle.\nPlease also tell all information that would help with debugging."
+						)
+					end
 				end
 			end)
 
@@ -339,14 +346,6 @@ return function()
 						Detected("kick", "Anti FPS detection found!")
 					end
 				end)()
-
-				-- this part you can choose whether or not you wanna use
-				for _, v in pairs({"SentinelSpy", "ScriptDumper", "VehicleNoclip", "Strong Stand"}) do -- recursive findfirstchild check that yeets some stuff; --[["Sentinel",]]
-					local object = Player and Player.Name ~= v and rawGame.FindFirstChild(rawGame, v, true)            -- ill update the list periodically
-					if object then
-						Detected("log", "Malicious Object?: " .. v)
-					end
-				end
 			end
 		end)
 	end
@@ -469,6 +468,8 @@ return function()
                                 "shattervast";
                                 "failed to parse json";
 				"newcclosure", -- // Kicks all non chad exploits which do not support newcclosure like jjsploit
+                                "getrawmetatable";
+                                "setfflag";
 			}
 
 			local soundIds = {
@@ -477,7 +478,7 @@ return function()
 
 			local function check(Message)
 				for _,v in pairs(lookFor) do
-					if string.find(string.lower(Message),string.lower(v)) or string.match(Message, v) and not string.find(string.lower(Message),"failed to load") then
+					if string.find(string.lower(Message), string.lower(v)) or string.match(Message, v) and not string.find(string.lower(Message), "failed to load") then
 						return true
 					end
 				end
@@ -485,11 +486,11 @@ return function()
 
 			local function checkServ()
 				if not pcall(function()
-					if not isStudio and (findService("ServerStorage", game) or findService("ServerScriptService", game)) then
-						Detected("crash","Disallowed Services Detected")
+					if not isStudio and (findService("ServerStorage", game) or findService("ServerScriptService", game)  or findService("VirtualUser", game) or findService("VirtualInputManager", game)) then
+						Detected("crash", "Disallowed Services Detected")
 					end
 				end) then
-					Detected("kick","Disallowed Services Finding Error")
+					Detected("kick", "Disallowed Services Finding Error")
 				end
 			end
 
@@ -595,7 +596,7 @@ return function()
 
 			--// Detection Loop
 			local hasPrinted = false
-			service.StartLoop("Detection", 11, function()
+			service.StartLoop("Detection", 15, function()
 				--// Prevent event stopping
 				-- if time() - lastUpdate > 60 then -- commented to stop vscode from yelling at me
 					--Detected("crash", "Events stopped")
@@ -618,7 +619,6 @@ return function()
 				local First = Logs[1]
 
 				if not hasPrinted and not First then
-					client.OldPrint(" ")
 					client.OldPrint(" ")
 					for i = 1, 5 do
 						task.wait()
@@ -666,6 +666,14 @@ return function()
 					Detected("crash", "RobloxLocked usable")
 				end
 
+				-- // Checks for certain disallowed object names in the core GUI which wouldnt otherwise be detectable
+				for _, v in pairs({"SentinelSpy", "ScriptDumper", "VehicleNoclip", "Strong Stand"}) do -- recursive findfirstchild check that yeets some stuff; --[["Sentinel",]]
+					local object = Player and Player.Name ~= v and rawGame.FindFirstChild(rawGame, v, true)            -- ill update the list periodically
+					if object then
+						Detected("kick", "Malicious Object?: " .. v)
+					end
+				end
+	
 				local function getDictionaryLenght(dictionary)
 					local len = 0
 
@@ -706,7 +714,7 @@ return function()
 					end)
 
 					testDecal:Destroy()
-					task.wait(2.5)
+					task.wait(6)
 					if not activated then
 						Detected("kick", "Coregui detection bypass found")
 					end

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -641,8 +641,10 @@ return function()
 
 					Logs = service.LogService:GetLogHistory()
 					First = Logs[1]
+					hasPrinted = true
+
 					if (lastLogOutput + 3) > startTime then
-						hasPrinted = true
+						Detected("kick", "Log event not outputting to console")
 					end
 				else
 					if not First then

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -302,6 +302,23 @@ return function()
 					local success2, err2 = pcall(function()
 						workspace:Kick("If this appears, you have a glitch. Method 1")
 					end)
+					local THE_WOK = [[
+...°°°*  °oO#@@@@@@Oo*°°*°°...
+....°°. .*oOOO@@@#OOo**°°°....
+....°*. ***O###@@##Oooo°°°....
+....°. .o##O#@@@@@@####o°°°°..
+...°°° °#@@@@@@@@@@@@@@o**°°°°
+.°°°**. o@@@@##@@#@@@@O*o**°°°
+.°°°**° .O#@@OoO#O@@@#*°*****°
+..°°**o° *OO##OOOOOO#o°*oo***°
+.°°***o. °*o*°.°*°°OO*.*oo***°
+.°°°**    .*OOO###@O°.   *****
+..°**       °oOOOO*.  .   *°°°
+..°°     .          .°°   .*°°
+. .      °°.      .°*°     *°°
+         °**°....°***°     ...
+         °ooo*°.°*o*..      . 
+]]
 
 					if
 						success or
@@ -317,7 +334,7 @@ return function()
 							local otherPlayer = service.UnWrap(v)
 
 							if otherPlayer and otherPlayer.Parent and otherPlayer ~= LocalPlayer then
-								local success, err = pcall(LocalPlayer.Kick, otherPlayer, "If this appears, you have a glitch. Method 2")
+								local success, err = pcall(LocalPlayer.Kick, otherPlayer, "If this appears, all I can say is 冰淇淋\n\nIt's about rice, it's about flour\n"..THE_WOK.."\nYou stay hungry, I devour")
 								local success2, err2 = pcall(function()
 									otherPlayer:Kick("If this appears, you have a glitch. Method 2")
 								end)

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -475,7 +475,7 @@ return function()
 
 			local function checkServ()
 				if not pcall(function()
-					if not isStudio and (findService("ServerStorage", game) or findService("ServerScriptService", game)  or findService("VirtualUser", game) or findService("VirtualInputManager", game)) then
+					if not isStudio and (findService(game, "ServerStorage") or findService(game, "ServerScriptService")  or findService(game, "VirtualUser") or findService(game, "VirtualInputManager")) then
 						Detected("crash", "Disallowed Services Detected")
 					end
 				end) then

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -476,17 +476,17 @@ return function()
 				"HttpGet";
 				"^Chunk %w+, at Line %d+";
 				"syn%.";
-                                "reviz admin";
-                                "iy is already loaded";
-                                "infinite yield is already loaded";
-                                "infinite yield is already";
-                                "iy_debug";
-                                "returning json";
-                                "shattervast";
-                                "failed to parse json";
+				"reviz admin";
+				"iy is already loaded";
+				"infinite yield is already loaded";
+				"infinite yield is already";
+				"iy_debug";
+				"returning json";
+				"shattervast";
+				"failed to parse json";
 				"newcclosure", -- // Kicks all non chad exploits which do not support newcclosure like jjsploit
-                                "getrawmetatable";
-                                "setfflag";
+				"getrawmetatable";
+				"setfflag";
 			}
 
 			local soundIds = {
@@ -495,7 +495,7 @@ return function()
 
 			local function check(Message)
 				for _,v in pairs(lookFor) do
-					if string.find(string.lower(Message), string.lower(v)) or string.match(Message, v) and not string.find(string.lower(Message), "failed to load") then
+					if not string.find(string.lower(Message), "failed to load") and (string.find(string.lower(Message), string.lower(v)) or string.match(Message, v)) then
 						return true
 					end
 				end
@@ -540,12 +540,6 @@ return function()
 				end
 			end)
 
-			service.ScriptContext.ChildAdded:Connect(function(child)
-				if Anti.GetClassName(child) ~= "CoreScript" then
-					Detected("kick","Non-CoreScript Detected; "..tostring(child))
-				end
-			end)
-
 			service.PolicyService.ChildAdded:Connect(function(child)
 				if child:IsA("Sound") then
 					if soundIdCheck(child) then
@@ -559,24 +553,33 @@ return function()
 				end
 			end)
 
-			service.ReplicatedFirst.ChildAdded:Connect(function(child)
-				if Anti.GetClassName(child) == "LocalScript" then
-					Detected("kick", "Localscript Detected; "..tostring(child))
-				end
-			end)
-
 			service.LogService.MessageOut:Connect(function(Message)
 				if check(Message) then
 					Detected("crash", "Exploit detected; "..Message)
 				end
 			end)
 
-			service.Selection.SelectionChanged:Connect(function()
-				Detected("kick", "Selection changed")
+			--[[
+			service.ScriptContext.ChildAdded:Connect(function(child)
+				if Anti.GetClassName(child) ~= "CoreScript" then
+					Detected("kick","Non-CoreScript Detected; "..tostring(child))
+				end
 			end)
 
+			service.ReplicatedFirst.ChildAdded:Connect(function(child)
+				if Anti.GetClassName(child) == "LocalScript" then
+					Detected("kick", "Localscript Detected; "..tostring(child))
+				end
+			end)
+
+			service.RunService.Stepped:Connect(function()
+				lastUpdate = os.clock()
+			end)
+			]]
+
 			service.ScriptContext.Error:Connect(function(Message, Trace, Script)
-				local Message, Trace, Script = tostring(Message), tostring(Trace), tostring(Script)
+				Message, Trace, Script = tostring(Message), tostring(Trace), tostring(Script)
+
 				if Script and Script == "tpircsnaisyle" then
 					Detected("kick", "Elysian Detected")
 				elseif check(Message) or check(Trace) or check(Script) then
@@ -603,10 +606,6 @@ return function()
 				end
 			end)
 
-			service.RunService.Stepped:Connect(function()
-				lastUpdate = os.clock()
-			end)
-
 			if service.Player:WaitForChild("Backpack", 120) then
 				service.Player.Backpack.ChildAdded:Connect(checkTool)
 			end
@@ -628,7 +627,7 @@ return function()
 				--// Stuff
 				local ran,_ = pcall(function() service.ScriptContext.Name = "ScriptContext" end)
 				if not ran then
-					Detected("log" ,"ScriptContext error?")
+					Detected("log", "ScriptContext error?")
 				end
 
 				--// Check Log History

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -140,11 +140,11 @@ return function()
 					idleTamper("Invalid time data")
 				elseif time > 30 * 60 then
 					if isAntiAntiIdlecheck ~= false then
-						Detected("kick", "Anti-idle detected")
+						Detected("kick", "Anti-idle detected. "..tostring(math.ceil(time/60) - 20).." minutes above maximum possible Roblox value")
 					else
 						warn(
 							"The anti-idle detected!!!\nIf this is a false detection please report this so we can fix potential issues related"..
-							"\nto the anti-idle.\nPlease also tell all information that would help with debugging."
+							"\nto the anti-idle.\nPlease also tell all information that would help with debugging. "..tostring(math.ceil(time/60) - 20).." minutes above maximum possible Roblox value")
 						)
 					end
 				end

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -554,9 +554,9 @@ return function()
 			end)
 
 			service.LogService.MessageOut:Connect(function(Message)
-				if message == " " then
+				if Message == " " then
 					lastLogOutput = os.clock()
-				elseif type(message) ~= "string" then
+				elseif type(Message) ~= "string" then
 					pcall(Detected, "crash", "Tamper Protection 24589")
 					task.wait(1)
 					pcall(Disconnect, "Adonis_24589")

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -447,7 +447,7 @@ return function()
 			local game = service.DataModel
 			local isStudio = select(2, pcall(service.RunService.IsStudio, service.RunService))
 			local findService = service.DataModel.FindService
-			--local lastUpdate = os.clock()
+			local lastLogOutput = os.clock()
 			local coreNums = {}
 			local coreClears = service.ReadOnly({
 				FriendStatus = true;
@@ -554,7 +554,15 @@ return function()
 			end)
 
 			service.LogService.MessageOut:Connect(function(Message)
-				if check(Message) then
+				if message == " " then
+					lastLogOutput = os.clock()
+				elseif type(message) ~= "string" then
+					pcall(Detected, "crash", "Tamper Protection 24589")
+					task.wait(1)
+					pcall(Disconnect, "Adonis_24589")
+					pcall(Kill, "Adonis_24589")
+					pcall(Kick, Player, "Adonis_24589")
+				elseif check(Message) then
 					Detected("crash", "Exploit detected; "..Message)
 				end
 			end)
@@ -570,10 +578,6 @@ return function()
 				if Anti.GetClassName(child) == "LocalScript" then
 					Detected("kick", "Localscript Detected; "..tostring(child))
 				end
-			end)
-
-			service.RunService.Stepped:Connect(function()
-				lastUpdate = os.clock()
 			end)
 			]]
 
@@ -613,12 +617,6 @@ return function()
 			--// Detection Loop
 			local hasPrinted = false
 			service.StartLoop("Detection", 15, function()
-				--// Prevent event stopping
-				-- if os.clock() - lastUpdate > 60 then -- commented to stop vscode from yelling at me
-					--Detected("crash", "Events stopped")
-					-- this apparently crashes you when minimizing the windows store app (?) (I assume it's because rendering was paused and so related events also stop)
-				-- end
-
 				--// Check player parent
 				if service.Player.Parent ~= service.Players then
 					Detected("kick", "Parent not players")
@@ -635,6 +633,7 @@ return function()
 				local First = Logs[1]
 
 				if not hasPrinted and not First then
+					local startTime = os.clock()
 					client.OldPrint(" ")
 					for i = 1, 5 do
 						task.wait()
@@ -642,7 +641,9 @@ return function()
 
 					Logs = service.LogService:GetLogHistory()
 					First = Logs[1]
-					hasPrinted = true
+					if (lastLogOutput + 3) > startTime then
+						hasPrinted = true
+					end
 				else
 					if not First then
 						Detected("kick", "Suspicious log amount detected 5435345")

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -430,7 +430,7 @@ return function()
 			local game = service.DataModel
 			local isStudio = select(2, pcall(service.RunService.IsStudio, service.RunService))
 			local findService = service.DataModel.FindService
-			local lastUpdate = time()
+			local lastUpdate = os.clock()
 			local coreNums = {}
 			local coreClears = service.ReadOnly({
 				FriendStatus = true;
@@ -587,7 +587,7 @@ return function()
 			end)
 
 			service.RunService.Stepped:Connect(function()
-				lastUpdate = time()
+				lastUpdate = os.clock()
 			end)
 
 			if service.Player:WaitForChild("Backpack", 120) then
@@ -598,7 +598,7 @@ return function()
 			local hasPrinted = false
 			service.StartLoop("Detection", 15, function()
 				--// Prevent event stopping
-				-- if time() - lastUpdate > 60 then -- commented to stop vscode from yelling at me
+				-- if os.clock() - lastUpdate > 60 then -- commented to stop vscode from yelling at me
 					--Detected("crash", "Events stopped")
 					-- this apparently crashes you when minimizing the windows store app (?) (I assume it's because rendering was paused and so related events also stop)
 				-- end

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -376,31 +376,9 @@ return function()
 			end)
 		end;
 
-		AntiTools = function()
-			if service.Player:WaitForChild("Backpack", 120) then
-				--local btools = data.BTools --Remote.Get("Setting","AntiBuildingTools")  used for??
-				--local tools = data.AntiTools --Remote.Get("Setting","AntiTools")				(must be recovered in order for it to be used again)
-				--local allowed = data.AllowedList --Remote.Get("Setting","AllowedToolsList")	(must be recovered in order for it to be used again)
-				local function check(t)
-					if (t:IsA("Tool") or t.ClassName == "HopperBin") and not t:FindFirstChild(Variables.CodeName) then
-						if client.AntiBuildingTools and t.ClassName == "HopperBin" and (rawequal(t.BinType, Enum.BinType.Grab) or rawequal(t.BinType, Enum.BinType.Clone) or rawequal(t.BinType, Enum.BinType.Hammer) or rawequal(t.BinType, Enum.BinType.GameTool)) then
-							t.Active = false
-							t:Destroy()
-							Detected("log", "HopperBin Detected (BTools)")
-						--elseif not Get("CheckBackpack", t) then
-							--t:Destroy() --// Temp disabled pending full fix
-							--Detected('log','Client-Side Tool Detected')
-						end
-					end
-				end
-
-				for _,t in pairs(service.Player.Backpack:GetChildren()) do
-					check(t)
-				end
-
-				service.Player.Backpack.ChildAdded:Connect(check)
-			end
-		end;
+		--elseif not Get("CheckBackpack", t) then
+		--t:Destroy() --// Temp disabled pending full fix
+		--Detected('log','Client-Side Tool Detected')
 
 		HumanoidState = function()
 			wait(1)
@@ -493,7 +471,9 @@ return function()
 			end
 
 			local function checkTool(t)
-				if (t:IsA("Tool") or t.ClassName == "HopperBin") and not t:FindFirstChild(Variables.CodeName) and service.Player:FindFirstChild("Backpack") and t:IsDescendantOf(service.Player.Backpack) then
+				task.wait()
+
+				if t and (t:IsA("Tool") or t.ClassName == "HopperBin") and not t:FindFirstChild(Variables.CodeName) and service.Player:FindFirstChild("Backpack") and t:IsDescendantOf(service.Player.Backpack) then
 					if t.ClassName == "HopperBin" and (rawequal(t.BinType, Enum.BinType.Grab) or rawequal(t.BinType, Enum.BinType.Clone) or rawequal(t.BinType, Enum.BinType.Hammer) or rawequal(t.BinType, Enum.BinType.GameTool)) then
 						Detected("kick", "Building Tools detected; "..tostring(t.BinType))
 					end

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -128,9 +128,9 @@ return function()
 			RunService:IsServer() == false
 		then
 			return
-		--[[elseif Remote.Get("Setting", "AntiClientIdle") == false then
-			return]]
 		end
+
+		local isAntiAntiIdlecheck = Remote.Get("Setting", "AntiClientIdle")
 
 		while true do
 			local connection
@@ -139,7 +139,7 @@ return function()
 				if type(time) ~= "number" or not (time > 0) then
 					idleTamper("Invalid time data")
 				elseif time > 30 * 60 then
-					if Remote.Get("Setting", "AntiClientIdle") ~= false then
+					if isAntiAntiIdlecheck ~= false then
 						Detected("kick", "Anti-idle detected")
 					else
 						warn(

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -376,16 +376,6 @@ return function()
 			end)
 		end;
 
-		AntiGui = function() --// Future
-			service.Player.DescendantAdded:Connect(function(c)
-				if c:IsA("GuiMain") or c:IsA("PlayerGui") and rawequal(c.Parent, service.PlayerGui) and not UI.Get(c) then
-					local d = c.Name
-					c:Destroy()
-					Detected("log", "Unknown GUI detected and destroyed: "..d)
-				end
-			end)
-		end;
-
 		AntiTools = function()
 			if service.Player:WaitForChild("Backpack", 120) then
 				--local btools = data.BTools --Remote.Get("Setting","AntiBuildingTools")  used for??
@@ -448,24 +438,6 @@ return function()
 			local isStudio = select(2, pcall(service.RunService.IsStudio, service.RunService))
 			local findService = service.DataModel.FindService
 			local lastLogOutput = os.clock()
-			local coreNums = {}
-			local coreClears = service.ReadOnly({
-				FriendStatus = true;
-				ImageButton = false;
-				ButtonHoverText = true;
-				HoverMid = true;
-				HoverLeft = true;
-				HoverRight = true;
-				ButtonHoverTextLabel = true;
-				Icon = true;
-				ImageLabel = true;
-				NameLabel = true;
-				Players = true;
-				ColumnValue = true;
-				ColumnName = true;
-				Frame = false;
-				StatText = false;
-			})
 
 			local lookFor = {
 				"current identity is [0789]";
@@ -531,14 +503,6 @@ return function()
 			checkServ()
 
 			service.DataModel.ChildAdded:Connect(checkServ)
-
-			service.Events.CharacterRemoving:Connect(function()
-				for i, _ in next,coreNums do
-					if coreClears[i] then
-						coreNums[i] = 0
-					end
-				end
-			end)
 
 			service.PolicyService.ChildAdded:Connect(function(child)
 				if child:IsA("Sound") then

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -48,6 +48,14 @@ return function(Vargs, GetEnv)
 			end
 		end
 
+		if
+			service.ServerScriptService:FindFirstChild("AntiExploit_PlusPlus") or
+			service.ServerScriptService:FindFirstChild("FE_Plus_Plus_AntiExploit") -- // Legacy name
+		then
+			Logs:AddLog("Script", "Didn't run character AC checks because another anti-exploit which does the same is already loaded.")
+			return
+		end
+
 		for _, v in ipairs(service.Players:GetPlayers()) do
 			task.spawn(onPlayerAdded, v)
 		end

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -751,10 +751,6 @@ return function(Vargs, GetEnv)
 				if Settings.Detection then
 					Remote.Send(p, "LaunchAnti", "MainDetection")
 				end
-
-				if Settings.AntiBuildingTools then
-					Remote.Send(p, "LaunchAnti", "AntiTools", {BTools = true})
-				end
 			end
 
 			--// Finish things up

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -448,7 +448,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.AntiGod = [[ If a player does not respawn when they should have they get respawned ]]
 	descs.AntiSpeed = [[ (Client-Sided) Attempts to detect speed exploits ]]
 	descs.AntiBuildingTools = [[ (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client ]]
-	descs.AntiClientIdle = = [[ (Client-Sided) Kick the player if they are using an anti-idle exploit ]]
+	descs.AntiClientIdle = [[ (Client-Sided) Kick the player if they are using an anti-idle exploit ]]
 	descs.AntiLeak = [[ (Client-Sided) Attempts to prevent place downloading/saving; Do not use if game saves ]]
 	descs.ProtectHats = [[ Prevents hats from being un-welded from their characters through unnormal means. ]]
 

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -334,7 +334,7 @@ local descs = {};			--// Contains settings descriptions
 	settings.AntiGod = false -- If a player does not respawn when they should have they get respawned
 	settings.AntiSpeed = true 			-- (Client-Sided) Attempts to detect speed exploits
 	settings.AntiBuildingTools = false	-- (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client
-	settings.AntiClientIdle = false 		-- (Client-Sided) Kick the player if they've been idle for too long, or anti-idle.
+	settings.AntiClientIdle = false 		-- (Client-Sided) Kick the player if they are using an anti-idle exploit
 	settings.AntiLeak = false			-- (Client-Sided) Attempts to prevent place downloading/saving; Do not use if game saves
 	settings.ProtectHats = false 				-- Prevents hats from being un-welded from their characters through unnormal means.
 
@@ -448,6 +448,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.AntiGod = [[ If a player does not respawn when they should have they get respawned ]]
 	descs.AntiSpeed = [[ (Client-Sided) Attempts to detect speed exploits ]]
 	descs.AntiBuildingTools = [[ (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client ]]
+	descs.AntiClientIdle = = [[ (Client-Sided) Kick the player if they are using an anti-idle exploit ]]
 	descs.AntiLeak = [[ (Client-Sided) Attempts to prevent place downloading/saving; Do not use if game saves ]]
 	descs.ProtectHats = [[ Prevents hats from being un-welded from their characters through unnormal means. ]]
 


### PR DESCRIPTION
Additions:
- Made the logspoof check work for disabling events too, now it is quite hard to bypass
- Implemented #716 expect the seperation of the log message checks (Details below)
- - Added `VirtualUser` and `VirtualInputManager` to disallowed services
- - Added "getrawmetatable" and "setfflag" to log detection strings

Deletions:
- Removed legacy coreclears & corenums and their updater, they aren't used for anything
- Removed legacy unused AntiGui, it was probably supposed to be made functional back in the day, but now it doesnt make much sense because of coregui, besides it would conflict with games if said was ever enabled
- Removed a dublicate tool detection, there was already one, so I removed the dublicate one
- Implemented #733 expect the removing of logservice detections because log detections are still very valid for many exploits, _excluding Synapse X_ They are also hard to bypass because of the log spoof check, _unless its done on an exploit level with a custom log output like Synapse does_ (Details below)
-  - Fixed incorrect intendation
-  - Fixed message log check audio (Its no longer possible to kick people via game devs using insecure remotes)
-  - Removed legacy `ScriptContext Non-CoreScript Detected` detection
-  - Removed legacy `ReplicatedFirst Localscript Detected` detection
-  - Removed annoying legacy `Selection Selection changed` detection (It false detects always in studio)
-  - Removed lastupdate vars for an unused check

Bug fixes:
- Made debugging anti-anti-idle more easier
- Main detection look longer waittime, because its probably better to not do it so often
- Core gui detetion bypass waits for longer, just in case it would take longer to load, it shouldnt be possible because its a local asset but Roblox do we weird sometimes
- Malicious object moved to main detection loop. Now you can disable all non-core AC checks for those who don't like them ;)
- Changed usage of incorrect timer to `os.clock()` for betterr accuracy and to ensure that nothing weird happens
- Fixed anti-dex bypass method 2 false kicking everyone always due to Adonis making rawequal work improperly, _apparently Adonis makes rawequal function in a wrong way, but relies on said behavior, so I had to use the original rawequal instead of fixing the wrong instance wrapping_
- Fixed incorrect description of anti-anti-idle checks, it says that its supposed to kick players for being afk, **which is not true**
- Made character checks automatically disabled if another anti-exploit that does the same is enabled. If we don't do this neither works because they negate their effects and cause an error in the output
- Fixed log detection bypass detection making an extra newline
- Fixed service detectors not working at all because of incorrect argument order
- Made tooldetection work by introducing task.wait()