### PR TITLE
Deprecation of Remote.UnEncrypted

### DIFF
--- a/MainModule/Client/Core/Process.lua
+++ b/MainModule/Client/Core/Process.lua
@@ -116,9 +116,9 @@ return function(Vargs, GetEnv)
 			RateLog = 10;
 		};
 
-		Remote = function(data,com,...)
+		Remote = function(data, com, ...)
 			local args = {...}
-			Remote.Received = Remote.Received+1
+			Remote.Received = += 1
 			if type(com) == "string" then
 				if com == client.DepsName.."GIVE_KEY" then
 					if not Core.Key then
@@ -128,8 +128,6 @@ return function(Vargs, GetEnv)
 						log("~! Call Finish_Loading()")
 						client.Finish_Loading()
 					end
-				elseif Remote.UnEncrypted[com] then
-					return {Remote.UnEncrypted[com](...)}
 				elseif Core.Key then
 					local comString = Remote.Decrypt(com,Core.Key)
 					local command = (data.Mode == "Get" and Remote.Returnables[comString]) or Remote.Commands[comString]

--- a/MainModule/Client/Core/Process.lua
+++ b/MainModule/Client/Core/Process.lua
@@ -118,7 +118,7 @@ return function(Vargs, GetEnv)
 
 		Remote = function(data, com, ...)
 			local args = {...}
-			Remote.Received = += 1
+			Remote.Received += 1
 			if type(com) == "string" then
 				if com == client.DepsName.."GIVE_KEY" then
 					if not Core.Key then
@@ -169,7 +169,7 @@ return function(Vargs, GetEnv)
 		CharacterAdded = function(...)
 			service.Events.CharacterAdded:Fire(...)
 
-			wait();
+			wait()
 			UI.GetHolder()
 		end;
 
@@ -194,11 +194,11 @@ return function(Vargs, GetEnv)
 			end
 
 			if Variables.ChatEnabled then
-				service.StarterGui:SetCoreGuiEnabled("Chat",true)
+				service.StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.Chat, true)
 			end
 
 			if Variables.PlayerListEnabled then
-				service.StarterGui:SetCoreGuiEnabled('PlayerList',true)
+				service.StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.PlayerList, true)
 			end
 
 			local textbox = service.UserInputService:GetFocusedTextBox()

--- a/MainModule/Client/Core/Remote.lua
+++ b/MainModule/Client/Core/Remote.lua
@@ -256,7 +256,12 @@ return function(Vargs, GetEnv)
 			end;
 		};
 
-		UnEncrypted = {};
+		UnEncrypted = setmetatable({}, {
+			__newindex = function(_, ind, val)
+				warn("Remote.UnEncrypted is deprecated; moving", ind, "to Remote.Commands")
+				Remote.Commands[ind] = val
+			end
+		});
 
 		Commands = {
 			GetReturn = function(args)

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -14,7 +14,7 @@ return function(Vargs, GetEnv)
 	local server = Vargs.Server
 	local service = Vargs.Service
 
-	local Commands, Decrypt, Encrypt, UnEncrypted, AddLog, TrackTask, Pcall
+	local Commands, Decrypt, Encrypt, AddLog, TrackTask, Pcall
 	local Functions, Admin, Anti, Core, HTTP, Logs, Remote, Process, Variables, Settings, Defaults
 	local function Init()
 		Functions = server.Functions;
@@ -32,7 +32,6 @@ return function(Vargs, GetEnv)
 		Commands = Remote.Commands
 		Decrypt = Remote.Decrypt
 		Encrypt = Remote.Encrypt
-		UnEncrypted = Remote.UnEncrypted
 		AddLog = Logs.AddLog
 		TrackTask = service.TrackTask
 		Pcall = server.Pcall
@@ -279,7 +278,7 @@ return function(Vargs, GetEnv)
 						if type(com) == "string" then
 							if com == keys.Special.."GET_KEY" then
 								if keys.LoadingStatus == "WAITING_FOR_KEY" then
-									Remote.Fire(p,keys.Special.."GIVE_KEY",keys.Key)
+									Remote.Fire(p, keys.Special.."GIVE_KEY", keys.Key)
 									keys.LoadingStatus = "LOADING"
 									keys.RemoteReady = true
 
@@ -293,14 +292,6 @@ return function(Vargs, GetEnv)
 									Desc = "Player requested key from server",
 									Player = p;
 								})
-							elseif UnEncrypted[com] then
-								AddLog("RemoteFires", {
-									Text = p.Name.." fired "..tostring(com),
-									Desc = "Player fired unencrypted remote command "..com,
-									Player = p;
-								})
-
-								return {UnEncrypted[com](p,...)}
 							elseif rateLimitCheck and string.len(com) <= Remote.MaxLen then
 								local comString = Decrypt(com, keys.Key, keys.Cache)
 								local command = (cliData.Mode == "Get" and Remote.Returnables[comString]) or Remote.Commands[comString]

--- a/MainModule/Server/Core/Remote.lua
+++ b/MainModule/Server/Core/Remote.lua
@@ -672,22 +672,12 @@ return function(Vargs, GetEnv)
 
 		};
 
-		UnEncrypted = {
-			--[[TrustCheck = function(p)
-				local keys = Remote.Clients[tostring(p.UserId)]
-				Remote.Fire(p, "TrustCheck", keys.Special)
-			end;--]]
-
-			ProcessChat = function(p: Player,msg: string)
-				Process.Chat(p,msg)
-			end;
-
-			ExplorerAction = function(p: Player, ...)
-				--if Admin.CheckAdmin(p) then
-				--// Handle stuff like Dex calls(?)
-				--end
-			end;
-		};
+		UnEncrypted = setmetatable({}, {
+			__newindex = function(_, ind, val)
+				warn("Unencrypted remote commands are deprecated; moving", ind, "to Remote.Commands")
+				Remote.Commands[ind] = val
+			end
+		});
 
 		Commands = {
 			GetReturn = function(p: Player,args: {[number]: any})


### PR DESCRIPTION
Kinda old and unused; also potentially abusable considering that it isn't ratelimited.

Credit to @fxeP1 for suggesting its complete removal.