### PR TITLE
better trello errors + provide example of `@username` in `!usage`

### DIFF
--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1350,6 +1350,7 @@ return function(Vargs, env)
 			Fun = false;
 			Filter = true;
 			CrossServerDenied = true;
+			TrelloRequired = true;
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string}, data: {any})
 				local trello = HTTP.Trello.API

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -264,6 +264,7 @@ return function(Vargs, env)
 			Hidden = false;
 			Description = "Adds a list to the Trello board set in Settings. AppKey and Token MUST be set and have write perms for this to work.";
 			Fun = false;
+			TrelloRequired = true;
 			AdminLevel = "HeadAdmins";
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "You need to supply a list name.")
@@ -283,6 +284,7 @@ return function(Vargs, env)
 			Hidden = false;
 			Description = "Views the specified Trello list from the primary board set in Settings.";
 			Fun = false;
+			TrelloRequired = true;
 			AdminLevel = "HeadAdmins";
 			Function = function(plr: Player, args: {string})
 				local trello = HTTP.Trello.API
@@ -306,6 +308,7 @@ return function(Vargs, env)
 			Hidden = false;
 			Description = "Opens a gui to make new Trello cards. AppKey and Token MUST be set and have write perms for this to work.";
 			Fun = false;
+			TrelloRequired = true;
 			AdminLevel = "HeadAdmins";
 			Function = function(plr: Player, args: {string})
 				Remote.MakeGui(plr, "CreateCard")

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1198,6 +1198,7 @@ return function(Vargs, env)
 			Hidden = false;
 			Description = "Shows Trello bans";
 			Fun = false;
+			TrelloRequired = true;
 			AdminLevel = "Moderators";
 			ListUpdater = function(plr: Player)
 				local tab = {}

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -548,7 +548,7 @@ return function(Vargs, env)
 					"<i>"..Settings.SpecialPrefix.."nonadmins</i> - Non-admins (normal players) in the server";
 					"<i>"..Settings.SpecialPrefix.."others</i> - Everyone except yourself";
 					"<i>"..Settings.SpecialPrefix.."random</i> - A random person in the server";
-					"<i>@USERNAME</i> - Targets a specific player with that exact username";
+					"<i>@USERNAME</i> - Targets a specific player with that exact username Ex: <i>"..Settings.Prefix.."god @Sceleratis </i> would give a player with the username 'Sceleratis' god powers";
 					"<i>#NUM</i> - NUM random players in the server <i>"..Settings.Prefix.."ff #5</i> will ff 5 random players.";
 					"<i>"..Settings.SpecialPrefix.."friends</i> - Your friends who are in the server";
 					"<i>%TEAMNAME</i> - Members of the team TEAMNAME Ex: "..Settings.Prefix.."kill %raiders";

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -296,7 +296,7 @@ return function(Vargs, GetEnv)
 						if allowed and (not Settings.Trello_Enabled or (Settings.Trello_Enabled and trello == nil)) and command.TrelloRequired then -- if trello is disabled or is setup incorrectly
 							Remote.MakeGui(p, "Output", {
 								Title = "";
-								Message = "Trello features is disabled or configured incorrectly in settings";
+								Message = "Trello features are disabled or configured incorrectly in settings";
 								Color = Color3.new(1, 0, 0);
 							})
 							return

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -296,7 +296,7 @@ return function(Vargs, GetEnv)
 						if allowed and (not Settings.Trello_Enabled or (Settings.Trello_Enabled and trello == nil)) and command.TrelloRequired then -- if trello is disabled or is setup incorrectly
 							Remote.MakeGui(p, "Output", {
 								Title = "";
-								Message = "Trello has not been configured correctly in settings";
+								Message = "Trello features is disabled or configured incorrectly in settings";
 								Color = Color3.new(1, 0, 0);
 							})
 							return

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -264,6 +264,7 @@ return function(Vargs, GetEnv)
 					else
 						local allowed = false
 						local isSystem = false
+						local trello = HTTP.Trello.API
 
 						local pDat = {
 							Player = opts.Player or p;
@@ -287,6 +288,15 @@ return function(Vargs, GetEnv)
 							Remote.MakeGui(p, "Output", {
 								Title = "";
 								Message = "This command cannot be used in Roblox Studio.";
+								Color = Color3.new(1, 0, 0);
+							})
+							return
+						end
+
+						if allowed and (not Settings.Trello_Enabled or (Settings.Trello_Enabled and trello == nil)) and command.TrelloRequired then -- if trello is disabled or is setup incorrectly
+							Remote.MakeGui(p, "Output", {
+								Title = "";
+								Message = "Trello has not been configured correctly in settings";
 								Color = Color3.new(1, 0, 0);
 							})
 							return


### PR DESCRIPTION
- for commands where trello is required, display an error saying that trello isnt configured correctly if it wasnt setup properly or disabled
- `!usage` now has an example for the `@username` argument