### PR TITLE
Some command feedback-related UX and misc. improvements 

### DIFF
--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1230,7 +1230,7 @@ return function(Vargs, env)
 					if data.PlayerData.Level > Admin.GetLevel(v) then
 						Remote.Send(v, "Function", "HardCrash")
 					else
-						Functions.Hint("Unable to crash "..service.FormatPlayer(v).." (insufficient permission level)", {plr})
+						Functions.Hint("Unable to crash "..tostring(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -1254,7 +1254,7 @@ return function(Vargs, env)
 					if data.PlayerData.Level > Admin.GetLevel(v) then
 						Remote.Send(v, "Function", "RAMCrash")
 					else
-						Functions.Hint("Unable to crash "..service.FormatPlayer(v).." (insufficient permission level)", {plr})
+						Functions.Hint("Unable to crash "..tostring(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -1278,7 +1278,7 @@ return function(Vargs, env)
 					if data.PlayerData.Level > Admin.GetLevel(v) then
 						Remote.Send(v, "Function", "GPUCrash")
 					else
-						Functions.Hint("Unable to crash "..service.FormatPlayer(v).." (insufficient permission level)", {plr})
+						Functions.Hint("Unable to crash "..tostring(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -1333,9 +1333,9 @@ return function(Vargs, env)
 					})) do
 					if level > Admin.GetLevel(v) then
 						Admin.AddBan(v, reason)
-						Functions.Hint("Server-banned "..service.FormatPlayer(v), {plr})
+						Functions.Hint("Server-banned "..tostring(v), {plr})
 					else
-						Functions.Hint("Unable to ban "..service.FormatPlayer(v).." (insufficient permission level)", {plr})
+						Functions.Hint("Unable to ban "..tostring(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -966,14 +966,14 @@ return function(Vargs, env)
 				elseif action == "list" then
 					local tab = {}
 					for i, v in pairs(sb.Script) do
-						table.insert(tab, {Text = "Script: "..tostring(i),Desc = "Running: "..tostring(v.Script.Disabled)})
+						table.insert(tab, {Text = "Script: "..tostring(i), Desc = "Running: "..tostring(v.Script.Disabled)})
 					end
 
 					for i, v in pairs(sb.LocalScript) do
-						table.insert(tab, {Text = "LocalScript: "..tostring(i),Desc = "Running: "..tostring(v.Script.Disabled)})
+						table.insert(tab, {Text = "LocalScript: "..tostring(i), Desc = "Running: "..tostring(v.Script.Disabled)})
 					end
 
-					Remote.MakeGui(plr, "List", {Title = "SB Scripts",Table = tab})
+					Remote.MakeGui(plr, "List", {Title = "SB Scripts", Table = tab})
 				end
 			end
 		};
@@ -992,7 +992,7 @@ return function(Vargs, env)
 				local bytecode = Core.Bytecode(args[1])
 				assert(string.find(bytecode, "\27Lua"), "Script unable to be created,".. string.gsub(bytecode, "Loadstring%.LuaX:%d+:", ""))
 
-				local cl = Core.NewScript('Script', args[1], true)
+				local cl = Core.NewScript("Script", args[1], true)
 				cl.Name = "[Adonis] Script"
 				cl.Parent = service.ServerScriptService
 				task.wait()
@@ -1014,7 +1014,7 @@ return function(Vargs, env)
 				local bytecode = Core.Bytecode(args[1])
 				assert(string.find(bytecode, "\27Lua"), "Script unable to be created,".. string.gsub(bytecode, "Loadstring%.LuaX:%d+:", ""))
 
-				local cl = Core.NewScript('LocalScript', "script.Parent = game:GetService('Players').LocalPlayer.PlayerScripts; "..args[1], true)
+				local cl = Core.NewScript("LocalScript", "script.Parent = game:GetService('Players').LocalPlayer.PlayerScripts; "..args[1], true)
 				cl.Name = "[Adonis] LocalScript"
 				cl.Disabled = true
 				cl.Parent = plr:FindFirstChildOfClass("Backpack")
@@ -1037,8 +1037,8 @@ return function(Vargs, env)
 				local bytecode = Core.Bytecode(args[2])
 				assert(string.find(bytecode, "\27Lua"), "Script unable to be created, ".. string.gsub(bytecode, "Loadstring%.LuaX:%d+:", ""))
 
-				local new = Core.NewScript('LocalScript', "script.Parent = game:GetService('Players').LocalPlayer.PlayerScripts; "..args[2], true)
-				for i, v in pairs(service.GetPlayers(plr, args[1]))do
+				local new = Core.NewScript("LocalScript", "script.Parent = game:GetService('Players').LocalPlayer.PlayerScripts; "..args[2], true)
+				for i, v in pairs(service.GetPlayers(plr, args[1])) do
 					local cl = new:Clone()
 					cl.Name = "[Adonis] LocalScript"
 					cl.Disabled = true
@@ -1062,8 +1062,8 @@ return function(Vargs, env)
 					local PlayerData = Core.GetPlayer(v)
 					if not PlayerData.AdminNotes then PlayerData.AdminNotes={} end
 					table.insert(PlayerData.AdminNotes, args[2])
-					Functions.Hint('Added '..v.Name..' Note '..args[2], {plr})
-					Core.SavePlayer(v,PlayerData)
+					Functions.Hint("Added "..v.Name.." Note "..args[2], {plr})
+					Core.SavePlayer(v, PlayerData)
 				end
 			end
 		};
@@ -1071,7 +1071,7 @@ return function(Vargs, env)
 		DeleteNote = {
 			Prefix = Settings.Prefix;
 			Commands = {"removenote", "remnote", "deletenote"};
-			Args = {"player", "note"};
+			Args = {"player", "note (specify 'all' to delete all notes)"};
 			Description = "Removes a note on the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
@@ -1079,16 +1079,16 @@ return function(Vargs, env)
 					local PlayerData = Core.GetPlayer(v)
 					if PlayerData.AdminNotes then
 						if string.lower(args[2]) == "all" then
-							PlayerData.AdminNotes={}
+							PlayerData.AdminNotes = {}
 						else
-							for k,m in ipairs(PlayerData.AdminNotes) do
-								if string.sub(string.lower(m), 1,#args[2]) == string.lower(args[2])then
-									Functions.Hint('Removed '..v.Name..' Note '..m, {plr})
-									table.remove(PlayerData.AdminNotes,k)
+							for k, m in ipairs(PlayerData.AdminNotes) do
+								if string.sub(string.lower(m), 1, #args[2]) == string.lower(args[2]) then
+									Functions.Hint("Removed "..v.Name.." Note "..m, {plr})
+									table.remove(PlayerData.AdminNotes, k)
 								end
 							end
 						end
-						Core.SavePlayer(v,PlayerData)--v:SaveInstance("Admin Notes", notes)
+						Core.SavePlayer(v, PlayerData)--v:SaveInstance("Admin Notes", notes)
 					end
 				end
 			end
@@ -1105,10 +1105,10 @@ return function(Vargs, env)
 					local PlayerData = Core.GetPlayer(v)
 					local notes = PlayerData.AdminNotes
 					if not notes then
-						Functions.Hint('No notes on '..v.Name, {plr})
+						Functions.Hint("No notes on "..v.Name, {plr})
 						return
 					end
-					Remote.MakeGui(plr,'List', {Title = v.Name,Table = notes})
+					Remote.MakeGui(plr, "List", {Title = v.Name, Table = notes})
 				end
 			end
 		};
@@ -1116,16 +1116,24 @@ return function(Vargs, env)
 		LoopKill = {
 			Prefix = Settings.Prefix;
 			Commands = {"loopkill"};
-			Args = {"player", "num(optional)"};
-			Description = "Loop kills the target player(s)";
+			Args = {"player", "num (optional)"};
+			Description = "Repeatedly kills the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				local num = tonumber(args[2]) or 9999
 
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
 					service.StopLoop(v.UserId.."LOOPKILL")
-					Routine(service.StartLoop, v.UserId.."LOOPKILL",3,function()
-						v.Character:BreakJoints()
+					local count = 0
+					Routine(service.StartLoop, v.UserId.."LOOPKILL", 3, function()
+						local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
+						if hum and hum.Health > 0 then
+							hum.Health = 0
+							count += 1
+						end
+						if count == num then
+							service.StopLoop(v.UserId.."LOOPKILL")
+						end
 					end)
 				end
 			end
@@ -1156,8 +1164,10 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string}, data: {any})
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
-					if data.PlayerData.Level>Admin.GetLevel(v) then
+					if data.PlayerData.Level > Admin.GetLevel(v) then
 						Remote.Send(v, "Function", "SetFPS", 5.6)
+					else
+						Functions.Hint("Unable to lag "..tostring(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -1193,8 +1203,10 @@ return function(Vargs, env)
 					IsKicking = true;
 					UseFakePlayer = true;
 					})) do
-					if data.PlayerData.Level>Admin.GetLevel(v) then
-						Remote.Send(v,'Function','Crash')
+					if data.PlayerData.Level > Admin.GetLevel(v) then
+						Remote.Send(v, "Function", "Crash")
+					else
+						Functions.Hint("Unable to crash "..tostring(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -1215,8 +1227,10 @@ return function(Vargs, env)
 					IsKicking = true;
 					UseFakePlayer = true;
 					})) do
-					if data.PlayerData.Level>Admin.GetLevel(v) then
-						Remote.Send(v,'Function','HardCrash')
+					if data.PlayerData.Level > Admin.GetLevel(v) then
+						Remote.Send(v, "Function", "HardCrash")
+					else
+						Functions.Hint("Unable to crash "..service.FormatPlayer(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -1237,8 +1251,10 @@ return function(Vargs, env)
 					IsKicking = true;
 					UseFakePlayer = true;
 					})) do
-					if data.PlayerData.Level>Admin.GetLevel(v) then
-						Remote.Send(v,'Function','RAMCrash')
+					if data.PlayerData.Level > Admin.GetLevel(v) then
+						Remote.Send(v, "Function", "RAMCrash")
+					else
+						Functions.Hint("Unable to crash "..service.FormatPlayer(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -1259,8 +1275,10 @@ return function(Vargs, env)
 					IsKicking = true;
 					UseFakePlayer = true;
 					})) do
-					if data.PlayerData.Level>Admin.GetLevel(v) then
-						Remote.Send(v,'Function','GPUCrash')
+					if data.PlayerData.Level > Admin.GetLevel(v) then
+						Remote.Send(v, "Function", "GPUCrash")
+					else
+						Functions.Hint("Unable to crash "..service.FormatPlayer(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -1284,7 +1302,7 @@ return function(Vargs, env)
 
 						local nlogs = #logs
 						if nlogs > 1000 then
-							table.remove(logs,nlogs)
+							table.remove(logs, nlogs)
 						end
 
 						return logs
@@ -1312,10 +1330,12 @@ return function(Vargs, env)
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = true;
-					}))do
+					})) do
 					if level > Admin.GetLevel(v) then
 						Admin.AddBan(v, reason)
