### PR TITLE
Remove legacy check Anti-Cheat Parent not players from the pre-Filtering Enabled era

### DIFF
--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -57,10 +57,7 @@ return function()
 
 	local function RunAfterLoaded()
 		service.Player.Changed:Connect(function()
-			if service.Player.Parent ~= service.Players then
-				wait(5)
-				Anti.Detected("kick", "Parent not players", true)
-			elseif Anti.RLocked(service.Player) then
+			if Anti.RLocked(service.Player) then
 				Anti.Detected("kick", "Player is Roblox Locked")
 			end
 		end)
@@ -561,10 +558,12 @@ return function()
 			--// Detection Loop
 			local hasPrinted = false
 			service.StartLoop("Detection", 15, function()
+				--[[
 				--// Check player parent
 				if service.Player.Parent ~= service.Players then
 					Detected("kick", "Parent not players")
 				end
+				]]
 
 				--// Stuff
 				local ran,_ = pcall(function() service.ScriptContext.Name = "ScriptContext" end)

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -558,13 +558,6 @@ return function()
 			--// Detection Loop
 			local hasPrinted = false
 			service.StartLoop("Detection", 15, function()
-				--[[
-				--// Check player parent
-				if service.Player.Parent ~= service.Players then
-					Detected("kick", "Parent not players")
-				end
-				]]
-
 				--// Stuff
 				local ran,_ = pcall(function() service.ScriptContext.Name = "ScriptContext" end)
 				if not ran then


### PR DESCRIPTION
These are mostly unnecessary checks. They used to serve a purpose when Filtering Enabled (mid 2018 and before) didn't exist because you should possible hide the local player. But it no longer serves much use to exploiters and causes issues.