### PR TITLE
Fixed anti-idle for the final time

### DIFF
--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -139,8 +139,8 @@ return function()
 			local clientReplicator = networkClient
 
 			if
-				networkClient:GetChildren() == 1 and
-				networkClient:GetDescendants() == 1 and
+				#networkClient:GetChildren() == 1 and
+				#networkClient:GetDescendants() == 1 and
 				networkClient:GetChildren()[1] == clientReplicator and
 				networkClient:GetDescendants()[1] == clientReplicator and
 				networkClient:FindFirstChild("ClientReplicator") == clientReplicator and
@@ -183,7 +183,9 @@ return function()
 				not rawequal(type(idledEvent.Connect), "function") or
 				not rawequal(type(idledEvent.Wait), "function")
 			then
-				idleTamper("Userdata disrepencies detected")
+				if isAntiAntiIdlecheck ~= false then
+					idleTamper("Userdata disrepencies detected")
+				end
 			end
 
 			task.wait(200)

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -131,6 +131,37 @@ return function()
 		end
 
 		local isAntiAntiIdlecheck = Remote.Get("Setting", "AntiClientIdle")
+		local clientHasClosed = false
+
+		task.spawn(function()
+			local connection
+			local networkClient = service.UnWrap(service.NetworkClient)
+			local clientReplicator = networkClient
+
+			if
+				networkClient:GetChildren() == 1 and
+				networkClient:GetDescendants() == 1 and
+				networkClient:GetChildren()[1] == clientReplicator and
+				networkClient:GetDescendants()[1] == clientReplicator and
+				networkClient:FindFirstChild("ClientReplicator") == clientReplicator and
+				networkClient:FindFirstChildOfClass("ClientReplicator") == clientReplicator and
+				networkClient:FindFirstChildWhichIsA("ClientReplicator") == clientReplicator and
+				networkClient:FindFirstDescendant("ClientReplicator") == clientReplicator and
+				clientReplicator:FindFirstAncestor("NetworkClient") == networkClient
+			then
+				connection = networkClient.DescendantRemoving:Connect(function(object)
+					if
+						object == clientReplicator and
+						object.Parent == networkClient and
+						object:IsA("NetworkReplicator") and
+						object:GetPlayer() == service.UnWrap(Player)
+					then
+						connection:Disconnect()
+						clientHasClosed = true
+					end
+				end)
+			end
+		end)
 
 		while true do
 			local connection
@@ -139,14 +170,7 @@ return function()
 				if type(time) ~= "number" or not (time > 0) then
 					idleTamper("Invalid time data")
 				elseif time > 30 * 60 then
-					if isAntiAntiIdlecheck ~= false then
-						Detected("kick", "Anti-idle detected. "..tostring(math.ceil(time/60) - 20).." minutes above maximum possible Roblox value")
-					else
-						warn(
-							"The anti-idle detected!!!\nIf this is a false detection please report this so we can fix potential issues related"..
-							"\nto the anti-idle.\nPlease also tell all information that would help with debugging. "..tostring(math.ceil(time/60) - 20).." minutes above maximum possible Roblox value"
-						)
-					end
+					Detected("kick", "Anti-idle detected. "..tostring(math.ceil(time/60) - 20).." minutes above maximum possible Roblox value")
 				end
 			end)
 
@@ -164,6 +188,10 @@ return function()
 
 			task.wait(200)
 			connection:Disconnect()
+	
+			if clientHasClosed then
+				return
+			end
 		end
 	end)()
 

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -136,7 +136,7 @@ return function()
 		task.spawn(function()
 			local connection
 			local networkClient = service.UnWrap(service.NetworkClient)
-			local clientReplicator = networkClient
+			local clientReplicator = networkClient.ClientReplicator
 
 			if
 				#networkClient:GetChildren() == 1 and

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -169,7 +169,7 @@ return function()
 			connection = idledEvent:Connect(function(time)
 				if type(time) ~= "number" or not (time > 0) then
 					idleTamper("Invalid time data")
-				elseif time > 30 * 60 then
+				elseif time > 30 * 60 and isAntiAntiIdlecheck ~= false then
 					Detected("kick", "Anti-idle detected. "..tostring(math.ceil(time/60) - 20).." minutes above maximum possible Roblox value")
 				end
 			end)
@@ -183,9 +183,7 @@ return function()
 				not rawequal(type(idledEvent.Connect), "function") or
 				not rawequal(type(idledEvent.Wait), "function")
 			then
-				if isAntiAntiIdlecheck ~= false then
-					idleTamper("Userdata disrepencies detected")
-				end
+				idleTamper("Userdata disrepencies detected")
 			end
 
 			task.wait(200)


### PR DESCRIPTION
When this
![unknown](https://user-images.githubusercontent.com/68124053/165288790-5354da98-2977-4093-9b95-ec0b9f7c9e1f.png)

happened. **It doesn't mean that the AC kicked the player**, **Roblox already kicked the player for AFKing for 20 minutes.** But what happens is that the localscripts continue running, until the .Idled event produces an invalid value. When the player has been already kicked from the game by Roblox, the AC re-kicks them changing the kick message. **This leads to confusion that the Anti-Idle kicked the player from the game which isn't true.**

This pull request makes it so that the AntiIdle stops after the player has been disconnected from the game. And this this will no longer lead to confusion

Also don't worry about the excessive if checks, they can't lead to any "false detections" because they don't controll any detections. They are only to stop simple bypasses from completely disabling Anti-Idle