### PR TITLE
Add option to force use MockDatastore

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -144,6 +144,7 @@ local descs = {};			--// Contains settings descriptions
 	settings.DataStore = "Adonis_1"					 -- DataStore the script will use for saving data; Changing this will lose any saved data
 	settings.DataStoreKey = "CHANGE_THIS"			 -- CHANGE THIS TO SOMETHING RANDOM! Key used to encrypt all datastore entries; Changing this will lose any saved data
 	settings.DataStoreEnabled = true				 -- Disable if you don't want to load settings and admins from the datastore; PlayerData will still save
+	settings.UseLocalDatastore = false				 -- If this is turned on, the datastores will never save and be different to each server
 
 	settings.Storage = game:GetService("ServerStorage") -- Where things like tools are stored
 	settings.RecursiveTools = false					 -- Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders)
@@ -349,6 +350,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.DataStore = [[ DataStore the script will use for saving data; Changing this will lose any saved data ]]
 	descs.DataStoreKey = [[ Key used to encode all datastore entries; Changing this will lose any saved data ]]
 	descs.DataStoreEnabled = [[ Disable if you don't want settings and admins to be saveable in-game; PlayerData will still save ]]
+	descs.UseLocalDatastore = [[ If this is turned on, the datastores will never save and be different to each server ]]
 
 	descs.Storage = [[ Where things like tools are stored ]]
 	descs.RecursiveTools = [[ Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders) ]]
@@ -462,6 +464,7 @@ local descs = {};			--// Contains settings descriptions
 		"DataStore";
 		"DataStoreKey";
 		"DataStoreEnabled";
+		"UseLocalDatastore";
 		" ";
 		"Storage";
 		"RecursiveTools";

--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -144,7 +144,7 @@ local descs = {};			--// Contains settings descriptions
 	settings.DataStore = "Adonis_1"					 -- DataStore the script will use for saving data; Changing this will lose any saved data
 	settings.DataStoreKey = "CHANGE_THIS"			 -- CHANGE THIS TO SOMETHING RANDOM! Key used to encrypt all datastore entries; Changing this will lose any saved data
 	settings.DataStoreEnabled = true				 -- Disable if you don't want to load settings and admins from the datastore; PlayerData will still save
-	settings.UseLocalDatastore = false				 -- If this is turned on, the datastores will never save and be different to each server
+	settings.LocalDatastore = false				 -- If this is turned on, the datastores will never save and be different to each server
 
 	settings.Storage = game:GetService("ServerStorage") -- Where things like tools are stored
 	settings.RecursiveTools = false					 -- Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders)
@@ -350,7 +350,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.DataStore = [[ DataStore the script will use for saving data; Changing this will lose any saved data ]]
 	descs.DataStoreKey = [[ Key used to encode all datastore entries; Changing this will lose any saved data ]]
 	descs.DataStoreEnabled = [[ Disable if you don't want settings and admins to be saveable in-game; PlayerData will still save ]]
-	descs.UseLocalDatastore = [[ If this is turned on, the datastores will never save and be different to each server ]]
+	descs.LocalDatastore = [[ If this is turned on, the datastores will never save and be different to each server ]]
 
 	descs.Storage = [[ Where things like tools are stored ]]
 	descs.RecursiveTools = [[ Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders) ]]
@@ -464,7 +464,7 @@ local descs = {};			--// Contains settings descriptions
 		"DataStore";
 		"DataStoreKey";
 		"DataStoreEnabled";
-		"UseLocalDatastore";
+		"LocalDatastore";
 		" ";
 		"Storage";
 		"RecursiveTools";

--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -144,7 +144,7 @@ local descs = {};			--// Contains settings descriptions
 	settings.DataStore = "Adonis_1"					 -- DataStore the script will use for saving data; Changing this will lose any saved data
 	settings.DataStoreKey = "CHANGE_THIS"			 -- CHANGE THIS TO SOMETHING RANDOM! Key used to encrypt all datastore entries; Changing this will lose any saved data
 	settings.DataStoreEnabled = true				 -- Disable if you don't want to load settings and admins from the datastore; PlayerData will still save
-	settings.LocalDatastore = false				 -- If this is turned on, the datastores will never save and be different to each server
+	settings.LocalDatastore = false				 -- If this is turned on, the datastores will never save and be different with each server
 
 	settings.Storage = game:GetService("ServerStorage") -- Where things like tools are stored
 	settings.RecursiveTools = false					 -- Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders)
