### PR TITLE
Fix for :resetstats not resetting NumberValues

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2404,7 +2404,7 @@ return function(Vargs, env)
 					cPcall(function()
 						if v and v:FindFirstChild("leaderstats") then
 							for a, q in pairs(v.leaderstats:GetChildren()) do
-								if q:IsA("IntValue") then q.Value = 0 end
+								if q:IsA("IntValue") or q:IsA("NumberValue") then q.Value = 0 end
 							end
 						end
 					end)


### PR DESCRIPTION
Caused by the script checking for an IntValue only,
This made it so it check for both IntValue and NumberValue