-						Functions.Hint("Server banned "..tostring(v), {plr})
+						Functions.Hint("Server-banned "..service.FormatPlayer(v), {plr})
+					else
+						Functions.Hint("Unable to ban "..service.FormatPlayer(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -1329,7 +1349,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Argument #1 (player) is required")
-				for _,v in pairs(service.GetPlayers(plr,args[1])) do
+				for _, v in pairs(service.GetPlayers(plr, args[1])) do
 					local ret = Admin.RemoveBan(v.Name)
 					if ret then
 						if type(ret) == "table" then
@@ -1419,14 +1439,15 @@ return function(Vargs, env)
 			Prefix = Settings.Prefix;
 			Commands = {"nil"};
 			Args = {"player"};
-			Hidden = false;
-			Description = "Sends the target player(s) to the nil, where they can still run admin commands etc and just not show up on the player list";
+			Hidden = true;
+			Description = "Sends the target player(s) to nil, where they will not show up on the player list and not normally be able to interact with the game";
 			Fun = false;
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
 					v.Character = nil
 					v.Parent = nil
+					Functions.Hint("Sent "..service.FormatPlayer(v).." to nil", {plr})
 				end
 			end
 		};

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -144,6 +144,8 @@ return function(Vargs, env)
 					if level > Admin.GetLevel(v) then
 						Admin.AddBan(v, reason, true)
 						Functions.Hint("Game banned "..tostring(v), {plr})
+					else
+						Functions.Hint("Unable to game-ban "..tostring(v).." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -192,9 +194,9 @@ return function(Vargs, env)
 							Icon = server.MatIcons["Admin panel settings"];
 							OnClick = Core.Bytecode("client.Remote.Send('ProcessCommand','"..Settings.Prefix.."cmds')");
 						})
