### PR TITLE
Added "helpop" as an alias for request help

### DIFF
--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -366,7 +366,7 @@ return function(Vargs, env)
 
 		RequestHelp = {
 			Prefix = Settings.PlayerPrefix;
-			Commands = {"helpop", "help", "requesthelp", "gethelp", "lifealert", "sos", "sus"};
+			Commands = {"helpop", "help", "requesthelp", "gethelp", "lifealert", "sos"};
 			Args = {"reason"};
 			Hidden = false;
 			Description = "Calls admins for help";

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -366,7 +366,7 @@ return function(Vargs, env)
 
 		RequestHelp = {
 			Prefix = Settings.PlayerPrefix;
-			Commands = {"help", "requesthelp", "gethelp", "lifealert", "sos"};
+			Commands = {"helpop", "help", "requesthelp", "gethelp", "lifealert", "sos", "sus"};
 			Args = {"reason"};
 			Hidden = false;
 			Description = "Calls admins for help";


### PR DESCRIPTION
"!helpop" is a is a better name then "!help" because it's more self explanatory. "!help" can be confused with ":cmds" or "!info".

The "op" in it stands for operators. Other games (mainly Minecraft) have the equivalent of this command named "helpop".
I still kept the "help" alias as well for backwards compatibility.

It's also easier to remember than "!requesthelp"