### PR TITLE
Changed the system shutdown title to that of the system message

### DIFF
--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1113,7 +1113,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		Shutdown = function(reason)
-			Functions.Message("Server Shutdown", "The server is shutting down...", service.Players:GetPlayers(), false, 5)
+			Functions.Message(Settings.SystemTitle, "The server is shutting down...", service.Players:GetPlayers(), false, 5)
 			wait(1)
 
 			service.Players.PlayerAdded:Connect(function(player)


### PR DESCRIPTION
Previously it was "SYSTEM TITLE", but was changed to "Server Shutdown".

It is a system message so it makes sense for it to adhere to the setting and not be an odd one out.

Also it's usefull for example for roleplay groups where it would say "Sizzleburgers" "Shutting down...".
It's also a bit weird for it to tell the information about the server shutting down 2 times "The server is shutting down..." already conveys this information so it doesn't make sense for it to be the title as well.