-						Functions.Hint(v.Name..' is now an admin', {plr})
+						Functions.Hint(v.Name.." is now an admin", {plr})
 					else
-						Functions.Hint(v.Name.." is the same admin level as you or higher", {plr})
+						Functions.Hint(v.Name.." is already the same admin level as you or higher", {plr})
 					end
 				end
 			end
@@ -221,9 +223,9 @@ return function(Vargs, env)
 							Icon = server.MatIcons["Admin panel settings"];
 							OnClick = Core.Bytecode("client.Remote.Send('ProcessCommand','"..Settings.Prefix.."cmds')");
 						})
-						Functions.Hint(v.Name..' is now a temp admin', {plr})
+						Functions.Hint(v.Name.." is now a temporary admin", {plr})
 					else
-						Functions.Hint(v.Name.." is the same admin level as you or higher", {plr})
+						Functions.Hint(v.Name.." is already the same admin level as you or higher", {plr})
 					end
 				end
 			end
@@ -242,7 +244,7 @@ return function(Vargs, env)
 				assert(args[1], "Missing message")
 
 				if not Core.CrossServer("Message", plr.Name, args[1]) then
-					error("CrossServer Handler Not Ready");
+					error("CrossServer handler not ready; please try again later")
 				end
 			end;
 		};
