### PR TITLE
Fixed Major issue that prevented certain DataStores to save, but specifically the rank adding and removing

### DIFF
--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -980,7 +980,7 @@ return function(Vargs, GetEnv)
 				local tab = data.Table
 				local value = data.Value
 
-				if type(tab) == "string" then
+				if typeof(tab) == "string" then
 					tab = {"Settings", tab}
 				end
 
@@ -1028,7 +1028,7 @@ return function(Vargs, GetEnv)
 				local tab = data.Table
 				local value = data.Value
 
-				if type(tab) == "string" then
+				if typeof(tab) == "string" then
 					tab = {"Settings", tab}
 				end
 


### PR DESCRIPTION
After this pull request was made https://github.com/Sceleratis/Adonis/pull/781


If you would be modding someone, it wouldn't be saving it.
![image](https://user-images.githubusercontent.com/12023782/175300436-dbff2a34-e14c-4f3a-adb2-d8a490333db7.png)


So when you Stop and retry game, you would see this.
![image](https://user-images.githubusercontent.com/12023782/175300584-650d9ee9-7fbf-4774-af41-7836e7da46ba.png)



The reason for that is because an issue like this was caused ``ServerScriptService.Adonis_Rojo.MainModule.Server.Core.Core:1031: attempt to call a string value``

This was caused by ``if type(tab) == "string" then``

and what I did, is I changed it to ``if typeof(tab) == "string" then`` and saving worked again.

There might be other DataStore issues, somewhere, but I fixed this one.