### PR TITLE
Fix TrelloAPI requiring Token

### DIFF
--- a/MainModule/Server/Dependencies/TrelloAPI.lua
+++ b/MainModule/Server/Dependencies/TrelloAPI.lua
@@ -187,14 +187,21 @@ return function(AppKey, Token)
 	
 	local CheckHttp = function()
 		local enabled, err = pcall(function()
-			HttpService:GetAsync(GetUrl("members/me?fields=id"))
+			HttpService:GetAsync(GetUrl("members/trello?fields=id"))
 		end)
-
+		
 		return enabled
 	end;
-
+	
+	local HttpEnabled = pcall(HttpService.GetAsync, HttpService, "http://www.google.com/robots.txt");
+	
+	if not HttpEnabled then
+		error("Unable to connect to trello, Http requests are not enabled. Enable them via game settings.")
+		return
+	end
+	
 	if not CheckHttp() then
-		error("Could not connect to Trello! Make sure HTTP is enabled")
+		error("Could not connect to Trello! Please check if your app-key/token are valid.")
 		return
 	end;
 


### PR DESCRIPTION
By sending a http request to `https://trello.com/1/members/me`, it would return 400 if there was no token. 

Changing this to some constant like `https://trello.com/1/members/trello` will work with a valid app key. With an invalid app key it returns an error. No token is required. 

This PR also adds in a check for httpenabled before running the trello validity check. 

I am open to criticism with this.