@@ -350,7 +350,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.DataStore = [[ DataStore the script will use for saving data; Changing this will lose any saved data ]]
 	descs.DataStoreKey = [[ Key used to encode all datastore entries; Changing this will lose any saved data ]]
 	descs.DataStoreEnabled = [[ Disable if you don't want settings and admins to be saveable in-game; PlayerData will still save ]]
-	descs.LocalDatastore = [[ If this is turned on, the datastores will never save and be different to each server ]]
+	descs.LocalDatastore = [[ If this is turned on, the datastores will never save and be different with each server ]]
 
 	descs.Storage = [[ Where things like tools are stored ]]
 	descs.RecursiveTools = [[ Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders) ]]

--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -144,7 +144,7 @@ local descs = {};			--// Contains settings descriptions
 	settings.DataStore = "Adonis_1"					 -- DataStore the script will use for saving data; Changing this will lose any saved data
 	settings.DataStoreKey = "CHANGE_THIS"			 -- CHANGE THIS TO SOMETHING RANDOM! Key used to encrypt all datastore entries; Changing this will lose any saved data
 	settings.DataStoreEnabled = true				 -- Disable if you don't want to load settings and admins from the datastore; PlayerData will still save
-	settings.LocalDatastore = false				 -- If this is turned on, the datastores will never save and be different with each server
+	settings.LocalDatastore = false				 -- If this is turned on, a mock DataStore will forcibly be used instead and shall never save across servers
 
 	settings.Storage = game:GetService("ServerStorage") -- Where things like tools are stored
 	settings.RecursiveTools = false					 -- Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders)
