### PR TITLE
Introduction of a built-in Discord webhook API

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -283,6 +283,10 @@ settings.Trello_Secondary = {}			-- Secondary Trello boards (read-only)		Format:
 settings.Trello_AppKey = ""				-- Your Trello AppKey						  	Link: https://trello.com/app-key
 settings.Trello_Token = ""				-- Trello token (DON'T SHARE WITH ANYONE!)    Link: https://trello.com/1/connect?name=Trello_API_Module&response_type=token&expires=never&scope=read,write&key=YOUR_APP_KEY_HERE
 
+settings.Webhook_API_Enabled = false					-- Adonis has a built-in Discord webhook API that plugins may use via server.HTTP.Webhooks.PostEmbed(url, embedData)
+settings.Webhook_Process_Interval = math.random(30, 45)	-- Delay between which webhook messages in queue are sent to Discord
+settings.Webhook_Global_Queues = true					-- Use game-wide batch queues to serve as an effective global ratelimit system (only works if game is published)
+
 settings.G_API = true					-- If true allows other server scripts to access certain functions described in the API module through _G.Adonis
 settings.G_Access = false				-- If enabled allows other scripts to access Adonis using _G.Adonis.Access; Scripts will still be able to do things like _G.Adonis.CheckAdmin(player)
 settings.G_Access_Key = "Example_Key"	-- Key required to use the _G access API; Example_Key will not work for obvious reasons

--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -57,16 +57,18 @@ return function(Vargs, GetEnv)
 			service.StartLoop("TRELLO_UPDATER", Settings.HttpWait, HTTP.Trello.Update, true)
 		end
 
-		if Settings.Webhook_Enabled then
-			if --Variables.IsStudio or
-				not pcall(function()
-					HTTP.Webhooks.EmbedQueue = service.MemoryStoreService:GetQueue(Core.DataStoreEncode("Adonis_WebhookEmbeds"))
-				end)
+		if Settings.Webhook_API_Enabled then
+			if not (
+				Settings.Webhook_Global_Queues
+					and pcall(function()
+						HTTP.Webhooks.EmbedQueue = service.MemoryStoreService:GetQueue(Core.DataStoreEncode("Adonis_WebhookEmbeds"))
+					end)
+				)
 			then
 				HTTP.Webhooks.EmbedQueue = {}
 				warn("Using local webhook embed queue")
 			end
-			service.StartLoop("WEBHOOK_PROCESSOR", math.random(30, 45), HTTP.Webhooks.ProcessEmbedQueue, true)
+			service.StartLoop("WEBHOOK_PROCESSOR", Settings.Webhook_Process_Interval, HTTP.Webhooks.ProcessEmbedQueue, true)
 			game:BindToClose(HTTP.Webhooks.ProcessEmbedQueue)
 		end
 
@@ -139,8 +141,8 @@ return function(Vargs, GetEnv)
 			end;
 
 			PostEmbed = function(url, embedData: WebhookEmbedData)
-				if not Settings.Webhook_Enabled then
-					warn("Webhook features are currently disabled in Settings.Webhook_Enabled")
+				if not Settings.Webhook_API_Enabled then
+					warn("Webhook features are currently disabled in Settings.Webhook_API_Enabled")
 					return
 				end
 
@@ -171,8 +173,8 @@ return function(Vargs, GetEnv)
 			end;
 
 			ProcessEmbedQueue = function()
-				if not Settings.Webhook_Enabled then
-					warn("Webhook features are currently disabled in Settings.Webhook_Enabled")
+				if not Settings.Webhook_API_Enabled then
+					warn("Webhook features are currently disabled in Settings.Webhook_API_Enabled")
 					return
 				end
 

--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -9,6 +9,29 @@ logError = nil
 type Card = {id: string, name: string, desc: string, labels: {any}?}
 type List = {id: string, name: string, cards: {Card}}
 
+type WebhookEmbedMediaData = {url: string, proxy_url: string?, height: number?, width: number?}
+type WebhookEmbedData = {
+	title: string?,
+	description: string?,
+	url: string?,
+	timestamp: number?,
+	color: number?,
+	footer: {text: string, icon_url: string?, proxy_icon_url: string?}?,
+	image: WebhookEmbedMediaData?,
+	thumbnail: WebhookEmbedMediaData?,
+	video: WebhookEmbedMediaData?,
+	provider: {name: string?, url: string?}?,
+	author: {name: string, url: string?, icon_url: string?, proxy_icon_url: string?}?,
+	fields: {{name: string, value: string, inline: boolean?}}?
+}
+type WebhookData = {
+	content: string?,
+	username: string?,
+	avatar_url: string?,
+	tts: boolean?,
+	embeds: {WebhookEmbedData}?,
+}
+
 return function(Vargs, GetEnv)
 	local env = GetEnv(nil, {script = script})
 	setfenv(1, env)
@@ -34,12 +57,26 @@ return function(Vargs, GetEnv)
 			service.StartLoop("TRELLO_UPDATER", Settings.HttpWait, HTTP.Trello.Update, true)
 		end
 
+		if Settings.Webhook_Enabled then
+			if --Variables.IsStudio or
+				not pcall(function()
+					HTTP.Webhooks.EmbedQueue = service.MemoryStoreService:GetQueue(Core.DataStoreEncode("Adonis_WebhookEmbeds"))
+				end)
+			then
+				HTTP.Webhooks.EmbedQueue = {}
+				warn("Using local webhook embed queue")
+			end
+			service.StartLoop("WEBHOOK_PROCESSOR", math.random(30, 45), HTTP.Webhooks.ProcessEmbedQueue, true)
+			game:BindToClose(HTTP.Webhooks.ProcessEmbedQueue)
+		end
+
 		HTTP.Init = nil;
 		Logs:AddLog("Script", "HTTP Module Initialized")
 	end;
 
 	server.HTTP = {
 		Init = Init;
+
 		HttpEnabled = (function()
 			local success, res = pcall(service.HttpService.GetAsync, service.HttpService, "https://google.com/robots.txt")
 			if not success and res:find("Http requests are not enabled.") then
@@ -47,6 +84,7 @@ return function(Vargs, GetEnv)
 			end
 			return true
 		end)();
+
 		LoadstringEnabled = pcall(loadstring, "");
 
 		CheckHttp = function()
@@ -62,6 +100,164 @@ return function(Vargs, GetEnv)
 			Bans = {};
 			Blacklist = {};
 			Whitelist = {};
+		};
+
+		Webhooks = {
+			FormatPlayer = function(plr, withUserId)
+				return string.format("[%s](https://www.roblox.com/users/%d/profile)",
+					service.FormatPlayer(plr, withUserId),
+					plr.UserId
+				)
+			end;
+
+			GetUserThumbnail = function(userId, outfitThumbnail)
+				return string.format("https://www.roblox.com/%s/image?userId=%d&width=420&height=420&format=png",
+					if outfitThumbnail then "outfit-thumbnail" else "bust-thumbnail",
+					userId
+				)
+			end;
+
+			ListPlayers = function(players, withUserIds)
+				if not players then
+					players = service.Players:GetPlayers()
+				end
+				local listedPlayers = "- "..HTTP.Webhooks.FormatPlayer(players[1], withUserIds)
+				for i, player in players do
+					if i ~= 1 then
+						listedPlayers ..= "\n- "..HTTP.Webhooks.FormatPlayer(player, withUserIds)
+					end
+				end
+				return listedPlayers
+			end;
+
+			GetTimestamp = function(specificTime)
+				return os.date("%Y%m%dT%H%M%SZ", specificTime)
+			end;
+
+			GetGameLink = function(gameId)
+				return "https://www.roblox.com/games/" .. gameId
+			end;
+
+			PostEmbed = function(url, embedData: WebhookEmbedData)
+				if not Settings.Webhook_Enabled then
+					warn("Webhook features are currently disabled in Settings.Webhook_Enabled")
+					return
+				end
+
+				local success, err
+				local tries = 0
+
+				if type(HTTP.Webhooks.EmbedQueue) == "table" then
+					success = true
+					table.insert(HTTP.Webhooks.EmbedQueue, {Url = url, Embed = embedData})
+				else
+					repeat
+						success, err = pcall(
+							HTTP.Webhooks.EmbedQueue.AddAsync, HTTP.Webhooks.EmbedQueue,
+							{Url = url, Embed = embedData}, 60 * 5 --// expires in 5 minutes
+						)
+						tries += 1
+					until success or tries == 3
+				end
+
+				if success then
+					Logs.AddLog("Script", {
+						Text = "Added webhook embed to queue";
+						Desc = "Attempts: "..tries.." | URL: "..url;
+					})
+				else
+					logError("Error adding webhook embed to queue (3 attempts); "..tostring(err))
+				end
+			end;
+
+			ProcessEmbedQueue = function()
+				if not Settings.Webhook_Enabled then
+					warn("Webhook features are currently disabled in Settings.Webhook_Enabled")
+					return
+				end
+
+				local getQueueSuccess, embedQueue: {{Url: string, Embed: WebhookEmbedData}}, removalId
+				local tries = 0
+
+				if type(HTTP.Webhooks.EmbedQueue) == "table" then
+					getQueueSuccess, embedQueue = true, table.clone(HTTP.Webhooks.EmbedQueue)
+				else
+					repeat
+						getQueueSuccess, embedQueue, removalId = pcall(
+							HTTP.Webhooks.EmbedQueue.ReadAsync, HTTP.Webhooks.EmbedQueue,
+							50, false, 0
+						)
+						tries += 1
+						task.wait(0.1)
+					until getQueueSuccess or tries == 3
+				end
+
+				if getQueueSuccess and #embedQueue > 0 then
+					if type(HTTP.Webhooks.EmbedQueue) == "table" then
+						table.clear(HTTP.Webhooks.EmbedQueue)
+					else
+						local clearQueueSuccess, clearQueueError
+						local tries = 0
+						repeat
+							clearQueueSuccess, clearQueueError = pcall(
+								HTTP.Webhooks.EmbedQueue.RemoveAsync, HTTP.Webhooks.EmbedQueue,
+								removalId
+							)
+							tries += 1
+							task.wait(0.1)
+						until clearQueueSuccess or tries == 3
+						if not clearQueueSuccess then
+							logError("Unable to clear webhook embed queue:", clearQueueError)
+						end
+					end
+
+					local embedsPerUrl = {}
+					for _, item in ipairs(embedQueue) do
+						if not (item.Url and item.Embed) then
+							continue
+						end
+						if embedsPerUrl[item.Url] then
+							table.insert(embedsPerUrl[item.Url], item.Embed)
+						else
+							embedsPerUrl[item.Url] = {item.Embed}
+						end
+					end
+
+					local urlCount = 0
+					for url, embeds in pairs(embedsPerUrl) do
+						urlCount += 1
+						local postSuccess, postError
+						local tries = 0
+						repeat
+							postSuccess, postError = pcall(function()
+								service.HttpService:PostAsync(
+									url, service.HttpService:JSONEncode({embeds = embeds})
+								)
+							end)
+							tries += 1
+						until postSuccess or tries == 3
+
+						if postSuccess then
+							Logs.AddLog("Script", {
+								Text = "Successfully processed webhook embed batch for URL";
+								Desc = "# Embeds: "..#embeds.." | URL: "..url;
+							})
+						else
+							Logs.AddLog("Errors", {
+								Text = "Error processing webhook embed batch for URL; "..tostring(postError);
+								Desc = "# Embeds: "..#embeds.." | URL: "..url;
+							})
+						end
+					end
+
+					Logs.AddLog("Script", {
+						Text = "Finished processing full webhook embed batch queue";
+						Desc = "# Total Embeds: "..#embedQueue.." | Unique URLs: "..urlCount;
+					})
+				elseif not getQueueSuccess then
+					logError("Error fetching webhook embed queue: "..tostring(embedQueue))
+				end
+			end;
 		};
 
 		Trello = {
@@ -91,7 +287,7 @@ return function(Vargs, GetEnv)
 							if string.sub(cmd, 1, 1) == "$" then
 								local placeid = string.match(string.sub(cmd, 2), ".%d+")
 								cmd = string.sub(cmd, #placeid+2)
-								if tonumber(placeid) ~= game.PlaceId then 
+								if tonumber(placeid) ~= game.PlaceId then
 									return
 								end
 							end
@@ -215,13 +411,13 @@ return function(Vargs, GetEnv)
 						local lists: {List} = HTTP.Trello.API.getListsAndCards(board, true)
 						if #lists == 0 then error("L + ratio") end --TODO: Improve TrelloAPI error handling so we don't need to assume no lists = failed request
 
-						for _, list in pairs(lists) do 
+						for _, list in pairs(lists) do
 							local foundOverride = false
 
-							for _, override in pairs(HTTP.Trello.Overrides) do 
+							for _, override in pairs(HTTP.Trello.Overrides) do
 								if table.find(override.Lists, list.name) then
 									foundOverride = true
-									for _, card in ipairs(list.cards) do 
+									for _, card in ipairs(list.cards) do
 										override.Process(card, data)
 									end
 									break
@@ -245,12 +441,12 @@ return function(Vargs, GetEnv)
 
 					local success = true
 					local boards = {
-						Settings.Trello_Primary, 
+						Settings.Trello_Primary,
 						unpack(Settings.Trello_Secondary)
 					}
 					for i,v in pairs(boards) do
-						if not v or service.Trim(v) == "" then 
-							continue 
+						if not v or service.Trim(v) == "" then
+							continue
 						end
 						local ran, err = pcall(grabData, v)
 						if not ran then
@@ -269,15 +465,15 @@ return function(Vargs, GetEnv)
 
 						Variables.Blacklist.Lists.Trello = data.Blacklist
 						Variables.Whitelist.Lists.Trello = data.Whitelist
-          
+
 						--// Clear any custom ranks that were not fetched from Trello
-						for rank, info in pairs(Settings.Ranks) do 
+						for rank, info in pairs(Settings.Ranks) do
 							if rank.IsExternal and not data.Ranks[rank] then
 								Settings.Ranks[rank] = nil
 							end
 						end
 
-						for rank, users in pairs(data.Ranks) do 
+						for rank, users in pairs(data.Ranks) do
 							local name = string.format("[Trello] %s", server.Functions.Trim(rank))
 							Settings.Ranks[name] = {
 								Level = Settings.Ranks[rank].Level or 1;
@@ -303,15 +499,15 @@ return function(Vargs, GetEnv)
 					end
 				end
 			end;
-			
+
 			GetOverrideLists = function()
 				local lists = {}
-				for _, override in ipairs(HTTP.Trello.Overrides) do 
-					for _, list in ipairs(override.Lists) do 
+				for _, override in ipairs(HTTP.Trello.Overrides) do
+					for _, list in ipairs(override.Lists) do
 						table.insert(lists, list)
 					end
 				end
-				for name, rank in pairs(Settings.Ranks) do 
+				for name, rank in pairs(Settings.Ranks) do
 					if not rank.IsExternal and not table.find(lists, name) then
 						table.insert(lists, name)
 					end

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -283,6 +283,10 @@ settings.Trello_Secondary = {}			-- Secondary Trello boards (read-only)		Format:
 settings.Trello_AppKey = ""				-- Your Trello AppKey						  	Link: https://trello.com/app-key
 settings.Trello_Token = ""				-- Trello token (DON'T SHARE WITH ANYONE!)    Link: https://trello.com/1/connect?name=Trello_API_Module&response_type=token&expires=never&scope=read,write&key=YOUR_APP_KEY_HERE
 
+settings.Webhook_API_Enabled = false					-- Adonis has a built-in Discord webhook API that plugins may use via server.HTTP.Webhooks.PostEmbed(url, embedData)
+settings.Webhook_Process_Interval = math.random(30, 45)	-- Delay between which webhook messages in queue are sent to Discord
+settings.Webhook_Global_Queues = true					-- Use game-wide batch queues to serve as an effective global ratelimit system (only works if game is published)
+
 settings.G_API = true					-- If true allows other server scripts to access certain functions described in the API module through _G.Adonis
 settings.G_Access = false				-- If enabled allows other scripts to access Adonis using _G.Adonis.Access; Scripts will still be able to do things like _G.Adonis.CheckAdmin(player)
 settings.G_Access_Key = "Example_Key"	-- Key required to use the _G access API; Example_Key will not work for obvious reasons


### PR DESCRIPTION
[Cancelled.]

## Usage
```lua
type WebhookEmbedMediaData = {url: string, proxy_url: string?, height: number?, width: number?}

type WebhookEmbedData = {
	title: string?,
	description: string?,
	url: string?,
	timestamp: number?,
	color: number?,
	footer: {text: string, icon_url: string?, proxy_icon_url: string?}?,
	image: WebhookEmbedMediaData?,
	thumbnail: WebhookEmbedMediaData?,
	video: WebhookEmbedMediaData?,
	provider: {name: string?, url: string?}?,
	author: {name: string, url: string?, icon_url: string?, proxy_icon_url: string?}?,
	fields: {{name: string, value: string, inline: boolean?}}?
}

--// To add an embed message to the queue:
server.HTTP.Webhooks.PostEmbed(webhookUrl: string, webhookEmbedData: WebhookEmbedData)
--// PostEmbed only works if Settings.Webhook_API_Enabled is true.
--// That's all.
```