### PR TITLE
Fixed typo on Keybinds settings description

### DIFF
--- a/MainModule/Client/UI/Default/Settings.lua
+++ b/MainModule/Client/UI/Default/Settings.lua
@@ -28,7 +28,7 @@ return function(data, env)
 	local cliSettings = {
 		{
 			Text = "Keybinds: ";
-			Desc = "- Enabled/Disables Keybinds";
+			Desc = "- Enables/Disables Keybinds";
 			Entry = "Boolean";
 			Value = Variables.KeybindsEnabled;
 			Function = function(enabled, toggle)

--- a/MainModule/Client/UI/Default/UserPanel.lua
+++ b/MainModule/Client/UI/Default/UserPanel.lua
@@ -1240,7 +1240,7 @@ return function(data, env)
 			local cliSettings = {
 				{
 					Text = "Keybinds: ";
-					Desc = "- Enabled/Disables Keybinds";
+					Desc = "- Enables/Disables Keybinds";
 					Entry = "Boolean";
 					Value = Variables.KeybindsEnabled;
 					Function = function(enabled, toggle)


### PR DESCRIPTION
The desc for the keybinds setting on the client page was "- Enabled/Disables Keybinds"
I have corrected it to be "- Enables/Disables Keybinds"