@@ -350,7 +350,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.DataStore = [[ DataStore the script will use for saving data; Changing this will lose any saved data ]]
 	descs.DataStoreKey = [[ Key used to encode all datastore entries; Changing this will lose any saved data ]]
 	descs.DataStoreEnabled = [[ Disable if you don't want settings and admins to be saveable in-game; PlayerData will still save ]]
-	descs.LocalDatastore = [[ If this is turned on, the datastores will never save and be different with each server ]]
+	descs.LocalDatastore = [[ If this is turned on, a mock DataStore will forcibly be used instead and shall never save across servers ]]
 
 	descs.Storage = [[ Where things like tools are stored ]]
 	descs.RecursiveTools = [[ Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders) ]]

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -147,6 +147,7 @@ return function(Vargs, GetEnv)
 			DataStore = true;
 			DataStoreKey = true;
 			DataStoreEnabled = true;
+			LocalDatastore = true;
 
 			Creators = true;
 			Permissions = true;
@@ -1133,7 +1134,7 @@ return function(Vargs, GetEnv)
 				local SavedSettings
 				local SavedTables
 				if Core.DataStore and Settings.DataStoreEnabled then
-					if Settings.DataStoreKey == server.Defaults.Settings.DataStoreKey then
+					if Settings.DataStoreKey == server.Defaults.Settings.DataStoreKey and not Settings.LocalDatastore then
 						table.insert(server.Messages, {
 							Title = "Warning!";
 							Message = "Using default datastore key!";

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -54,7 +54,7 @@ return function(Vargs, GetEnv)
 		Core.LoadstringObj = Core.GetLoadstring()
 		Core.Loadstring = require(Core.LoadstringObj)
 
-		service.DataStoreService = require(Deps.MockDataStoreService)
+		service.DataStoreService = require(Deps.MockDataStoreService)(Settings.LocalDatastore)
 
 		disableAllGUIs(server.Client.UI);
 

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -144,7 +144,7 @@ local descs = {};			--// Contains settings descriptions
 	settings.DataStore = "Adonis_1"					 -- DataStore the script will use for saving data; Changing this will lose any saved data
 	settings.DataStoreKey = "CHANGE_THIS"			 -- CHANGE THIS TO SOMETHING RANDOM! Key used to encrypt all datastore entries; Changing this will lose any saved data
 	settings.DataStoreEnabled = true				 -- Disable if you don't want to load settings and admins from the datastore; PlayerData will still save
-	settings.LocalDatastore = false				 -- If this is turned on, the datastores will never save and be different to each server
+	settings.LocalDatastore = false				 -- If this is turned on, the datastores will never save and be different with each server
 
 	settings.Storage = game:GetService("ServerStorage") -- Where things like tools are stored
 	settings.RecursiveTools = false					 -- Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders)
@@ -374,7 +374,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.DataStore = [[ DataStore the script will use for saving data; Changing this will lose any saved data ]]
 	descs.DataStoreKey = [[ Key used to encode all datastore entries; Changing this will lose any saved data ]]
 	descs.DataStoreEnabled = [[ Disable if you don't want settings and admins to be saveable in-game; PlayerData will still save ]]
-	descs.LocalDatastore = [[ If this is turned on, the datastores will never save and be different to each server ]]
+	descs.LocalDatastore = [[ If this is turned on, the datastores will never save and be different with each server ]]
 
 	descs.Storage = [[ Where things like tools are stored ]]
 	descs.RecursiveTools = [[ Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders) ]]

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -144,7 +144,7 @@ local descs = {};			--// Contains settings descriptions
 	settings.DataStore = "Adonis_1"					 -- DataStore the script will use for saving data; Changing this will lose any saved data
 	settings.DataStoreKey = "CHANGE_THIS"			 -- CHANGE THIS TO SOMETHING RANDOM! Key used to encrypt all datastore entries; Changing this will lose any saved data
 	settings.DataStoreEnabled = true				 -- Disable if you don't want to load settings and admins from the datastore; PlayerData will still save
-	settings.LocalDatastore = false				 -- If this is turned on, the datastores will never save and be different with each server
+	settings.LocalDatastore = false				 -- If this is turned on, a mock DataStore will forcibly be used instead and shall never save across servers
 
 	settings.Storage = game:GetService("ServerStorage") -- Where things like tools are stored
 	settings.RecursiveTools = false					 -- Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders)
@@ -374,7 +374,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.DataStore = [[ DataStore the script will use for saving data; Changing this will lose any saved data ]]
 	descs.DataStoreKey = [[ Key used to encode all datastore entries; Changing this will lose any saved data ]]
 	descs.DataStoreEnabled = [[ Disable if you don't want settings and admins to be saveable in-game; PlayerData will still save ]]
-	descs.LocalDatastore = [[ If this is turned on, the datastores will never save and be different with each server ]]
+	descs.LocalDatastore = [[ If this is turned on, a mock DataStore will forcibly be used instead and shall never save across servers ]]
 
 	descs.Storage = [[ Where things like tools are stored ]]
 	descs.RecursiveTools = [[ Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders) ]]

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -144,6 +144,7 @@ local descs = {};			--// Contains settings descriptions
 	settings.DataStore = "Adonis_1"					 -- DataStore the script will use for saving data; Changing this will lose any saved data
 	settings.DataStoreKey = "CHANGE_THIS"			 -- CHANGE THIS TO SOMETHING RANDOM! Key used to encrypt all datastore entries; Changing this will lose any saved data
 	settings.DataStoreEnabled = true				 -- Disable if you don't want to load settings and admins from the datastore; PlayerData will still save
+	settings.LocalDatastore = false				 -- If this is turned on, the datastores will never save and be different to each server
 
 	settings.Storage = game:GetService("ServerStorage") -- Where things like tools are stored
 	settings.RecursiveTools = false					 -- Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders)
@@ -373,6 +374,7 @@ local descs = {};			--// Contains settings descriptions
 	descs.DataStore = [[ DataStore the script will use for saving data; Changing this will lose any saved data ]]
 	descs.DataStoreKey = [[ Key used to encode all datastore entries; Changing this will lose any saved data ]]
 	descs.DataStoreEnabled = [[ Disable if you don't want settings and admins to be saveable in-game; PlayerData will still save ]]
+	descs.LocalDatastore = [[ If this is turned on, the datastores will never save and be different to each server ]]
 
 	descs.Storage = [[ Where things like tools are stored ]]
 	descs.RecursiveTools = [[ Whether tools included in subcontainers within settings.Storage are available via the :give command (useful if your tools are organized into multiple folders) ]]
@@ -486,6 +488,7 @@ local descs = {};			--// Contains settings descriptions
 		"DataStore";
 		"DataStoreKey";
 		"DataStoreEnabled";
+		"LocalDatastore";
 		" ";
 		"Storage";
 		"RecursiveTools";

--- a/MainModule/Server/Dependencies/MockDataStoreService.rbxmx
+++ b/MainModule/Server/Dependencies/MockDataStoreService.rbxmx
@@ -26,12 +26,14 @@ elseif game:GetService("RunService"):IsStudio() then -- Published file in Studio
 	end
 end
 
--- Return the mock or actual service depending on environment:
-if shouldUseMock then
-	warn(":: Adonis :: Using MockDataStoreService instead of DataStoreService")
-	return require(MockDataStoreServiceModule)
-else
-	return game:GetService("DataStoreService")
+return function(forceMockDatastore)
+	-- Return the mock or actual service depending on environment:
+	if shouldUseMock or forceMockDatastore then
+		warn(":: Adonis :: Using MockDataStoreService instead of DataStoreService")
+		return require(MockDataStoreServiceModule)
+	else
+		return game:GetService("DataStoreService")
+	end
 end
 ]]></string>
     </Properties>


### PR DESCRIPTION
Useful for testing or if you have a free admin game.

For example on free Admin games (or other games too) you never wan't any datastores to ever save.