@@ -260,9 +262,8 @@ return function(Vargs, env)
 				assert(args[1], "Missing time amount")
 				assert(args[2], "Missing message")
 
-
 				if not Core.CrossServer("Message", plr.Name, args[2], args[1]) then
-					error("CrossServer Handler Not Ready");
+					error("CrossServer handler not ready; please try again later")
 				end
 			end;
 		};
@@ -405,7 +406,7 @@ return function(Vargs, env)
 			Commands = {"explore", "explorer"};
 			Args = {};
 			Hidden = false;
-			Description = "Lets you explore the game, kinda like a file browser";
+			Description = "Lets you explore the game, kinda like a file browser (alternative to "..Settings.Prefix.."dex)";
 			Fun = false;
 			AdminLevel = "HeadAdmins";
 			Function = function(plr: Player, args: {string})

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -37,7 +37,9 @@ return function(Vargs, env)
 							v:Kick(args[2])
 						end
 
-						Functions.Hint("Kicked ".. PlayerName, {plr})
+						Functions.Hint("Kicked "..PlayerName, {plr})
+					else
+						Functions.Hint("Unable to kick "..PlayerName.." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -415,6 +417,8 @@ return function(Vargs, env)
 							Time = 5;
 							OnClick = Core.Bytecode("client.Remote.Send('ProcessCommand','"..Settings.Prefix.."warnings "..v.Name.."')")
 						})
+					else
+						Functions.Hint("Unable to warn "..v.Name.." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -492,6 +496,8 @@ return function(Vargs, env)
 							Time = 5;
 							OnClick = Core.Bytecode("client.Remote.Send('ProcessCommand','"..Settings.Prefix.."warnings "..v.Name.."')")
 						})
+					else
+						Functions.Hint("Unable to kickwarn "..v.Name.." (insufficient permission level)", {plr})
 					end
 				end
 			end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -39,7 +39,7 @@ return function(Vargs, env)
 
 						Functions.Hint("Kicked "..PlayerName, {plr})
 					else
-						Functions.Hint("Unable to kick "..PlayerName.." (insufficient permission level)", {plr})
+						Functions.Hint("Unable to kick "..v.Name.." (insufficient permission level)", {plr})
 					end
 				end
 			end
@@ -1486,28 +1486,32 @@ return function(Vargs, env)
 			Description = "Makes a camera named whatever you pick";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				if plr and plr.Character and plr.Character:FindFirstChild("Head") then
-					if workspace:FindFirstChild("Camera: "..args[1]) then
-						Functions.Hint(args[1].." Already Exists!", {plr})
-					else
-						local cam = service.New("Part", workspace)
-						cam.Position = plr.Character.Head.Position
-						cam.Anchored = true
-						cam.BrickColor = BrickColor.new("Really black")
-						cam.CanCollide = false
-						cam.Locked = true
-						cam.FormFactor = "Custom"
-						cam.Size = Vector3.new(1, 1, 1)
-						cam.TopSurface = "Smooth"
-						cam.BottomSurface = "Smooth"
-						cam.Name="Camera: "..args[1]
-						--service.New("PointLight", cam)
-						cam.Transparency=1--.9
-						local mesh=service.New("SpecialMesh", cam)
-						mesh.Scale=Vector3.new(1, 1, 1)
-						mesh.MeshType="Sphere"
-						table.insert(Variables.Cameras, {Brick = cam, Name = args[1]})
-					end
+				local head = plr.Character and (plr.Character:FindFirstChild("Head") or plr.Character:FindFirstChild("HumanoidRootPart"))
+				assert(head and head:IsA("BasePart"), "You don't have a character head or root part")
+				if workspace:FindFirstChild("Camera: "..args[1]) then
+					Functions.Hint(args[1].." Already Exists!", {plr})
+				else
+					local cam = service.New("Part", {
+						Parent = workspace;
+						Name = "Camera: "..args[1];
+						Position = head.Position;
+						Anchored = true;
+						BrickColor = BrickColor.new("Really black");
+						CanCollide = false;
+						Locked = true;
+						FormFactor = "Custom";
+						Size = Vector3.new(1, 1, 1);
+						TopSurface = "Smooth";
+						BottomSurface = "Smooth";
+						cam.Transparency = 1;--.9
+					})
+					--service.New("PointLight", cam)
+					local mesh = service.New("SpecialMesh", {
+						Parent = cam;
+						Scale = Vector3.new(1, 1, 1);
+						MeshType = "Sphere";
+					})
+					table.insert(Variables.Cameras, {Brick = cam, Name = args[1]})
 				end
 			end
 		};
