### PR TITLE
Check for specific http-enabled error for HTTP check

### DIFF
--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -39,15 +39,11 @@ return function(Vargs, GetEnv)
 	end;
 	
 	local function TestHttp()
-		local pass = false;
-		local addresses = {"https://google.com/robots.txt","https://api.github.com","https://testing.googleapis.com/$discovery/rest?version=v1"}
-		for _,addr in pairs(addresses) do
-			local suc = pcall(service.HttpService.GetAsync, service.HttpService, addr)
-			if suc then
-				pass = true
-			end
+		local suc,res = pcall(service.HttpService.GetAsync, service.HttpService, "https://google.com/robots.txt")
+		if not suc and res:find("Http requests are not enabled.") then
+			return false
 		end
-		return pass
+		return true
 	end;
 
 	server.HTTP = {

--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -37,18 +37,16 @@ return function(Vargs, GetEnv)
 		HTTP.Init = nil;
 		Logs:AddLog("Script", "HTTP Module Initialized")
 	end;
-	
-	local function TestHttp()
-		local suc,res = pcall(service.HttpService.GetAsync, service.HttpService, "https://google.com/robots.txt")
-		if not suc and res:find("Http requests are not enabled.") then
-			return false
-		end
-		return true
-	end;
 
 	server.HTTP = {
 		Init = Init;
-		HttpEnabled = TestHttp();
+		HttpEnabled = (function()
+			local sucess, res = pcall(service.HttpService.GetAsync, service.HttpService, "https://google.com/robots.txt")
+			if not success and res:find("Http requests are not enabled.") then
+				return false
+			end
+			return true
+		end)();
 		LoadstringEnabled = pcall(loadstring, "");
 
 		CheckHttp = function()

--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -37,10 +37,22 @@ return function(Vargs, GetEnv)
 		HTTP.Init = nil;
 		Logs:AddLog("Script", "HTTP Module Initialized")
 	end;
+	
+	local function TestHttp()
+		local pass = false;
+		local addresses = {"https://google.com/robots.txt","https://api.github.com","https://testing.googleapis.com/$discovery/rest?version=v1"}
+		for _,addr in pairs(addresses) do
+			local suc = pcall(service.HttpService.GetAsync, service.HttpService, addr)
+			if suc then
+				pass = true
+			end
+		end
+		return pass
+	end;
 
 	server.HTTP = {
 		Init = Init;
-		HttpEnabled = pcall(service.HttpService.GetAsync, service.HttpService, "http://www.google.com/robots.txt");
+		HttpEnabled = TestHttp();
 		LoadstringEnabled = pcall(loadstring, "");
 
 		CheckHttp = function()


### PR DESCRIPTION
Fixes issue where HTTP Service occasionally would block calls. Instead, checks for a specific roblox-created error when disabled rather than a pcall failure alone.