@@ -1538,7 +1542,7 @@ return function(Vargs, env)
 					for _, v in pairs(service.GetPlayers(plr, args[2])) do
 						if v and v.Character:FindFirstChild("Humanoid") then
 							plr.ReplicationFocus = v.Character.PrimaryPart
-							Remote.Send(p, "Function", "SetView", v.Character.Humanoid)
+							Remote.Send(p, "Function", "SetView", v.Character:FindFirstChildOfClass("Humanoid"))
 						end
 					end
 				end
@@ -1555,7 +1559,7 @@ return function(Vargs, env)
 				for _, v in pairs(service.GetPlayers(plr, args[1])) do
 					if v and v.Character:FindFirstChild("Humanoid") then
 						plr.ReplicationFocus = v.Character.PrimaryPart
-						Remote.Send(plr, "Function", "SetView", v.Character.Humanoid)
+						Remote.Send(plr, "Function", "SetView", v.Character:FindFirstChildOfClass("Humanoid"))
 					end
 				end
 			end
@@ -1569,7 +1573,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for _, v in pairs(service.GetPlayers(plr, args[1])) do
-					if v and v.Character:FindFirstChild("Humanoid") then
+					if v and v.Character:FindFirstChildOfClass("Humanoid") then
 						Remote.MakeGui(plr, "Viewport", {Subject = v.Character.HumanoidRootPart});
 					end
 				end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -985,7 +985,7 @@ return function(Vargs, env)
 							end
 						elseif cmd == "EndSession" and p == plr then
 							systemMessage("<i>Session ended</i>")
-							
+
 							newSession:End()
 						elseif cmd == "AddPlayerToSession" and (p == plr or Admin.CheckAdmin(p)) then
 							local player = args[1]
@@ -1480,7 +1480,7 @@ return function(Vargs, env)
 
 		MakeCamera = {
 			Prefix = Settings.Prefix;
-			Commands = {"makecam", "makecamera", "camera"};
+			Commands = {"makecam", "makecamera", "camera", "newcamera", "newcam"};
 			Args = {"name"};
 			Filter = true;
 			Description = "Makes a camera named whatever you pick";
@@ -1503,7 +1503,7 @@ return function(Vargs, env)
 						Size = Vector3.new(1, 1, 1);
 						TopSurface = "Smooth";
 						BottomSurface = "Smooth";
-						cam.Transparency = 1;--.9
+						Transparency = 1;--.9
 					})
 					--service.New("PointLight", cam)
 					local mesh = service.New("SpecialMesh", {
@@ -3631,7 +3631,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Argument 1 missing")
-				
+
 				local color = Functions.ParseColor3(args[1])
 				assert(color, "Invalid color provided")
 
@@ -4901,12 +4901,12 @@ return function(Vargs, env)
 					[71] = Enum.AccessoryType.RightShoe,
 					[72] = Enum.AccessoryType.DressSkirt,
 				}
-				
+
 				for _, v: Player in pairs(service.GetPlayers(plr, args[1])) do
 					local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
-						
+
 						if SingleAssetIds[typeId] then
 							humanoidDesc[SingleAssetIds[typeId]] = itemId
 						elseif AccessoryAssetIds[typeId] then
@@ -4925,7 +4925,7 @@ return function(Vargs, env)
 						else
 							error("Item not supported")
 						end
-						
+
 						task.defer(humanoid.ApplyDescription, humanoid, humanoidDesc)
 					end
 				end
@@ -4973,7 +4973,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-		
+
 		RemovePants = {
 			Prefix = Settings.Prefix;
 			Commands = {"removepants"};


### PR DESCRIPTION
- Attempting to run ``:crash``, ``:ban`` etc. on a higher-ranked admin now displays an "insufficient permission level" error hint as a feedback to the executor, rather than doing nothing and leaving them to wonder if the command is working properly.

- Edited and fixed ``:loopkill <player> <num>``. That is, I hope.

- Updated the description of ``:nil`` and made it a hidden command since we don't expect it to be useful in any way nor easily-understood by users.

- Updated the description of ``:explorer``, amongst a few miscellaneous wording improvements.

- And of course, there's the random code formatting improvements here and there.