### PR TITLE
Remove all instances of pairs()/ipairs() in core modules

### DIFF
--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -587,9 +587,9 @@ return function(Vargs, GetEnv)
 					First = Logs[1]
 					hasPrinted = true
 
-					if (lastLogOutput + 3) > startTime then
-						--Detected("kick", "Log event not outputting to console")
-					end
+					--[[if (lastLogOutput + 3) > startTime then
+						Detected("kick", "Log event not outputting to console")
+					end]]
 				else
 					if not First then
 						--Detected("kick", "Suspicious log amount detected 5435345")

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -13,25 +13,25 @@ return function(Vargs, GetEnv)
 	setfenv(1, env)
 
 	local _G, game, script, getfenv, setfenv, workspace,
-		getmetatable, setmetatable, loadstring, coroutine,
-		rawequal, typeof, print, math, warn, error,  pcall,
-		xpcall, select, rawset, rawget, ipairs, pairs,
-		next, Rect, Axes, os, time, Faces, unpack, string, Color3,
-		newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
-		NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
-		NumberSequenceKeypoint, PhysicalProperties, Region3int16,
-		Vector3int16, require, table, type, wait,
-		Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay =
-			_G, game, script, getfenv, setfenv, workspace,
-			getmetatable, setmetatable, loadstring, coroutine,
-			rawequal, typeof, print, math, warn, error,  pcall,
-			xpcall, select, rawset, rawget, ipairs, pairs,
-			next, Rect, Axes, os, time, Faces, unpack, string, Color3,
-			newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
-			NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
-			NumberSequenceKeypoint, PhysicalProperties, Region3int16,
-			Vector3int16, require, table, type, wait,
-			Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay
+	getmetatable, setmetatable, loadstring, coroutine,
+	rawequal, typeof, print, math, warn, error,  pcall,
+	xpcall, select, rawset, rawget, ipairs, pairs,
+	next, Rect, Axes, os, time, Faces, unpack, string, Color3,
+	newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
+	NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
+	NumberSequenceKeypoint, PhysicalProperties, Region3int16,
+	Vector3int16, require, table, type, wait,
+	Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay =
+		_G, game, script, getfenv, setfenv, workspace,
+	getmetatable, setmetatable, loadstring, coroutine,
+	rawequal, typeof, print, math, warn, error,  pcall,
+	xpcall, select, rawset, rawget, ipairs, pairs,
+	next, Rect, Axes, os, time, Faces, unpack, string, Color3,
+	newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
+	NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
+	NumberSequenceKeypoint, PhysicalProperties, Region3int16,
+	Vector3int16, require, table, type, wait,
+	Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay
 
 	local Anti, Process, UI, Variables
 	local script = script
@@ -209,7 +209,7 @@ return function(Vargs, GetEnv)
 					while true do end
 				end
 
-				for method, detector in pairs(detectors) do
+				for method, detector in detectors do
 					local action, callback = detector[1],  detector[2]
 
 					local success, value = pcall(callback)
@@ -245,7 +245,7 @@ return function(Vargs, GetEnv)
 					end
 
 					if #service.Players:GetPlayers() > 1 then
-						for _, v in ipairs(service.Players:GetPlayers()) do
+						for _, v in service.Players:GetPlayers() do
 							local otherPlayer = service.UnWrap(v)
 
 							if otherPlayer and otherPlayer.Parent and otherPlayer ~= LocalPlayer then
@@ -448,14 +448,14 @@ return function(Vargs, GetEnv)
 			}
 
 			local function check(Message)
-				for _,v in pairs(lookFor) do
+				for _,v in lookFor do
 					if not string.find(string.lower(Message), "failed to load") and (string.find(string.lower(Message), string.lower(v)) or string.match(Message, v)) then
 						return true
 					end
 				end
 			end
 
-			-- Tons of false positives. Disabled for now. All anti-exploit stuff needs to just be moved to a non-default plugin or something cuz it consistently causes problems every update qq. 
+			-- Tons of false positives. Disabled for now. All anti-exploit stuff needs to just be moved to a non-default plugin or something cuz it consistently causes problems every update qq.
 			local function checkServ()
 				--[[if not pcall(function()
 					if not isStudio and (findService(game, "ServerStorage") or findService(game, "ServerScriptService")) then
@@ -467,7 +467,7 @@ return function(Vargs, GetEnv)
 			end
 
 			local function soundIdCheck(Sound)
-				for _,v in pairs(soundIds) do
+				for _,v in soundIds do
 					if Sound.SoundId and (string.find(string.lower(tostring(Sound.SoundId)), tostring(v)) or Sound.SoundId == tostring(v)) then
 						return true
 					end
@@ -541,7 +541,7 @@ return function(Vargs, GetEnv)
 					local tab = service.LogService:GetLogHistory()
 					local continue = false
 					if Script then
-						for i, v in pairs(tab) do
+						for i, v in tab do
 							if v.message == Message and tab[i+1] and tab[i+1].message == Trace then
 								continue = true
 							end
@@ -588,11 +588,11 @@ return function(Vargs, GetEnv)
 					hasPrinted = true
 
 					if (lastLogOutput + 3) > startTime then
-						Detected("kick", "Log event not outputting to console")
+						--Detected("kick", "Log event not outputting to console")
 					end
 				else
 					if not First then
-						Detected("kick", "Suspicious log amount detected 5435345")
+						--Detected("kick", "Suspicious log amount detected 5435345")
 						client.OldPrint(" ") -- // To prevent the log amount check from firing every 10 seconds (Just to be safe)
 					end
 				end
@@ -605,7 +605,7 @@ return function(Vargs, GetEnv)
 				then
 					Detected("kick", "Bypass detected 5435345")
 				else
-					for _, v in ipairs(Logs) do
+					for _, v in Logs do
 						if check(v.message) then
 							Detected("crash", "Exploit detected; "..v.message)
 						end
@@ -630,7 +630,7 @@ return function(Vargs, GetEnv)
 				end
 
 				-- // Checks for certain disallowed object names in the core GUI which wouldnt otherwise be detectable
-				--[=[for _, v in pairs({"SentinelSpy", "ScriptDumper", "VehicleNoclip", "Strong Stand"}) do -- recursive findfirstchild check that yeets some stuff; --[["Sentinel",]]
+				--[=[for _, v in {"SentinelSpy", "ScriptDumper", "VehicleNoclip", "Strong Stand"} do -- recursive findfirstchild check that yeets some stuff; --[["Sentinel",]]
 					local object = Player and Player.Name ~= v and service.UnWrap(game).FindFirstChild(service.UnWrap(game), v, true)            -- ill update the list periodically
 					if object then
 						Detected("kick", "Malicious Object?: " .. v)
@@ -640,7 +640,7 @@ return function(Vargs, GetEnv)
 				local function getDictionaryLenght(dictionary)
 					local len = 0
 
-					for _, _ in pairs(dictionary) do
+					for _, _ in dictionary do
 						len += 1
 					end
 
@@ -686,25 +686,6 @@ return function(Vargs, GetEnv)
 					Detected("kick", "Tamper Protection 568234")
 				end)]]
 
-				-- // Checks disallowed content URLs in the CoreGui
-				xpcall(function()
-					if isStudio then
-						return
-					end
-
-					local hasDetected = false
-					local tempDecal = service.UnWrap(Instance.new("Decal"))
-					service.UnWrap(service.ContentProvider):PreloadAsync({tempDecal, tempDecal, service.UnWrap(service.CoreGui), tempDecal}, function(url, status)
-						if not hasDetected and (string.match(url, "^rbxassetid://") or string.match(url, "^http://www%.roblox%.com/asset/%?id=")) then
-							hasDetected = true
-							Detected("Kick", "Disallowed content URL detected in CoreGui")
-						end
-					end)
-
-					tempDecal:Destroy()
-				end, function()
-					Detected("kick", "Tamper Protection 456754")
-				end)
 			end)
 		end
 	}, false, true)

--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -23,15 +23,15 @@ return function(Vargs, GetEnv)
 	Vector3int16, require, table, type, wait,
 	Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay =
 		_G, game, script, getfenv, setfenv, workspace,
-		getmetatable, setmetatable, loadstring, coroutine,
-		rawequal, typeof, print, math, warn, error,  pcall,
-		xpcall, select, rawset, rawget, ipairs, pairs,
-		next, Rect, Axes, os, time, Faces, unpack, string, Color3,
-		newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
-		NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
-		NumberSequenceKeypoint, PhysicalProperties, Region3int16,
-		Vector3int16, require, table, type, wait,
-		Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay
+	getmetatable, setmetatable, loadstring, coroutine,
+	rawequal, typeof, print, math, warn, error,  pcall,
+	xpcall, select, rawset, rawget, ipairs, pairs,
+	next, Rect, Axes, os, time, Faces, unpack, string, Color3,
+	newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
+	NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
+	NumberSequenceKeypoint, PhysicalProperties, Region3int16,
+	Vector3int16, require, table, type, wait,
+	Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay
 
 	local script = script
 	local service = Vargs.Service
@@ -81,7 +81,7 @@ return function(Vargs, GetEnv)
 				RunAfterPlugins = true;
 			}, true)--]]
 
-			Functions.RunLast = nil;
+		Functions.RunLast = nil;
 	end
 
 	getfenv().client = nil
@@ -100,7 +100,7 @@ return function(Vargs, GetEnv)
 
 			local LocalPlayer = service.UnWrap(service.Player)
 
-			for i, part in ipairs(obj:GetChildren()) do
+			for i, part in obj:GetChildren() do
 				if part:IsA("BasePart") then
 					if part.Name == "Head" and not part:FindFirstChild("__ADONIS_NAMETAG") then
 						local player = service.Players:GetPlayerFromCharacter(part.Parent)
@@ -143,7 +143,7 @@ return function(Vargs, GetEnv)
 						end
 					end
 
-					for _, surface in ipairs(Functions.ESPFaces) do
+					for _, surface in Functions.ESPFaces do
 						local gui = New("SurfaceGui", {
 							AlwaysOnTop = true,
 							ResetOnSpawn = false,
@@ -163,7 +163,7 @@ return function(Vargs, GetEnv)
 							if obj == gui and parent == nil then
 								tempConnection:Disconnect()
 								Debris:AddItem(gui,0)
-								for i,v in ipairs(Variables.ESPObjects) do
+								for i,v in Variables.ESPObjects do
 									if v == gui then
 										table.remove(Variables.ESPObjects, i)
 										break;
@@ -189,7 +189,7 @@ return function(Vargs, GetEnv)
 				Variables.ESPEvent = nil;
 			end
 
-			for obj in pairs(Variables.ESPObjects) do
+			for obj in Variables.ESPObjects do
 				if not mode or not target or (target and obj:IsDescendantOf(target)) then
 					local __ADONIS_NAMETAG = obj.Parent and obj.Parent:FindFirstChild("__ADONIS_NAMETAG")
 					if __ADONIS_NAMETAG then
@@ -213,7 +213,7 @@ return function(Vargs, GetEnv)
 						end
 					end)
 
-					for i, Player in ipairs(service.Players:GetPlayers()) do
+					for i, Player in service.Players:GetPlayers() do
 						if Player.Character then
 							task.spawn(Functions.ESPify, UnWrap(Player.Character), color);
 						end
@@ -447,7 +447,7 @@ return function(Vargs, GetEnv)
 			local add; add = function(tab,child)
 				local good = false
 
-				for i,v in pairs(classes) do
+				for i,v in classes do
 					if child:IsA(v) then
 						good = true
 					end
@@ -459,19 +459,19 @@ return function(Vargs, GetEnv)
 						Children = {};
 					}
 
-					for i,v in pairs(props) do
+					for i,v in props do
 						pcall(function()
 							new.Properties[v] = child[v]
 						end)
 					end
 
-					for _, v in ipairs(child:GetChildren()) do
+					for _, v in child:GetChildren() do
 						add(new,v)
 					end
 					table.insert(tab.Children, new)
 				end
 			end
-			for _, v in ipairs(service.PlayerGui:GetChildren()) do
+			for _, v in service.PlayerGui:GetChildren() do
 				pcall(add, guis, v)
 			end
 			return guis
@@ -519,14 +519,14 @@ return function(Vargs, GetEnv)
 		end;
 
 		UnLoadGuiData = function()
-			for i,v in ipairs(service.PlayerGui:GetChildren()) do
+			for i,v in service.PlayerGui:GetChildren() do
 				if v.Name == "LoadedGuis" then
 					v:Destroy()
 				end
 			end
 
 			if Variables.GuiViewFolder then
-				for i,v in ipairs(Variables.GuiViewFolder:GetChildren()) do
+				for i,v in Variables.GuiViewFolder:GetChildren() do
 					v.Parent = service.PlayerGui
 				end
 				Variables.GuiViewFolder:Destroy()
@@ -536,7 +536,7 @@ return function(Vargs, GetEnv)
 
 		GetParticleContainer = function(target)
 			if target then
-				for i,v in ipairs(service.LocalContainer():GetChildren()) do
+				for i,v in service.LocalContainer():GetChildren() do
 					if v.Name == target:GetFullName().."PARTICLES" then
 						local obj = v:FindFirstChild("_OBJECT")
 						if obj.Value == target then
@@ -569,7 +569,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		RemoveParticle = function(target, name)
-			for i,effect in pairs(Variables.Particles) do
+			for i,effect in Variables.Particles do
 				if effect.Parent == target and effect.Name == name then
 					effect:Destroy();
 					Variables.Particles[i] = nil;
@@ -578,7 +578,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		EnableParticles = function(enabled)
-			for i,effect in pairs(Variables.Particles) do
+			for i,effect in Variables.Particles do
 				if enabled then
 					effect.Enabled = true
 				else
@@ -625,7 +625,7 @@ return function(Vargs, GetEnv)
 			elseif parent == "PlayerGui" then
 				par = service.PlayerGui
 			end
-			for ind,obj in ipairs(par:GetChildren()) do
+			for ind,obj in par:GetChildren() do
 				if obj.Name == object or obj == obj then
 					obj.Parent = newParent
 				end
@@ -642,7 +642,7 @@ return function(Vargs, GetEnv)
 				par = service.PlayerGui
 			end
 
-			for ind, obj in ipairs(par:GetChildren()) do
+			for ind, obj in par:GetChildren() do
 				if match and string.match(obj.Name,object) or obj.Name == object or object == obj then
 					obj:Destroy()
 				end
@@ -730,7 +730,7 @@ return function(Vargs, GetEnv)
 			end
 		end;
 		RemoveCape = function(parent)
-			for i,v in pairs(Variables.Capes) do
+			for i,v in Variables.Capes do
 				if v.Parent == parent or not v.Parent or not v.Parent.Parent then
 					pcall(v.Part.Destroy,v.Part)
 					Variables.Capes[i] = nil
@@ -738,7 +738,7 @@ return function(Vargs, GetEnv)
 			end
 		end;
 		HideCapes = function(hide)
-			for i,v in pairs(Variables.Capes) do
+			for i,v in Variables.Capes do
 				local torso = v.Torso
 				local parent = v.Parent
 				local part = v.Part
@@ -775,7 +775,7 @@ return function(Vargs, GetEnv)
 				if Functions.CountTable(Variables.Capes) == 0 or not Variables.CapesEnabled then
 					service.StopLoop("CapeMover")
 				else
-					for i,v in pairs(Variables.Capes) do
+					for i,v in Variables.Capes do
 						local torso = v.Torso
 						local parent = v.Parent
 						local isPlayer = v.isPlayer
@@ -829,13 +829,13 @@ return function(Vargs, GetEnv)
 
 		CountTable = function(tab)
 			local count = 0
-			for _ in pairs(tab) do count += 1 end
+			for _ in tab do count += 1 end
 			return count
 		end;
 
 		ClearAllInstances = function()
 			local objects = service.GetAdonisObjects()
-			for i in pairs(objects) do
+			for i in objects do
 				i:Destroy()
 			end
 			table.clear(objects)
@@ -849,7 +849,7 @@ return function(Vargs, GetEnv)
 			local animator = human and human:FindFirstChildOfClass("Animator") or human and human:WaitForChild("Animator", 9e9)
 			if not animator then return end
 
-			for _, v in ipairs(animator:GetPlayingAnimationTracks()) do v:Stop() end
+			for _, v in animator:GetPlayingAnimationTracks() do v:Stop() end
 			local anim = service.New('Animation', {
 				AnimationId = 'rbxassetid://'..animId,
 				Name = "ADONIS_Animation"
@@ -1030,7 +1030,7 @@ return function(Vargs, GetEnv)
 		KeyCodeToName = function(keyVal)
 			local keyVal = tonumber(keyVal);
 			if keyVal then
-				for i,e in ipairs(Enum.KeyCode:GetEnumItems()) do
+				for i,e in Enum.KeyCode:GetEnumItems() do
 					if e.Value == keyVal then
 						return e.Name;
 					end
@@ -1103,7 +1103,7 @@ return function(Vargs, GetEnv)
 					pa.CFrame = workspace.CurrentCamera.CoordinateFrame*CFrame.new(0,0,-2.5)*CFrame.Angles(12.6,0,0)
 				end
 			else
-				for i,v in ipairs(workspace.CurrentCamera:GetChildren()) do
+				for i,v in workspace.CurrentCamera:GetChildren() do
 					if v.Name == "ADONIS_WINDOW_FUNC_BLUR" then
 						v:Destroy()
 					end
@@ -1134,7 +1134,7 @@ return function(Vargs, GetEnv)
 				Variables.localSounds[tostring(audioId)]:Destroy()
 				Variables.localSounds[tostring(audioId)] = nil
 			elseif audioId == "all" then
-				for i,v in pairs(Variables.localSounds) do
+				for i,v in Variables.localSounds do
 					Variables.localSounds[i]:Stop()
 					Variables.localSounds[i]:Destroy()
 					Variables.localSounds[i] = nil
@@ -1166,7 +1166,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		KillAllLocalAudio = function()
-			for i,v in pairs(Variables.localSounds) do
+			for i,v in Variables.localSounds do
 				v:Stop()
 				v:Destroy()
 				table.remove(Variables.localSounds,i)
@@ -1174,7 +1174,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		RemoveGuis = function()
-			for i,v in ipairs(service.PlayerGui:GetChildren()) do
+			for i,v in service.PlayerGui:GetChildren() do
 				if not UI.Get(v) then
 					v:Destroy()
 				end
@@ -1587,7 +1587,7 @@ return function(Vargs, GetEnv)
 				local tab = {}
 				local str = str
 				local function getNext()
-					for i,v in ipairs(phonemes) do
+					for i,v in phonemes do
 						local occ,pos = string.find(string.lower(str),"^"..v.str)
 						if occ then
 							if v.capture then
@@ -1631,12 +1631,12 @@ return function(Vargs, GetEnv)
 
 			audio:Play()
 			audio2:Play()
-			for i,v in ipairs(phos) do
+			for i,v in phos do
 				--print(i,v.str)
 				if type(v.func)=="string" then--v.func=="wait" then
 					wait(0.5)
 				elseif type(v)=="table" then
-					for l,p in ipairs(v.func) do
+					for l,p in v.func do
 						--[[--]]
 						if swap then
 							swap=false
@@ -1690,7 +1690,7 @@ return function(Vargs, GetEnv)
 				"TouchEnabled";
 				"VREnabled";
 			}
-			for i, p in pairs(props) do
+			for i, p in props do
 				data[p] = service.UserInputService[p]
 			end
 			return data

--- a/MainModule/Client/Core/Remote.lua
+++ b/MainModule/Client/Core/Remote.lua
@@ -14,25 +14,25 @@ return function(Vargs, GetEnv)
 	setfenv(1, env)
 
 	local _G, game, script, getfenv, setfenv, workspace,
-		getmetatable, setmetatable, loadstring, coroutine,
-		rawequal, typeof, print, math, warn, error,  pcall,
-		xpcall, select, rawset, rawget, ipairs, pairs,
-		next, Rect, Axes, os, time, Faces, unpack, string, Color3,
-		newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
-		NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
-		NumberSequenceKeypoint, PhysicalProperties, Region3int16,
-		Vector3int16, require, table, type, wait,
-		Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay =
+	getmetatable, setmetatable, loadstring, coroutine,
+	rawequal, typeof, print, math, warn, error,  pcall,
+	xpcall, select, rawset, rawget, ipairs, pairs,
+	next, Rect, Axes, os, time, Faces, unpack, string, Color3,
+	newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
+	NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
+	NumberSequenceKeypoint, PhysicalProperties, Region3int16,
+	Vector3int16, require, table, type, wait,
+	Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay =
 		_G, game, script, getfenv, setfenv, workspace,
-		getmetatable, setmetatable, loadstring, coroutine,
-		rawequal, typeof, print, math, warn, error,  pcall,
-		xpcall, select, rawset, rawget, ipairs, pairs,
-		next, Rect, Axes, os, time, Faces, unpack, string, Color3,
-		newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
-		NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
-		NumberSequenceKeypoint, PhysicalProperties, Region3int16,
-		Vector3int16, require, table, type, wait,
-		Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay
+	getmetatable, setmetatable, loadstring, coroutine,
+	rawequal, typeof, print, math, warn, error,  pcall,
+	xpcall, select, rawset, rawget, ipairs, pairs,
+	next, Rect, Axes, os, time, Faces, unpack, string, Color3,
+	newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
+	NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
+	NumberSequenceKeypoint, PhysicalProperties, Region3int16,
+	Vector3int16, require, table, type, wait,
+	Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay
 
 	local script = script
 	local service = Vargs.Service
@@ -109,7 +109,7 @@ return function(Vargs, GetEnv)
 				RunAfterPlugins = true;
 			}, true)--]]
 
-			Remote.RunLast = nil;
+		Remote.RunLast = nil;
 	end
 
 	getfenv().client = nil
@@ -219,7 +219,7 @@ return function(Vargs, GetEnv)
 			InstanceList = function(args)
 				local objects = service.GetAdonisObjects()
 				local temp = {}
-				for i,v in pairs(objects) do
+				for i,v in objects do
 					table.insert(temp, {
 						Text = v:GetFullName();
 						Desc = v.ClassName;
@@ -247,7 +247,7 @@ return function(Vargs, GetEnv)
 			LocallyFormattedTime = function(args)
 				if type(args[1]) == "table" then
 					local results = {}
-					for i, t in ipairs(args[1]) do
+					for i, t in args[1] do
 						results[i] = service.FormatTime(t, select(2, unpack(args)))
 					end
 					return results
@@ -298,7 +298,7 @@ return function(Vargs, GetEnv)
 
 			SetVariables = function(args)
 				local vars = args[1]
-				for var, val in pairs(vars) do
+				for var, val in vars do
 					Variables[var] = val
 				end
 			end;
@@ -347,13 +347,13 @@ return function(Vargs, GetEnv)
 			RemoveUI = function(args)
 				UI.Remove(args[1],args[2])
 			end;
-				
+
 			RefreshUI = function(args)
 				local guiName = args[1]
 				local ignore = args[2]
-				
+
 				UI.Remove(guiName,ignore)
-				
+
 				local themeData = args[3]
 				local guiData = args[4]
 
@@ -522,7 +522,7 @@ return function(Vargs, GetEnv)
 				local sub = string.sub
 				local char = string.char
 
-				local keyCache = cache[key] or {}				
+				local keyCache = cache[key] or {}
 				local endStr = {}
 
 				for i = 1, #str do

--- a/MainModule/Client/Core/UI.lua
+++ b/MainModule/Client/Core/UI.lua
@@ -128,7 +128,7 @@ return function(Vargs, GetEnv)
 				new.Active = true
 				new.Text = ""
 
-				for ind,child in ipairs(gui:GetChildren()) do
+				for ind,child in gui:GetChildren() do
 					child.Parent = new
 				end
 
@@ -158,7 +158,7 @@ return function(Vargs, GetEnv)
 				newEnv.service.Threads = CloneTable(service.Threads)
 			end
 
-			for i,v in pairs(newEnv.client) do
+			for i,v in newEnv.client do
 				if type(v) == "table" and i ~= "Variables" and i ~= "Handlers" then
 					newEnv.client[i] = CloneTable(v)
 				end
@@ -167,14 +167,14 @@ return function(Vargs, GetEnv)
 			if ran then
 				--// Temporarily disabled NoEnv; it seems to be causing some issues(?)
 				--// ~ Expertcoderz
-				
+
 				--[[if (data.isModifier and not data.modNoEnv) or (not data.isModifier and data.isCode and not data.NoEnv) then
 					setfenv(func, env)
 				end]]
 
 				local rets = {
 					TrackTask("UI: ".. module:GetFullName(),
-						--func, 
+						--func,
 						setfenv(func, newEnv),
 						data,
 						newEnv
@@ -244,9 +244,9 @@ return function(Vargs, GetEnv)
 
 			if #foundConfigs > 0 then
 				--// Combine all configs found in order  to build full config (in order of closest from target gui to furthest)
-				for i,v in pairs(foundConfigs) do
+				for i,v in foundConfigs do
 					if v.Config then
-						for k,m in ipairs(v.Config:GetChildren()) do
+						for k,m in v.Config:GetChildren() do
 							if not endConfig[m.Name] then
 								if string.sub(m.Name, 1, 5) == "NoEnv" then
 									endConfig["Code"] = m
@@ -259,7 +259,7 @@ return function(Vargs, GetEnv)
 				end
 
 				--// Load all config values into the new Config folder
-				for i,v in pairs(endConfig) do
+				for i,v in endConfig do
 					v:Clone().Parent = confFolder;
 				end
 
@@ -394,7 +394,7 @@ return function(Vargs, GetEnv)
 			local found = {}
 			local num = 0
 			if obj then
-				for ind,g in pairs(client.GUIs) do
+				for ind,g in client.GUIs do
 					if g.Name ~= ignore and g.Object ~= ignore and g ~= ignore then
 						if type(obj) == "string" then
 							if g.Name == obj then
@@ -426,7 +426,7 @@ return function(Vargs, GetEnv)
 		Remove = function(name, ignore)
 			local gui = UI.Get(name, ignore)
 			if gui then
-				for i,v in pairs(gui) do
+				for i,v in gui do
 					v.Destroy()
 				end
 			end
@@ -474,7 +474,7 @@ return function(Vargs, GetEnv)
 					local Events = gTable.Events
 					local disc = function()
 						origDisc(signal)
-						for i,v in pairs(Events) do
+						for i,v in Events do
 							if v.Signal == signal then
 								table.remove(Events, i)
 							end
@@ -494,7 +494,7 @@ return function(Vargs, GetEnv)
 				end,
 
 				ClearEvents = function()
-					for i,v in pairs(gTable.Events) do
+					for i,v in gTable.Events do
 						v:Remove()
 					end
 				end,
@@ -549,7 +549,7 @@ return function(Vargs, GetEnv)
 			}
 
 			if data then
-				for i,v in pairs(data) do
+				for i,v in data do
 					gTable[i] = v
 				end
 			end

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1199,12 +1199,13 @@ return function(Vargs, env)
 			Description = "Crashes the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string}, data: {any})
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = true;
-					})) do
+					})
+				do
 					if data.PlayerData.Level > Admin.GetLevel(v) then
 						Remote.Send(v, "Function", "Crash")
 					else
@@ -1221,12 +1222,13 @@ return function(Vargs, env)
 			Description = "Hard crashes the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string}, data: {any})
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = true;
-					})) do
+					})
+				do
 					if data.PlayerData.Level > Admin.GetLevel(v) then
 						Remote.Send(v, "Function", "HardCrash")
 					else
@@ -1243,12 +1245,13 @@ return function(Vargs, env)
 			Description = "RAM crashes the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string}, data: {any})
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = true;
-					})) do
+					})
+				do
 					if data.PlayerData.Level > Admin.GetLevel(v) then
 						Remote.Send(v, "Function", "RAMCrash")
 					else
@@ -1265,12 +1268,13 @@ return function(Vargs, env)
 			Description = "GPU crashes the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string}, data: {any})
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = true;
-					})) do
+					})
+				do
 					if data.PlayerData.Level > Admin.GetLevel(v) then
 						Remote.Send(v, "Function", "GPUCrash")
 					else
@@ -1319,12 +1323,13 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string}, data: {any})
 				local level = data.PlayerData.Level
 				local reason = args[2] or "No reason provided";
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = true;
-					})) do
+					})
+				do
 					if level > Admin.GetLevel(v) then
 						Admin.AddBan(v, reason, false, plr)
 						Functions.Hint("Server-banned "..tostring(v), {plr})
@@ -1376,13 +1381,13 @@ return function(Vargs, env)
 				local level = data.PlayerData.Level
 				local reason = string.format("Administrator: %s\nReason: %s", service.FormatPlayer(plr), (args[2] or "N/A"))
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = true;
-					})) do
-
+					})
+				do
 					if level > Admin.GetLevel(v) then
 						trello.makeCard(
 							list.id,

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -50,7 +50,7 @@ return function(Vargs, env)
 
 				local newRank = Settings.Ranks[rankName]
 				if not newRank then
-					for thisRankName, thisRank in pairs(Settings.Ranks) do
+					for thisRankName, thisRank in Settings.Ranks do
 						if thisRankName:lower() == rankName:lower() then
 							rankName = thisRankName
 							newRank = thisRank
@@ -65,7 +65,7 @@ return function(Vargs, env)
 
 				assert(newLevel < senderLevel, string.format("Rank level (%s) cannot be equal to or above your own level (%s)", newLevel, senderLevel))
 
-				for _, p in ipairs(Functions.GetPlayers(plr, args[1], {UseFakePlayer = true}))do
+				for _, p in Functions.GetPlayers(plr, args[1], {UseFakePlayer = true})do
 					if senderLevel > Admin.GetLevel(p) then
 						Admin.AddAdmin(p, rankName)
 						Remote.MakeGui(p, "Notification", {
@@ -95,7 +95,7 @@ return function(Vargs, env)
 
 				local newRank = Settings.Ranks[rankName]
 				if not newRank then
-					for thisRankName, thisRank in pairs(Settings.Ranks) do
+					for thisRankName, thisRank in Settings.Ranks do
 						if thisRankName:lower() == rankName:lower() then
 							rankName = thisRankName
 							newRank = thisRank
@@ -110,7 +110,7 @@ return function(Vargs, env)
 
 				assert(newLevel < senderLevel, string.format("Rank level (%s) cannot be equal to or above your own level (%s)", newLevel, senderLevel))
 
-				for _, p in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, p in service.GetPlayers(plr, args[1]) do
 					if senderLevel > Admin.GetLevel(p) then
 						Admin.AddAdmin(p, rankName, true)
 						Remote.MakeGui(p, "Notification", {
@@ -141,7 +141,7 @@ return function(Vargs, env)
 
 				assert(newLevel < senderLevel, "Level cannot be equal to or above your own permission level (".. senderLevel ..")");
 
-				for _, p in ipairs(service.GetPlayers(plr, args[1]))do
+				for _, p in service.GetPlayers(plr, args[1])do
 					if senderLevel > Admin.GetLevel(p) then
 						Admin.SetLevel(p, newLevel)--, args[3] == "true")
 						Remote.MakeGui(p, "Notification", {
@@ -177,7 +177,7 @@ return function(Vargs, env)
 				})
 
 				if plrs and #plrs > 0 then
-					for _, v in ipairs(plrs) do
+					for _, v in plrs do
 						local targLevel, targRank = Admin.GetLevel(v)
 						if targLevel > 0 then
 							if sendLevel > targLevel then
@@ -196,6 +196,10 @@ return function(Vargs, env)
 							Functions.Hint(service.FormatPlayer(v).." does not already have any rank to remove", {plr})
 						end
 					end
+				end
+
+				if sendLevel < 900 then
+					error("Player not found. Try the full username or use id-USERSIDHERE");
 				else
 					if sendLevel < 900 then
 						error("Player not found; try the full username or use id-USERSIDHERE")
@@ -203,9 +207,9 @@ return function(Vargs, env)
 						local checkThis = args[1];
 						local found = false;
 
-						for rank, data in pairs(Settings.Ranks) do
+						for rank, data in Settings.Ranks do
 							if sendLevel > data.Level then
-								for i, user in ipairs(data.Users) do
+								for i, user in data.Users do
 									if Admin.DoCheck(checkThis, user) then
 										local ans = Remote.GetGui(plr, "YesNoPrompt", {
 											Question = "Remove '"..tostring(user).."' from '".. rank .."'?";
@@ -213,17 +217,16 @@ return function(Vargs, env)
 
 										if ans == "Yes" then
 											table.remove(data.Users, i)
-
 											if not temp and Settings.SaveAdmins then
 												service.TrackTask("Thread: RemoveAdmin", Core.DoSave, {
 													Type = "TableRemove";
 													Table = {"Settings", "Ranks", rank, "Users"};
 													Value = user;
 												});
-											end
+												Functions.Hint("Removed ".. tostring(user) .." from ".. rank, {plr})
+												Logs:AddLog("Script", string.format("%s removed %s from %s", tostring(plr), tostring(user), rank))
 
-											Functions.Hint("Removed ".. tostring(user) .." from ".. rank, {plr})
-											Logs:AddLog("Script", string.format("%s removed %s from %s", tostring(plr), tostring(user), rank))
+											end
 										end
 										found = true
 									end
@@ -248,7 +251,7 @@ return function(Vargs, env)
 				local sendLevel = data.PlayerData.Level
 				local plrs = service.GetPlayers(plr, args[1], {DontError = true;})
 				if plrs and #plrs > 0 then
-					for _, v in ipairs(plrs) do
+					for _, v in plrs do
 						local targLevel = Admin.GetLevel(v)
 						if targLevel > 0 then
 							if sendLevel > targLevel then
@@ -280,7 +283,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string}, data: {any})
 				assert(args[1], "Missing target player (argument #1)")
 				local sendLevel = data.PlayerData.Level
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if sendLevel > Admin.GetLevel(v) then
 						Admin.AddAdmin(v, "Moderators", true)
 						Remote.MakeGui(v, "Notification", {
@@ -307,7 +310,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string}, data: {any})
 				assert(args[1], "Missing target player (argument #1)")
 				local sendLevel = data.PlayerData.Level
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if sendLevel > Admin.GetLevel(v) then
 						Admin.AddAdmin(v, "Moderators")
 						Remote.MakeGui(v, "Notification", {
@@ -333,7 +336,7 @@ return function(Vargs, env)
 			Description = "Makes a message in the chat window";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers()) do
+				for _, v in service.GetPlayers() do
 					Remote.Send(v, "Function", "ChatMessage", string.format("[%s] %s", Settings.SystemTitle, service.Filter(args[1], plr, v)), Color3.fromRGB(255,64,77))
 				end
 			end
@@ -348,7 +351,7 @@ return function(Vargs, env)
 			ListUpdater = function(plr: Player)
 				local logs = Core.GetData("ShutdownLogs") or {}
 				local tab = {}
-				for i, v in ipairs(logs) do
+				for i, v in logs do
 					if v.Restart then v.Time ..= " [RESTART]" end
 					tab[i] = {
 						Text = v.Time..": "..v.User;
@@ -407,7 +410,7 @@ return function(Vargs, env)
 							UseFakePlayer = true;
 						})
 						if #plrs>0 then
-							for _, v in ipairs(plrs) do
+							for _, v in plrs do
 								table.insert(Variables.Whitelist.Lists.Settings, v.Name..":"..v.UserId)
 								Functions.Hint("Added "..service.FormatPlayer(v).." to the whitelist", {plr})
 							end
@@ -419,7 +422,7 @@ return function(Vargs, env)
 					end
 				elseif sub == "remove" then
 					if args[2] then
-						for i, v in pairs(Variables.Whitelist.Lists.Settings) do
+						for i, v in Variables.Whitelist.Lists.Settings do
 							if string.sub(string.lower(v), 1,#args[2]) == string.lower(args[2])then
 								table.remove(Variables.Whitelist.Lists.Settings,i)
 								Functions.Hint("Removed "..tostring(v).." from the whitelist", {plr})
@@ -430,9 +433,9 @@ return function(Vargs, env)
 					end
 				elseif sub == "list" then
 					local Tab = {}
-					for Key, List in pairs(Variables.Whitelist.Lists) do
+					for Key, List in Variables.Whitelist.Lists do
 						local Prefix = Key == "Settings" and "" or "["..Key.."] "
-						for _, User in ipairs(List) do
+						for _, User in List do
 							table.insert(Tab, {Text = Prefix .. User, Desc = User})
 						end
 					end
@@ -452,7 +455,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing message")
-				for _, v in ipairs(service.GetPlayers()) do
+				for _, v in service.GetPlayers() do
 					Remote.RemoveGui(v, "Notify")
 					Remote.MakeGui(v, "Notify", {
 						Title = Settings.SystemTitle;
@@ -474,12 +477,12 @@ return function(Vargs, env)
 
 				if args[1] == "off" or args[1] == "false" then
 					Variables.NotifMessage = nil
-					for _, v in ipairs(service.GetPlayers()) do
+					for _, v in service.GetPlayers() do
 						Remote.RemoveGui(v, "Notif")
 					end
 				else
 					Variables.NotifMessage = args[1]
-					for _, v in ipairs(service.GetPlayers()) do
+					for _, v in service.GetPlayers() do
 						Remote.MakeGui(v, "Notif", {
 							Message = Variables.NotifMessage;
 						})
@@ -523,7 +526,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing message")
-				for _, v in ipairs(service.Players:GetPlayers()) do
+				for _, v in service.Players:GetPlayers() do
 					Remote.RemoveGui(v, "Message")
 					Remote.MakeGui(v, "Message", {
 						Title = Settings.SystemTitle;
@@ -540,7 +543,7 @@ return function(Vargs, env)
 			Description = "Enables or disables CoreGui elements for the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _,v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _,v in service.GetPlayers(plr, args[1]) do
 					if string.lower(args[3]) == "on" or string.lower(args[3]) == "true" then
 						Remote.Send(v, "Function", "SetCoreGuiEnabled", args[2], true)
 					elseif string.lower(args[3]) == 'off' or string.lower(args[3]) == "false" then
@@ -558,7 +561,7 @@ return function(Vargs, env)
 			Description = "Get someone's attention";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr,string.lower(args[1])))do
+				for _, v in service.GetPlayers(plr,string.lower(args[1]))do
 					Remote.MakeGui(v, "Alert", {Message = args[2] and service.Filter(args[2],plr, v) or "Wake up; Your attention is required"})
 				end
 			end
@@ -571,7 +574,7 @@ return function(Vargs, env)
 			Description = "Locks the map";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, Obj in ipairs(workspace:GetDescendants())do
+				for _, Obj in workspace:GetDescendants()do
 					if Obj:IsA("BasePart")then
 						Obj.Locked = true
 					end
@@ -586,7 +589,7 @@ return function(Vargs, env)
 			Description = "Unlocks the map";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, Obj in ipairs(workspace:GetDescendants())do
+				for _, Obj in workspace:GetDescendants()do
 					if Obj:IsA("BasePart")then
 						Obj.Locked = false
 					end
@@ -615,18 +618,18 @@ return function(Vargs, env)
 					})
 
 					local clonedDeps = Deps.Assets:FindFirstChild("F3X Deps"):Clone()
-					for _, BaseScript in ipairs(clonedDeps:GetDescendants()) do
+					for _, BaseScript in clonedDeps:GetDescendants() do
 						if BaseScript:IsA("BaseScript") then
 							BaseScript.Disabled = false
 						end
 					end
-					for _, Child in ipairs(clonedDeps:GetChildren()) do
+					for _, Child in clonedDeps:GetChildren() do
 						Child.Parent = F3X
 					end
 					clonedDeps:Destroy()
 				end
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local Backpack = v:FindFirstChildOfClass("Backpack")
 
 					if Backpack then
@@ -645,14 +648,14 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local id = string.lower(args[1])
 
-				for i, v in pairs(Variables.InsertList) do
+				for i, v in Variables.InsertList do
 					if id == string.lower(v.Name)then
 						id = v.ID
 						break
 					end
 				end
 
-				for i, v in pairs(HTTP.Trello.InsertList) do
+				for i, v in HTTP.Trello.InsertList do
 					if id == string.lower(v.Name) then
 						id = v.ID
 						break
@@ -676,7 +679,7 @@ return function(Vargs, env)
 			Description = "Saves the equipped tool to the storage so that it can be inserted using "..Settings.Prefix.."give";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local tool = v.Character and v.Character:FindFirstChildWhichIsA("BackpackItem")
 					if tool then
 						tool = tool:Clone()
@@ -699,7 +702,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				local count = 0
-				for tool in pairs(Variables.SavedTools) do
+				for tool in Variables.SavedTools do
 					count += 1
 					tool:Destroy()
 				end
@@ -737,7 +740,7 @@ return function(Vargs, env)
 			Description = "Remove the specified team";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.Teams:GetTeams()) do
+				for _, v in service.Teams:GetTeams() do
 					if string.sub(string.lower(v.Name), 1, #args[1]) == string.lower(args[1]) then
 						v:Destroy()
 					end
@@ -770,7 +773,7 @@ return function(Vargs, env)
 				Variables.RestoringMap = true
 				Functions.Hint("Restoring Map...", service.Players:GetPlayers())
 
-				for _, obj in ipairs(workspace:GetChildren()) do
+				for _, obj in workspace:GetChildren() do
 					if obj.ClassName ~= "Terrain" and not service.Players:GetPlayerFromCharacter(obj) then
 						obj:Destroy()
 						service.RunService.Stepped:Wait()
@@ -778,7 +781,7 @@ return function(Vargs, env)
 				end
 
 				local new = Variables.MapBackup:Clone()
-				for _, obj in ipairs(new:GetChildren()) do
+				for _, obj in new:GetChildren() do
 					obj.Parent = workspace
 					if obj:IsA("Model") then
 						obj:MakeJoints()
@@ -954,11 +957,11 @@ return function(Vargs, env)
 					end
 				elseif action == "list" then
 					local tab = {}
-					for i, v in pairs(sb.Script) do
+					for i, v in sb.Script do
 						table.insert(tab, {Text = "Script: "..tostring(i), Desc = "Running: "..tostring(v.Script.Disabled)})
 					end
 
-					for i, v in pairs(sb.LocalScript) do
+					for i, v in sb.LocalScript do
 						table.insert(tab, {Text = "LocalScript: "..tostring(i), Desc = "Running: "..tostring(v.Script.Disabled)})
 					end
 
@@ -1043,7 +1046,7 @@ return function(Vargs, env)
 				assert(string.find(bytecode, "\27Lua"), "LocalScript unable to be created; ".. string.gsub(bytecode, "Loadstring%.LuaX:%d+:", ""))
 
 				local new = Core.NewScript("LocalScript", "script.Parent = game:GetService('Players').LocalPlayer.PlayerScripts; "..args[2], true)
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local cl = new:Clone()
 					cl.Name = "[Adonis] LocalScript"
 					cl.Disabled = true
@@ -1064,7 +1067,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				assert(args[2], "Missing note (argument #2)")
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local PlayerData = Core.GetPlayer(v)
 					if not PlayerData.AdminNotes then PlayerData.AdminNotes = {} end
 					table.insert(PlayerData.AdminNotes, args[2])
@@ -1082,13 +1085,13 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				assert(args[2], "Missing note (argument #2)")
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local PlayerData = Core.GetPlayer(v)
 					if PlayerData.AdminNotes then
 						if string.lower(args[2]) == "all" then
 							PlayerData.AdminNotes = {}
 						else
-							for k, m in ipairs(PlayerData.AdminNotes) do
+							for k, m in PlayerData.AdminNotes do
 								if string.sub(string.lower(m), 1, #args[2]) == string.lower(args[2]) then
 									Functions.Hint("Removed "..service.FormatPlayer(v).." Note "..m, {plr})
 									table.remove(PlayerData.AdminNotes, k)
@@ -1108,7 +1111,7 @@ return function(Vargs, env)
 			Description = "Views notes on the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local PlayerData = Core.GetPlayer(v)
 					local notes = PlayerData.AdminNotes
 					if not notes then
@@ -1129,7 +1132,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local num = tonumber(args[2]) or 9999
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					service.StopLoop(v.UserId.."LOOPKILL")
 					local count = 0
 					Routine(service.StartLoop, v.UserId.."LOOPKILL", 3, function()
@@ -1153,7 +1156,7 @@ return function(Vargs, env)
 			Description = "Un-Loop Kill";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					service.StopLoop(v.UserId.."LOOPKILL")
 				end
 			end
@@ -1166,7 +1169,7 @@ return function(Vargs, env)
 			Description = "Makes the target player(s)'s FPS drop";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string}, data: {any})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if data.PlayerData.Level > Admin.GetLevel(v) then
 						Remote.Send(v, "Function", "SetFPS", 5.6)
 					else
@@ -1183,7 +1186,7 @@ return function(Vargs, env)
 			Description = "Un-Lag";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "RestoreFPS")
 				end
 			end
@@ -1340,7 +1343,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Argument #1 (player) is required")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local ret = Admin.RemoveBan(v.Name)
 					if ret then
 						if type(ret) == "table" then
@@ -1412,7 +1415,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing message title")
 				assert(args[2], "Missing message")
-				for _, v in ipairs(service.Players:GetPlayers()) do
+				for _, v in service.Players:GetPlayers() do
 					Remote.RemoveGui(v, "Message")
 					Remote.MakeGui(v, "Message", {
 						Title = args[1];
@@ -1432,7 +1435,7 @@ return function(Vargs, env)
 			Description = "Sends the target player(s) to nil, where they will not show up on the player list and not normally be able to interact with the game";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					v.Character = nil
 					v.Parent = nil
 					Functions.Hint("Sent "..service.FormatPlayer(v).." to nil", {plr})
@@ -1447,7 +1450,7 @@ return function(Vargs, env)
 			Description = "Opens the Roblox Premium purchase prompt for the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					service.MarketplaceService:PromptPremiumPurchase(v)
 				end
 			end
@@ -1461,7 +1464,7 @@ return function(Vargs, env)
 			Description = "Sends a Roblox-styled notification for the target player(s)";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "SetCore", "SendNotification", {
 						Title = "Notification";
 						Text = args[3] or "Hello, from Adonis!";
@@ -1497,7 +1500,7 @@ return function(Vargs, env)
 
 				local ChatService = Functions.GetChatService()
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if Variables.DisguiseBindings[v.UserId] then
 						Variables.DisguiseBindings[v.UserId].Rename:Disconnect()
 						Variables.DisguiseBindings[v.UserId].Rename = nil
@@ -1544,7 +1547,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				local ChatService = Functions.GetChatService()
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if Variables.DisguiseBindings[v.UserId] then
 						Variables.DisguiseBindings[v.UserId].Rename:Disconnect()
 						Variables.DisguiseBindings[v.UserId].Rename = nil
@@ -1569,7 +1572,7 @@ return function(Vargs, env)
 			Hidden = true;
 			ListUpdater = function(plr: Player)
 				local tab = {}
-				for p: Player, t: number in pairs(Variables.IncognitoPlayers) do
+				for p: Player, t: number in Variables.IncognitoPlayers do
 					table.insert(tab, {
 						Text = service.FormatPlayer(p);
 						Desc = string.format("ID: %d | Went incognito at: %s", p.UserId, service.FormatTime(t));

--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -119,7 +119,7 @@ return function(Vargs, env)
 			AdminLevel = "Creators";
 			Function = function(plr: Player, args: {string})
 				local amount = assert(tonumber(args[2]), "Invalid/no amount provided (argument #2 must be a number)")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local ran, failed = pcall(service.PointsService.AwardPoints, service.PointsService, v.UserId, amount)
 					if ran and service.PointsService:GetAwardablePoints() >= amount then
 						Functions.Hint("Gave "..amount.." points to "..service.FormatPlayer(v), {plr})
@@ -152,7 +152,7 @@ return function(Vargs, env)
 			AdminLevel = "Creators";
 			Function = function(plr: Player, args: {string}, data: {any})
 				local sendLevel = data.PlayerData.Level
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local targLevel = Admin.GetLevel(v)
 					if sendLevel > targLevel then
 						Admin.AddAdmin(v, "HeadAdmins")
@@ -179,7 +179,7 @@ return function(Vargs, env)
 			AdminLevel = "Creators";
 			Function = function(plr: Player, args: {string}, data: {any})
 				local sendLevel = data.PlayerData.Level
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local targLevel = Admin.GetLevel(v)
 					if sendLevel > targLevel then
 						Admin.AddAdmin(v, "HeadAdmins", true)
@@ -207,7 +207,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing target player (argument #1)")
 				assert(args[2], "Missing command string (argument #2)")
-				for _, v in pairs(service.GetPlayers(plr, args[1], {UseFakePlayer = false})) do
+				for _, v in service.GetPlayers(plr, args[1], {UseFakePlayer = false}) do
 					task.defer(Process.Command, v, args[2], {isSystem = true})
 				end
 			end

--- a/MainModule/Server/Commands/Donors.lua
+++ b/MainModule/Server/Commands/Donors.lua
@@ -42,7 +42,7 @@ return function(Vargs, env)
 			AdminLevel = "Donors";
 			Function = function(plr: Player, args: {[number]:string})
 				if plr.Character then
-					for _, v in pairs(plr.Character:GetChildren()) do
+					for _, v in plr.Character:GetChildren() do
 						if v:IsA("ShirtGraphic") then v:Destroy() end
 					end
 					local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
@@ -64,7 +64,7 @@ return function(Vargs, env)
 			AdminLevel = "Donors";
 			Function = function(plr: Player, args: {string})
 				if plr.Character then
-					for _,p in pairs(plr.Character:GetChildren()) do
+					for _,p in plr.Character:GetChildren() do
 						if p:IsA("BasePart") then
 							if args[1] then
 								p.BrickColor = BrickColor.new(args[1])
@@ -357,7 +357,7 @@ return function(Vargs, env)
 			Donors = true;
 			AdminLevel = "Donors";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(plr.Character:GetChildren()) do
+				for _, v in plr.Character:GetChildren() do
 					if v:IsA("Accoutrement") then
 						v:Destroy()
 					end

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -25,7 +25,7 @@ return function(Vargs, env)
 				local scr = Deps.Assets.Glitcher:Clone()
 				scr.Num.Value = num
 				scr.Type.Value = "trippy"
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local new = scr:Clone()
 					if v.Character then
 						local torso = v.Character:FindFirstChild("HumanoidRootPart")
@@ -51,7 +51,7 @@ return function(Vargs, env)
 				local scr = Deps.Assets.Glitcher:Clone()
 				scr.Num.Value = num
 				scr.Type.Value = "ghost"
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local new = scr:Clone()
 					if v.Character then
 						local torso = v.Character:FindFirstChild("HumanoidRootPart")
@@ -77,7 +77,7 @@ return function(Vargs, env)
 				local scr = Deps.Assets.Glitcher:Clone()
 				scr.Num.Value = num
 				scr.Type.Value = "vibrate"
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local new = scr:Clone()
 					if v.Character then
 						local torso = v.Character:FindFirstChild("HumanoidRootPart")
@@ -101,7 +101,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local torso = v.Character:FindFirstChild("HumanoidRootPart")
 					if torso then
 						local scr = torso:FindFirstChild("Glitchify")
@@ -124,7 +124,7 @@ return function(Vargs, env)
 				assert(args[1], "Missing player name")
 				assert(args[2], "Missing FPS value")
 				assert(tonumber(args[2]), tostring(args[2]).." is not a valid number")
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "SetFPS", tonumber(args[2]))
 				end
 			end
@@ -138,7 +138,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "RestoreFPS")
 				end
 			end
@@ -161,7 +161,7 @@ return function(Vargs, env)
 				local rAssets = require(7679952474) --// This apparently caches, so don't delete anything else future usage breaks
 				local gerald = rAssets.Gerald
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local human = v.Character:FindFirstChildOfClass("Humanoid");
 						if human then
@@ -182,7 +182,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local gerald = v.Character:FindFirstChild("__ADONIS_GERALD");
 						if gerald then
@@ -228,7 +228,7 @@ return function(Vargs, env)
 			Description = "Makes the target player really angry";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v: Player in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v: Player in service.GetPlayers(plr, args[1]) do
 					task.defer(function()
 						local char = v.Character
 						local head = char and char:FindFirstChild("Head")
@@ -268,7 +268,7 @@ return function(Vargs, env)
 			Fun = true;
 			Description = "You're going to";
 			Function = function (plr, args)
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local root = v.Character:FindFirstChild("HumanoidRootPart")
 					local sound = Instance.new("Sound")
 					sound.SoundId = "rbxassetid://5816432987"
@@ -334,7 +334,7 @@ return function(Vargs, env)
 					local cfr = (plr.Character:FindFirstChild("Right Arm") or plr.Character:FindFirstChild("RightFoot")).CFrame
 					handle.CFrame = cfr
 					model:FindFirstChild("Animate").Disabled = true
-					for _, obj in pairs(model:GetDescendants()) do
+					for _, obj in model:GetDescendants() do
 						if obj:IsA("BasePart") then
 							obj.Massless = true
 							obj.CanCollide = false
@@ -350,7 +350,7 @@ return function(Vargs, env)
 				end
 
 				if pcall(function() service.GetPlayers(plr, args[1]) end) then
-					for _, v in pairs(service.GetPlayers(plr, args[1])) do
+					for _, v in service.GetPlayers(plr, args[1]) do
 						generate(v.UserId)
 					end
 				else
@@ -372,7 +372,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Description = "Turns a player into a doll which can be picked up";
 			Function = function(runner, args)
-				for _, plr in pairs(service.GetPlayers(runner, args[1])) do
+				for _, plr in service.GetPlayers(runner, args[1]) do
 					if plr.Character.Parent:IsA("Tool") ~= true then
 						local tool = Instance.new("Tool")
 						tool.ToolTip = plr.DisplayName .. " as a tool, converted with Adonis."
@@ -397,7 +397,7 @@ return function(Vargs, env)
 						local cfr = (plr.Character:FindFirstChild("HumanoidRootPart")).CFrame
 						handle.CFrame = cfr
 						handle.CanCollide = false
-						for _, v in pairs(model:GetDescendants()) do
+						for _, v in model:GetDescendants() do
 							if v:IsA("BasePart") then
 								v.Massless = true
 							end
@@ -426,7 +426,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local size = tonumber(args[2]) or 19
 				local dist = tonumber(args[3]) or 100
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Effect", {
 						Mode = "Pixelize";
 						Resolution = size;
@@ -450,7 +450,7 @@ return function(Vargs, env)
 						table.insert(Variables.FrozenObjects, obj)
 					end
 
-					for i, v in pairs(obj:GetChildren()) do
+					for i, v in obj:GetChildren() do
 						doPause(v)
 					end
 				end
@@ -464,7 +464,7 @@ return function(Vargs, env)
 						audio.Volume = 0.5
 						audio:Play()
 						wait(2)
-						for i, part in pairs(Variables.FrozenObjects) do
+						for i, part in Variables.FrozenObjects do
 							part.Anchored = false
 						end
 
@@ -533,7 +533,7 @@ return function(Vargs, env)
 				if not speed or not tonumber(speed) then
 					speed = 1000
 				end
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "Dizzy", tonumber(speed))
 				end
 			end
@@ -547,7 +547,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Fun = true;
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "Dizzy", false)
 				end
 			end
@@ -561,7 +561,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Admin.RunCommand(Settings.Prefix.."char", v.Name, "userid-698712377")
 				end
 			end
@@ -578,7 +578,7 @@ return function(Vargs, env)
 				local gear = service.Insert(tonumber(212641536))
 				if gear:IsA("BackpackItem") then
 					service.New("StringValue", gear).Name = Variables.CodeName..gear.Name
-					for i, v in pairs(service.GetPlayers(plr, args[1])) do
+					for i, v in service.GetPlayers(plr, args[1]) do
 						if v:FindFirstChild("Backpack") then
 							gear:Clone().Parent = v.Backpack
 						end
@@ -602,7 +602,7 @@ return function(Vargs, env)
 						cl.Name = "Infected"
 						cl.Parent = char
 
-						for _, prt in pairs(char:GetChildren()) do
+						for _, prt in char:GetChildren() do
 							if prt:IsA("BasePart") and prt.Name ~= "HumanoidRootPart" and (prt.Name ~= "Head" or not prt.Parent:FindFirstChild("NameTag", true)) then
 								prt.Transparency = 0
 								prt.Reflectance = 0
@@ -632,7 +632,7 @@ return function(Vargs, env)
 					end
 				end
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					infect(v)
 				end
 			end
@@ -651,7 +651,7 @@ return function(Vargs, env)
 						wait(0.1)
 						local char = script.Parent.Parent
 						local clr = BrickColor.random()
-						for i, v in pairs(char:GetChildren()) do
+						for i, v in char:GetChildren() do
 							if v:IsA("BasePart") and v.Name ~= "HumanoidRootPart" and (v.Name ~= "Head" or not v.Parent:FindFirstChild("NameTag", true)) then
 								v.BrickColor = clr
 								v.Reflectance = 0
@@ -667,7 +667,7 @@ return function(Vargs, env)
 				]])
 				scr.Name = "Effectify"
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						if v.Character:FindFirstChild("Shirt") then
 							v.Character.Shirt:Destroy()
@@ -702,9 +702,9 @@ return function(Vargs, env)
 					TorsoColor = BrickColor.new("Bright blue")
 				})
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for _, p in pairs(v.Character:GetChildren()) do
+						for _, p in v.Character:GetChildren() do
 							if p:IsA("Shirt") or p:IsA("Pants") or p:IsA("CharacterMesh") or p:IsA("Accoutrement") or p:IsA("BodyColors") then
 								p:Destroy()
 							end
@@ -761,9 +761,9 @@ return function(Vargs, env)
 					return
 				end
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for _, p in pairs(v.Character:GetChildren()) do
+						for _, p in v.Character:GetChildren() do
 							if p:IsA"BasePart" then
 								p.Material = chosenMat
 							end
@@ -781,9 +781,9 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for _, p in pairs(v.Character:GetChildren()) do
+						for _, p in v.Character:GetChildren() do
 							if p:IsA("Shirt") or p:IsA("Pants") or p:IsA("ShirtGraphic") or p:IsA("CharacterMesh") or p:IsA("Accoutrement") then
 								p:Destroy()
 							elseif p:IsA("Part") then
@@ -813,7 +813,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						Admin.RunCommand(Settings.Prefix.."noclip", v.Name)
 
@@ -825,7 +825,7 @@ return function(Vargs, env)
 							v.Character.Pants:Destroy()
 						end
 
-						for _, prt in pairs(v.Character:GetChildren()) do
+						for _, prt in v.Character:GetChildren() do
 							if prt:IsA("BasePart") and prt.Name ~= "HumanoidRootPart" and (prt.Name ~= "Head" or not prt.Parent:FindFirstChild("NameTag", true)) then
 								prt.Transparency = .5
 								prt.Reflectance = 0
@@ -852,7 +852,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						if v.Character:FindFirstChild("Shirt") then
 							v.Character.Shirt.Parent = v.Character.HumanoidRootPart
@@ -862,7 +862,7 @@ return function(Vargs, env)
 							v.Character.Pants.Parent = v.Character.HumanoidRootPart
 						end
 
-						for _, prt in pairs(v.Character:GetChildren()) do
+						for _, prt in v.Character:GetChildren() do
 							if prt:IsA("BasePart") and prt.Name ~= "HumanoidRootPart" and (prt.Name ~= "Head" or not prt.Parent:FindFirstChild("NameTag", true)) then
 								prt.Transparency = 0
 								prt.Reflectance = .4
@@ -886,7 +886,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						if v.Character:FindFirstChild("Shirt") then
 							v.Character.Shirt:Destroy()
@@ -895,7 +895,7 @@ return function(Vargs, env)
 							v.Character.Pants:Destroy()
 						end
 
-						for _, prt in pairs(v.Character:GetChildren()) do
+						for _, prt in v.Character:GetChildren() do
 							if prt:IsA("BasePart") and prt.Name ~= "HumanoidRootPart" and (prt.Name ~= "Head" or not prt.Parent:FindFirstChild("NameTag", true)) then
 								prt.Transparency = 0
 								prt.Reflectance = 1
@@ -919,7 +919,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Effect", {Mode = "Spooky";})
 				end
 			end
@@ -986,7 +986,7 @@ return function(Vargs, env)
 					end
 				end
 
-				for i, p in pairs(players) do
+				for i, p in players do
 					service.TrackTask("Thread: Thanos", function()
 						for t = 0.1, 1.1, 0.05 do
 							if p.Character then
@@ -998,7 +998,7 @@ return function(Vargs, env)
 									human.NameOcclusion = "OccludeAll"
 								end
 
-								for k, v in ipairs(p.Character:GetChildren()) do
+								for k, v in p.Character:GetChildren() do
 									if v:IsA("BasePart") then
 										local decal = v:FindFirstChildOfClass("Decal")
 										local foundDust = v:FindFirstChild("Thanos_Emitter")
@@ -1119,7 +1119,7 @@ return function(Vargs, env)
 					error(forYou[ind])
 				end
 
-				for _, p in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, p in service.GetPlayers(plr, args[1]) do
 					if p ~= plr and Admin.GetLevel(p) >= data.PlayerData.Level then
 						Functions.Hint("You don't have permission to do this to "..service.FormatPlayer(p), {plr})
 						continue
@@ -1205,7 +1205,7 @@ return function(Vargs, env)
 							torso.Anchored = true
 							tween:Play()
 
-							for i, v in ipairs(p.Character:GetChildren()) do
+							for i, v in p.Character:GetChildren() do
 								if v:IsA("BasePart") then
 									service.TweenService:Create(v, TweenInfo.new(1), {
 										Transparency = 1
@@ -1237,7 +1237,7 @@ return function(Vargs, env)
 										end
 									]])
 
-							for i, v in ipairs(p.Character:GetChildren()) do
+							for i, v in p.Character:GetChildren() do
 								if v:IsA("BasePart") then
 									v.Anchored = true
 									v.Transparency = 1
@@ -1292,7 +1292,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Effect", {Mode = "Blind";})
 				end
 			end
@@ -1308,7 +1308,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local img = tostring(args[2])
 				if not img then error(args[2].." is not a valid ID") end
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Effect", {
 						Mode = "ScreenImage";
 						Image = args[2];
@@ -1327,7 +1327,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local img = tostring(args[2])
 				if not img then error(args[2].." is not a valid ID") end
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Effect", {Mode = "ScreenVideo"; video = args[2];})
 				end
 			end
@@ -1341,7 +1341,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Effect", {Mode = "Off";})
 				end
 			end
@@ -1357,7 +1357,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string}, data: {})
 				local players = service.GetPlayers(plr, args[1])
-				for i, p in ipairs(players) do
+				for i, p in players do
 					if p ~= plr and data.PlayerData.Level <= Admin.GetLevel(p) then
 						table.remove(players, i)
 						Functions.Hint("Unable to send "..service.FormatPlayer(p).." to The Forest (insufficient permission level)", {plr})
@@ -1377,7 +1377,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string}, data: {})
 				local players = service.GetPlayers(plr, args[1])
-				for i, p in ipairs(players) do
+				for i, p in players do
 					if p ~= plr and data.PlayerData.Level <= Admin.GetLevel(p) then
 						table.remove(players, i)
 						Functions.Hint("Unable to send "..service.FormatPlayer(p).." to The Maze (insufficient permission level)", {plr})
@@ -1426,7 +1426,7 @@ return function(Vargs, env)
 					error(forYou[ind])
 				end
 
-				for _, p in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, p in service.GetPlayers(plr, args[1]) do
 					if p ~= plr and Admin.GetLevel(p) >= data.PlayerData.Level then
 						Functions.Hint("You don't have permission to do this to "..service.FormatPlayer(p), {plr})
 						continue
@@ -1587,7 +1587,7 @@ return function(Vargs, env)
 				service.StopLoop("ChickenSpam")
 				service.StartLoop("ChickenSpam", 5, function()
 					tempHats = {}
-					for i, v in pairs(hats) do
+					for i, v in hats do
 						wait(0.5)
 						if not hat or not hat.Parent or not scr or not scr.Parent then
 							break
@@ -1602,11 +1602,11 @@ return function(Vargs, env)
 					end
 					hats = tempHats
 				end)
-				for i, v in pairs(tempHats) do
+				for i, v in tempHats do
 					pcall(function() v:Destroy() end)
 					table.remove(tempHats, i)
 				end
-				for i, v in pairs(hats) do
+				for i, v in hats do
 					pcall(function() v:Destroy() end)
 					table.remove(hats, i)
 				end
@@ -1621,7 +1621,7 @@ return function(Vargs, env)
 			AdminLevel = "HeadAdmins";
 			Fun = true;
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local p = service.New("Part", workspace)
 					table.insert(Variables.Objects, p)
 					p.Transparency = 1
@@ -1677,7 +1677,7 @@ return function(Vargs, env)
 							if obj ~= main and obj:IsA("Part") then
 								table.insert(parts, 1, obj)
 							elseif obj:IsA("Model") or obj:IsA("Accoutrement") or obj:IsA("Tool") or obj == workspace then
-								for i, v in pairs(obj:GetChildren()) do
+								for i, v in obj:GetChildren() do
 									Pcall(get, v)
 								end
 								obj.ChildAdded:Connect(function(p)Pcall(get, p)end)
@@ -1687,7 +1687,7 @@ return function(Vargs, env)
 						get(workspace)
 
 						repeat
-							for i, v in pairs(parts) do
+							for i, v in parts do
 								if (((main.Position - v.Position).Magnitude * 250 * 20) < (5000 * 40)) and v and v:IsDescendantOf(workspace) then
 									coroutine.wrap(fling, v)
 								elseif not v or not v:IsDescendantOf(workspace) then
@@ -1723,7 +1723,7 @@ return function(Vargs, env)
 				local nukes = {}
 				local partsHit = {}
 
-				for i, v in ipairs(Functions.GetPlayers(plr, args[1])) do
+				for i, v in Functions.GetPlayers(plr, args[1]) do
 					local char = v.Character
 					local human = char and char:FindFirstChild("HumanoidRootPart")
 					if human then
@@ -1763,7 +1763,7 @@ return function(Vargs, env)
 				end
 
 				for i = 1, 333 do
-					for i, v in pairs(nukes) do
+					for i, v in nukes do
 						local curPos = v.CFrame
 						v.Size = v.Size + Vector3.new(3, 3, 3)
 						v.CFrame = curPos
@@ -1771,7 +1771,7 @@ return function(Vargs, env)
 					wait(1/44)
 				end
 
-				for i, v in pairs(nukes) do
+				for i, v in nukes do
 					v:Destroy()
 				end
 
@@ -1812,7 +1812,7 @@ return function(Vargs, env)
 						partsHit = nil
 						finished = true
 					elseif partsHit and objs and Variables.WildFire ~= partsHit then
-						for i, v in pairs(objs) do
+						for i, v in objs do
 							v:Destroy()
 						end
 
@@ -1862,7 +1862,7 @@ return function(Vargs, env)
 					end
 				end
 
-				for i, v in pairs(Functions.GetPlayers(plr, args[1])) do
+				for i, v in Functions.GetPlayers(plr, args[1]) do
 					local char = v.Character
 					local human = char and char:FindFirstChild("HumanoidRootPart")
 					if human then
@@ -1883,9 +1883,9 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for _, v in pairs(v.Character:GetChildren()) do
+						for _, v in v.Character:GetChildren() do
 							if v.Name == "Shirt" then local cl = v:Clone() cl.Parent = v.Parent cl.ShirtTemplate = "http://www.roblox.com/asset/?id=109163376" v:Destroy() end
 							if v.Name == "Pants" then local cl = v:Clone() cl.Parent = v.Parent cl.PantsTemplate = "http://www.roblox.com/asset/?id=109163376" v:Destroy() end
 						end
@@ -1903,13 +1903,13 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 							Admin.RunCommand(Settings.Prefix.."pants", v.Name, "233373970")
 							Admin.RunCommand(Settings.Prefix.."shirt", v.Name, "133078195")
 
-							for _, v in pairs(v.Character:GetChildren()) do
+							for _, v in v.Character:GetChildren() do
 								if v:IsA("Accoutrement") or v:IsA("CharacterMesh") then
 									v:Destroy()
 								end
@@ -1935,7 +1935,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					cPcall(function()
 						if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 							local knownchar = v.Character
@@ -1988,7 +1988,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChildOfClass("Humanoid") then
 						local human = v.Character:FindFirstChildOfClass("Humanoid")
 						local rigType = human and (human.RigType == Enum.HumanoidRigType.R6 and "R6" or "R15") or nil
@@ -2006,7 +2006,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					cPcall(function()
 						local color
 						local num = math.random(1, 7)
@@ -2047,7 +2047,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					cPcall(function()
 						if not v:IsA("Player") or not v or not v.Character or not v.Character:FindFirstChild("Head") or v.Character:FindFirstChild("Epix Puke") then return end
 						local run = true
@@ -2118,7 +2118,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					cPcall(function()
 						if not v:IsA("Player") or not v or not v.Character or not v.Character:FindFirstChild("Head") or v.Character:FindFirstChild("ADONIS_BLEED") then return end
 						local run = true
@@ -2189,7 +2189,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						local torso = v.Character:FindFirstChild("HumanoidRootPart")
 						local larm=v.Character:FindFirstChild("Left Arm")
@@ -2242,7 +2242,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if args[2] and args[2]:lower() == "destroy" then
 						local hats = v.Character:FindFirstChild("ADONIS_HAT_PETS")
 						if hats then hats:Destroy() end
@@ -2273,7 +2273,7 @@ return function(Vargs, env)
 								obj = m.Target
 							end
 
-							for _, h in pairs(v.Character:GetChildren()) do
+							for _, h in v.Character:GetChildren() do
 								if h:IsA("Accessory") then
 									hat = h
 									break
@@ -2312,7 +2312,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local hats = plr.Character:FindFirstChild("ADONIS_HAT_PETS")
 				if hats then
-					for i, v in pairs(service.GetPlayers(plr, args[2])) do
+					for i, v in service.GetPlayers(plr, args[2]) do
 						if v.Character:FindFirstChild("HumanoidRootPart") and v.Character.HumanoidRootPart:IsA("Part") then
 							if args[1]:lower() == "follow" then
 								hats.Mode.Value = "Follow"
@@ -2343,9 +2343,9 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
-						for _, frc in pairs(v.Character.HumanoidRootPart:GetChildren()) do
+						for _, frc in v.Character.HumanoidRootPart:GetChildren() do
 							if frc.Name == "ADONIS_GRAVITY" then
 								frc:Destroy()
 							end
@@ -2363,9 +2363,9 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
-						for _, frc in pairs(v.Character.HumanoidRootPart:GetChildren()) do
+						for _, frc in v.Character.HumanoidRootPart:GetChildren() do
 							if frc.Name == "ADONIS_GRAVITY" then
 								frc:Destroy()
 							end
@@ -2374,7 +2374,7 @@ return function(Vargs, env)
 						local frc = service.New("BodyForce", v.Character.HumanoidRootPart)
 						frc.Name = "ADONIS_GRAVITY"
 						frc.force = Vector3.new(0, 0, 0)
-						for _, prt in pairs(v.Character:GetChildren()) do
+						for _, prt in v.Character:GetChildren() do
 							if prt:IsA("BasePart") then
 								frc.force = frc.force - Vector3.new(0, prt:GetMass()*tonumber(args[2]), 0)
 							elseif prt:IsA("Accoutrement") then
@@ -2394,9 +2394,9 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v and v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
-						for _, frc in pairs(v.Character.HumanoidRootPart:GetChildren()) do
+						for _, frc in v.Character.HumanoidRootPart:GetChildren() do
 							if frc.Name == "ADONIS_GRAVITY" then
 								frc:Destroy()
 							end
@@ -2405,7 +2405,7 @@ return function(Vargs, env)
 						local frc = service.New("BodyForce", v.Character.HumanoidRootPart)
 						frc.Name = "ADONIS_GRAVITY"
 						frc.force = Vector3.new(0, 0, 0)
-						for _, prt in pairs(v.Character:GetChildren()) do
+						for _, prt in v.Character:GetChildren() do
 							if prt:IsA("BasePart") then
 								frc.force = frc.force + Vector3.new(0, prt:GetMass()*196.25, 0)
 							elseif prt:IsA("Accoutrement") then
@@ -2428,7 +2428,7 @@ return function(Vargs, env)
 				local bunnyScript = Deps.Assets.BunnyHop
 				bunnyScript.Name = "HippityHopitus"
 				local hat = service.Insert(110891941)
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					hat:Clone().Parent = v.Character
 					local clone = bunnyScript:Clone()
 					clone.Parent = v.Character
@@ -2445,7 +2445,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local scr = v.Character:FindFirstChild("HippityHopitus")
 					if scr then
 						scr.Disabled = true
@@ -2463,7 +2463,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character:FindFirstChild("HumanoidRootPart") then
 						v.Character.HumanoidRootPart.CFrame = v.Character.HumanoidRootPart.CFrame+Vector3.new(0, tonumber(args[2]), 0)
 					end
@@ -2479,9 +2479,9 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for kay, player in pairs(service.GetPlayers(plr, args[1])) do
+				for kay, player in service.GetPlayers(plr, args[1]) do
 					local m = player.Character
-					for i, v in pairs(m:GetChildren()) do
+					for i, v in m:GetChildren() do
 						if v:IsA("Part") then
 							local s = service.New("SelectionPartLasso")
 							s.Parent = m.HumanoidRootPart
@@ -2510,7 +2510,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for kay, player in pairs(service.GetPlayers(plr, args[1])) do
+				for kay, player in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						local torso = player.Character:FindFirstChild("HumanoidRootPart")
 						if torso then
@@ -2547,7 +2547,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					cPcall(function()
 						Admin.RunCommand(Settings.Prefix.."freeze", v.Name)
 						local char = v.Character
@@ -2660,9 +2660,9 @@ return function(Vargs, env)
 				bg.maxTorque = Vector3.new(0, math.huge, 0)
 				bg.P = 11111
 				bg.D = 0
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
-						for _, q in pairs(v.Character.HumanoidRootPart:GetChildren()) do
+						for _, q in v.Character.HumanoidRootPart:GetChildren() do
 							if q.Name == "SPINNER" or q.Name == "SPINNER_GYRO" then
 								q:Destroy()
 							end
@@ -2686,9 +2686,9 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
-						for _, q in pairs(v.Character.HumanoidRootPart:GetChildren()) do
+						for _, q in v.Character.HumanoidRootPart:GetChildren() do
 							if q.Name == "SPINNER" or q.Name == "SPINNER_GYRO" then
 								q:Destroy()
 							end
@@ -2706,7 +2706,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(p, args)
-				for _, plr in ipairs(service.GetPlayers(p, args[1])) do
+				for _, plr in service.GetPlayers(p, args[1]) do
 					if plr and plr.Character and plr.Character:FindFirstChild("HumanoidRootPart") then
 						local human = plr.Character:FindFirstChildOfClass("Humanoid")
 
@@ -2727,7 +2727,7 @@ return function(Vargs, env)
 
 							torso.Transparency = 1
 
-							for _, v in ipairs(torso:GetChildren()) do
+							for _, v in torso:GetChildren() do
 								if v:IsA("Motor6D") then
 									local lc0 = service.New("CFrameValue", {Name = "LastC0";Value = v.C0;Parent = v})
 								end
@@ -2754,7 +2754,7 @@ return function(Vargs, env)
 
 							local weld = service.New("Weld", {Parent = st, Part0 = torso, Part1 = st, C1 = CFrame.new(0, .5, 0)})
 
-							for _, v in ipairs(char:GetDescendants()) do
+							for _, v in char:GetDescendants() do
 								if v:IsA("BasePart") then
 									v.BrickColor = BrickColor.new("Brown")
 								end
@@ -2792,9 +2792,9 @@ return function(Vargs, env)
 				sound.SoundId = "rbxassetid://137545053"
 				sound.Looped = true
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local character = v.Character
-					for k, p in pairs(character.HumanoidRootPart:GetChildren()) do
+					for k, p in character.HumanoidRootPart:GetChildren() do
 						if p:IsA("Decal") or p:IsA("Sound") then
 							p:Destroy()
 						end
@@ -2814,7 +2814,7 @@ return function(Vargs, env)
 						headMesh.Scale = Vector3.new(0.01, 0.01, 0.01)
 					else
 						character.Head.Transparency = 1
-						for _, c in ipairs(character.Head:GetChildren()) do
+						for _, c in character.Head:GetChildren() do
 							if c:IsA("Decal") then
 								c.Transparency = 1
 							elseif c:IsA("LayerCollector") then
@@ -2864,8 +2864,8 @@ return function(Vargs, env)
 				sound.SoundId = "rbxassetid://174270407"
 				sound.Looped = true
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
-					for k, p in pairs(v.Character.HumanoidRootPart:GetChildren()) do
+				for i, v in service.GetPlayers(plr, args[1]) do
+					for k, p in v.Character.HumanoidRootPart:GetChildren() do
 						if p:IsA("Decal") or p:IsA("Sound") then
 							p:Destroy()
 						end
@@ -2885,7 +2885,7 @@ return function(Vargs, env)
 						headMesh.Scale = Vector3.new(0.01, 0.01, 0.01)
 					else
 						v.Character.Head.Transparency = 1
-						for _, c in ipairs(v.Character.Head:GetChildren()) do
+						for _, c in v.Character.Head:GetChildren() do
 							if c:IsA("Decal") then
 								c.Transparency = 1
 							elseif c:IsA("LayerCollector") then
@@ -2935,8 +2935,8 @@ return function(Vargs, env)
 				sound.SoundId = "rbxassetid://179393562"
 				sound.Looped = true
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
-					for k, p in pairs(v.Character.HumanoidRootPart:GetChildren()) do
+				for i, v in service.GetPlayers(plr, args[1]) do
+					for k, p in v.Character.HumanoidRootPart:GetChildren() do
 						if p:IsA("Decal") or p:IsA("Sound") then
 							p:Destroy()
 						end
@@ -2956,7 +2956,7 @@ return function(Vargs, env)
 						headMesh.Scale = Vector3.new(0.01, 0.01, 0.01)
 					else
 						v.Character.Head.Transparency = 1
-						for _, c in ipairs(v.Character.Head:GetChildren()) do
+						for _, c in v.Character.Head:GetChildren() do
 							if c:IsA("Decal") then
 								c.Transparency = 1
 							elseif c:IsA("LayerCollector") then
@@ -3010,8 +3010,8 @@ return function(Vargs, env)
 				sound.SoundId = "rbxassetid://265125691"
 				sound.Looped = true
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
-					for k, p in pairs(v.Character.HumanoidRootPart:GetChildren()) do
+				for i, v in service.GetPlayers(plr, args[1]) do
+					for k, p in v.Character.HumanoidRootPart:GetChildren() do
 						if p:IsA("Decal") or p:IsA("Sound") then
 							p:Destroy()
 						end
@@ -3070,8 +3070,8 @@ return function(Vargs, env)
 				sound.SoundId = "rbxassetid://149690685"
 				sound.Looped = true
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
-					for k, p in pairs(v.Character.HumanoidRootPart:GetChildren()) do
+				for i, v in service.GetPlayers(plr, args[1]) do
+					for k, p in v.Character.HumanoidRootPart:GetChildren() do
 						if p:IsA("Decal") or p:IsA("Sound") then
 							p:Destroy()
 						end
@@ -3131,8 +3131,8 @@ return function(Vargs, env)
 
 				cl.Name = "Animator"
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
-					for k, p in pairs(v.Character.HumanoidRootPart:GetChildren()) do
+				for i, v in service.GetPlayers(plr, args[1]) do
+					for k, p in v.Character.HumanoidRootPart:GetChildren() do
 						if p:IsA("Decal") or p:IsA("Sound") then
 							p:Destroy()
 						end
@@ -3191,9 +3191,9 @@ return function(Vargs, env)
 					}
 				end
 
-				for _, v in pairs(Functions.GetPlayers(plr, args[1])) do
+				for _, v in Functions.GetPlayers(plr, args[1]) do
 					local char = v.Character
-					for _, p in pairs(char:GetChildren()) do
+					for _, p in char:GetChildren() do
 						if p:IsA("BasePart") then
 							Functions.RemoveParticle(p, "ADONIS_CMD_TRAIL")
 
@@ -3229,7 +3229,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local torso = v.Character:FindFirstChild("HumanoidRootPart")
 					if torso then
 						Functions.RemoveParticle(torso, "PARTICLE")
@@ -3272,7 +3272,7 @@ return function(Vargs, env)
 					endc = Color3.new(endColor[1], endColor[2], endColor[3])
 				end
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local torso = v.Character:FindFirstChild("HumanoidRootPart")
 					if torso then
 						Functions.NewParticle(torso, "ParticleEmitter", {
@@ -3329,14 +3329,14 @@ return function(Vargs, env)
 						torso.BottomSurface = 0
 						torso.TopSurface = 0
 
-						for _, v in ipairs(char:GetChildren()) do
+						for _, v in char:GetChildren() do
 							if v:IsA("BasePart") then
 								v.Anchored = true
 							end
 						end
 
 						local function size(part)
-							for _, v in ipairs(part:GetChildren()) do
+							for _, v in part:GetChildren() do
 								if (v:IsA("Weld") or v:IsA("Motor") or v:IsA("Motor6D")) and v.Part1 and v.Part1:IsA("Part") then
 									local p1 = v.Part1
 									local c0 = {v.C0:components()}
@@ -3356,7 +3356,7 @@ return function(Vargs, env)
 										p1.Size = Vector3.new(p1.Size.X, p1.Size.Y, num)
 									elseif p1.Name ~= "Torso" then
 										p1.Anchored = true
-										for _, m in pairs(p1:GetChildren()) do
+										for _, m in p1:GetChildren() do
 											if m:IsA("Weld") then
 												m.Part0 = nil
 												m.Part1.Anchored = true
@@ -3366,7 +3366,7 @@ return function(Vargs, env)
 										p1.formFactor = 3
 										p1.Size = Vector3.new(p1.Size.X, p1.Size.Y, num)
 
-										for _, m in pairs(p1:GetChildren()) do
+										for _, m in p1:GetChildren() do
 											if m:IsA("Weld") then
 												m.Part0 = p1
 												m.Part1.Anchored = false
@@ -3402,12 +3402,12 @@ return function(Vargs, env)
 						torso.formFactor = 3
 						torso.Size = Vector3.new(torso.Size.X, torso.Size.Y, num)
 
-						for i, v in pairs(welds) do
+						for i, v in welds do
 							v.Part0 = torso
 							v.Part1.Anchored = false
 						end
 
-						for i, v in pairs(char:GetChildren()) do
+						for i, v in char:GetChildren() do
 							if v:IsA("BasePart") then
 								v.Anchored = false
 							end
@@ -3424,7 +3424,7 @@ return function(Vargs, env)
 					end
 				end
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					sizePlayer(v)
 				end
 			end
@@ -3438,9 +3438,9 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					cPcall(function()
-						for _, p in pairs(v.Character:GetChildren()) do
+						for _, p in v.Character:GetChildren() do
 							if p:IsA("Part") then
 								if p:FindFirstChild("Mesh") then p.Mesh:Destroy() end
 								service.New("BlockMesh", p).Scale = Vector3.new(1, 1, args[2] or 0.1)
@@ -3467,7 +3467,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local event
 					local torso = v.Character.HumanoidRootPart
 					event = v.Character.HumanoidRootPart.Touched:Connect(function(p)
@@ -3489,7 +3489,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					cPcall(function()
 						if v.Character then
 							local head = v.Character.Head
@@ -3498,7 +3498,9 @@ return function(Vargs, env)
 							local rarm = v.Character["Right Arm"]
 							local lleg = v.Character["Left Leg"]
 							local rleg = v.Character["Right Leg"]
-							for _, v in pairs(v.Character:GetChildren()) do if v:IsA("Part") then v.Anchored = true end end
+							for _, v in v.Character:GetChildren() do
+								if v:IsA("Part") then v.Anchored = true end
+							end
 							torso.FormFactor = "Custom"
 							torso.Size = Vector3.new(torso.Size.X, torso.Size.Y, tonumber(args[2]) or 0.1)
 							local weld = service.New("Weld", v.Character.HumanoidRootPart)
@@ -3536,7 +3538,9 @@ return function(Vargs, env)
 							weld.Part1=rleg
 							weld.C0=v.Character.HumanoidRootPart.CFrame*CFrame.new(1,-1.5, 0)
 							wait()
-							for _, v in pairs(v.Character:GetChildren()) do if v:IsA("Part") then v.Anchored = false end end
+							for _, v in v.Character:GetChildren() do
+								if v:IsA("Part") then v.Anchored = false end
+							end
 						end
 					end)
 				end
@@ -3553,8 +3557,8 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local hat = service.Insert(36883367)
 				local players = service.GetPlayers(plr, args[1])
-				for _, v in pairs(players) do
-					for _, m in pairs(v.Character:GetChildren()) do
+				for _, v in players do
+					for _, m in v.Character:GetChildren() do
 						if m:IsA("CharacterMesh") or m:IsA("Accoutrement") then
 							m:Destroy()
 						end
@@ -3565,7 +3569,7 @@ return function(Vargs, env)
 					-- This is done outside of the for loop above as the Package command inserts all package items each time the command is run
 					-- By only running it once, it's only inserting the items once and therefore reducing overhead
 					local t = {}
-					for _, v in pairs(players) do
+					for _, v in players do
 						table.insert(t, v.Name)
 					end
 					Admin.RunCommand(Settings.Prefix.."package "..table.concat(t, ",").." 295")
@@ -3581,7 +3585,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
 						if humanoid then
@@ -3615,7 +3619,7 @@ return function(Vargs, env)
 								lleg.C0 = isR15 and (CFrame.new(0.5,-0.5, 0.5) * CFrame.Angles(0, math.rad(180), 0)) or (CFrame.new(0,-1,.5) * CFrame.Angles(0, math.rad(-90), 0))
 							end
 
-							for _, part in pairs(v.Character:GetChildren()) do
+							for _, part in v.Character:GetChildren() do
 								if part:IsA("BasePart") then
 									part.BrickColor = BrickColor.new("Bright green")
 									if part.Name == "FAKETORSO" then
@@ -3639,7 +3643,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local char = v.Character;
 						local human = char and char:FindFirstChildOfClass("Humanoid")
@@ -3668,7 +3672,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local char = v.Character;
 						local human = char and char:FindFirstChildOfClass("Humanoid")
@@ -3707,7 +3711,7 @@ return function(Vargs, env)
 					Functions.Hint("Size changed to the maximum "..tostring(num).." [Argument #2 (size multiplier) went over the size limit]", {plr})
 				end
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local char = v.Character
 					local human = char and char:FindFirstChildOfClass("Humanoid")
 
@@ -3726,7 +3730,7 @@ return function(Vargs, env)
 					end
 
 					if human and human.RigType == Enum.HumanoidRigType.R15 then
-						for _, val in pairs(human:GetChildren()) do
+						for _, val in human:GetChildren() do
 							if val:IsA("NumberValue") and val.Name:match(".*Scale") then
 								val.Value *= num
 							end
@@ -3734,15 +3738,15 @@ return function(Vargs, env)
 					elseif human and human.RigType == Enum.HumanoidRigType.R6 then
 						local motors = {}
 						table.insert(motors, char.HumanoidRootPart:FindFirstChild("RootJoint"))
-						for _, motor in pairs(char.Torso:GetChildren()) do
+						for _, motor in char.Torso:GetChildren() do
 							if motor:IsA("Motor6D") then table.insert(motors, motor) end
 						end
-						for _, motor in pairs(motors) do
+						for _, motor in motors do
 							motor.C0 = CFrame.new((motor.C0.Position * num)) * (motor.C0 - motor.C0.Position)
 							motor.C1 = CFrame.new((motor.C1.Position * num)) * (motor.C1 - motor.C1.Position)
 						end
 
-						for _, v in ipairs(char:GetDescendants()) do
+						for _, v in char:GetDescendants() do
 							if v:IsA("BasePart") then
 								v.Size *= num
 							elseif v:IsA("Accessory") and v:FindFirstChild("Handle") then
@@ -3772,7 +3776,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local scr = Deps.Assets.Seize
 				scr.Name = "Seize"
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character:FindFirstChild("HumanoidRootPart") then
 						v.Character.HumanoidRootPart.CFrame = v.Character.HumanoidRootPart.CFrame * CFrame.Angles(math.rad(90), 0, 0)
 						local new = scr:Clone()
@@ -3791,7 +3795,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("Humanoid") and v.Character:FindFirstChild("HumanoidRootPart") then
 						local old = v.Character.HumanoidRootPart:FindFirstChild("Seize")
 						if old then old:Destroy() end
@@ -3809,9 +3813,9 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for a, obj in pairs(v.Character:GetChildren()) do
+						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") and (obj.Name:find("Leg") or obj.Name:find("Arm")) then
 								obj:Destroy()
 							end
@@ -3829,7 +3833,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					service.StartLoop(v.UserId.."LOOPFLING", 2, function()
 						Admin.RunCommand(Settings.Prefix.."fling", v.Name)
 					end)
@@ -3845,7 +3849,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					service.StopLoop(v.UserId.."LOOPFLING")
 				end
 			end
@@ -3860,7 +3864,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local dist = 1000000 * (tonumber(args[2]) or 1.5)
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local torso = v.Character:FindFirstChild("HumanoidRootPart")
 						if torso then
@@ -3881,7 +3885,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local torso = v.Character:FindFirstChild("HumanoidRootPart")
 						local pTorso = plr.Character:FindFirstChild("HumanoidRootPart")
@@ -3906,8 +3910,8 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				assert(args[1] and args[2], "Missing player names (must specify two)")
-				for i, player1 in pairs(service.GetPlayers(plr, args[1])) do
-					for i2, player2 in pairs(service.GetPlayers(plr, args[2])) do
+				for i, player1 in service.GetPlayers(plr, args[1]) do
+					for i2, player2 in service.GetPlayers(plr, args[2]) do
 						local torso1 = player1.Character:FindFirstChild("HumanoidRootPart")
 						local torso2 = player2.Character:FindFirstChild("HumanoidRootPart")
 						if torso1 and torso2 then
@@ -3937,10 +3941,10 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, p in pairs(service.GetPlayers(plr, args[1])) do
+				for i, p in service.GetPlayers(plr, args[1]) do
 					local torso = p.Character:FindFirstChild("HumanoidRootPart")
 					if torso then
-						for i, v in pairs(torso:GetChildren()) do
+						for i, v in torso:GetChildren() do
 							if v.Name == "Adonis_Rope_Attachment" or v.Name == "Adonis_Rope_Constraint" then
 								v:Destroy()
 							end
@@ -4077,7 +4081,7 @@ return function(Vargs, env)
 				}
 
 				local function clear(char)
-					for i, v in pairs(char:GetChildren()) do
+					for i, v in char:GetChildren() do
 						if v:IsA("CharacterMesh") or v:IsA("Accoutrement") or v:IsA("ShirtGraphic") or v:IsA("Pants") or v:IsA("Shirt") then
 							v:Destroy()
 						end
@@ -4116,7 +4120,7 @@ return function(Vargs, env)
 					service.Insert(face).Parent = char
 				end
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						clear(v.Character)
 						apply(v.Character)
@@ -4135,7 +4139,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				local message = args[2]
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					service.ChatService:Chat(v.Character.Head, message, Enum.ChatColor.Blue)
 				end
 			end
@@ -4149,10 +4153,10 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
-							for _, obj in ipairs(v.Character:GetChildren()) do
+							for _, obj in v.Character:GetChildren() do
 								if obj:IsA("BasePart") and obj.Name ~= "HumanoidRootPart" then obj.Anchored = true end
 							end
 							local ice = service.New("Part", v.Character)
@@ -4196,7 +4200,7 @@ return function(Vargs, env)
 					secondary = str
 				end
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local torso = v.Character:FindFirstChild("HumanoidRootPart")
 					if torso then
 						Functions.NewParticle(torso, "Fire", {
@@ -4223,7 +4227,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local torso = v.Character:FindFirstChild("HumanoidRootPart")
 					if torso then
 						Functions.RemoveParticle(torso, "FIRE")
@@ -4254,7 +4258,7 @@ return function(Vargs, env)
 					color = str
 				end
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local torso = v.Character:FindFirstChild("HumanoidRootPart")
 					if torso then
 						Functions.NewParticle(torso, "Smoke", {
@@ -4274,7 +4278,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local torso = v.Character:FindFirstChild("HumanoidRootPart")
 					if torso then
 						Functions.RemoveParticle(torso, "SMOKE")
@@ -4304,7 +4308,7 @@ return function(Vargs, env)
 					color = str
 				end
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local torso = v.Character:FindFirstChild("HumanoidRootPart")
 					if torso then
 						Functions.NewParticle(torso, "Sparkles", {
@@ -4330,7 +4334,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local torso = v.Character:FindFirstChild("HumanoidRootPart")
 					if torso then
 						Functions.RemoveParticle(torso, "SPARKLES")
@@ -4352,7 +4356,7 @@ return function(Vargs, env)
 
 				assert(tonumber(args[2]), tostring(args[2]).." is not a valid ID")
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Functions.PlayAnimation(v , args[2])
 				end
 			end
@@ -4379,12 +4383,12 @@ return function(Vargs, env)
 					animId = "180426354"
 				end
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local animateScript = v.Character:FindFirstChild("Animate")
 						if animateScript then
 							local found = false
-							for _, v2 in pairs(animateScript:GetDescendants()) do
+							for _, v2 in animateScript:GetDescendants() do
 								if v2.Name == "walk" then
 									found = true
 									local walkAnimation = v2:FindFirstChildOfClass("Animation")
@@ -4431,12 +4435,12 @@ return function(Vargs, env)
 					animId = "180426354"
 				end
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local animateScript = v.Character:FindFirstChild("Animate")
 						if animateScript then
 							local found = false
-							for _,v2 in pairs(animateScript:GetDescendants()) do
+							for _,v2 in animateScript:GetDescendants() do
 								if v2.Name == "run" then
 									found = true
 									local runAnimation = v2:FindFirstChildOfClass("Animation")
@@ -4483,12 +4487,12 @@ return function(Vargs, env)
 					animId = "125750702"
 				end
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local animateScript = v.Character:FindFirstChild("Animate")
 						if animateScript then
 							local found = false
-							for _, v2 in pairs(animateScript:GetDescendants()) do
+							for _, v2 in animateScript:GetDescendants() do
 								if v2.Name == "jump" then
 									found = true
 									local jumpAnimation = v2:FindFirstChildOfClass("Animation")
@@ -4535,12 +4539,12 @@ return function(Vargs, env)
 					animId = "180436148"
 				end
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local animateScript = v.Character:FindFirstChild("Animate")
 						if animateScript then
 							local found = false
-							for _,v2 in pairs(animateScript:GetDescendants()) do
+							for _,v2 in animateScript:GetDescendants() do
 								if v2.Name == "fall" then
 									found = true
 									local fallAnimation = v2:FindFirstChildOfClass("Animation")
@@ -4576,7 +4580,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local moder = tonumber(args[2]) or 0.5
 				if moder > 5 then moder = 5 end
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.NewLocal(v, "BlurEffect", {
 						Name = "WINDOW_BLUR",
 						Size = tonumber(args[2]) or 24,
@@ -4594,7 +4598,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.NewLocal(v, "BloomEffect", {
 						Name = "WINDOW_BLOOM",
 						Intensity = tonumber(args[2]) or 0.4,
@@ -4614,7 +4618,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.NewLocal(v, "SunRaysEffect", {
 						Name = "WINDOW_SUNRAYS",
 						Intensity = tonumber(args[2]) or 0.25,
@@ -4639,7 +4643,7 @@ return function(Vargs, env)
 				end
 				r, g, b = tonumber(r), tonumber(g), tonumber(b)
 				if not r or not g or not b then error("Invalid Input") end
-				for _, p in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, p in service.GetPlayers(plr, args[1]) do
 					Remote.NewLocal(p, "ColorCorrectionEffect", {
 						Name = "WINDOW_COLORCORRECTION",
 						Brightness = tonumber(args[2]) or 0,
@@ -4671,7 +4675,7 @@ return function(Vargs, env)
 				num2 = "-"..num2.."00000"
 				num3 = "-"..num3.."00000"
 				if args[2] then
-					for i, v in pairs(service.GetPlayers(plr, args[2])) do
+					for i, v in service.GetPlayers(plr, args[2]) do
 						Remote.SetLighting(v, "FogColor", Color3.new(tonumber(num1), tonumber(num2), tonumber(num3)))
 						Remote.SetLighting(v, "FogEnd", 9e9)
 					end
@@ -4690,11 +4694,11 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.Lighting:GetChildren()) do
+				for _, v in service.Lighting:GetChildren() do
 					if v:IsA("Sky") then v:Destroy() end
 				end
 				local sky = service.New("Sky", service.Lighting)
-				for i, v in ipairs({"Ft", "Bk", "Lf", "Rt", "Up", "Dn"}) do
+				for i, v in {"Ft", "Bk", "Lf", "Rt", "Up", "Dn"} do
 					local img = args[i] or args[1]
 					if img --[[and (v ~= "Dn" or args[6])]] then
 						sky["Skybox"..v] = tonumber(img) and ("rbxassetid://"..img) or img
@@ -4726,7 +4730,7 @@ return function(Vargs, env)
 
 					if gear:IsA("BackpackItem") then
 						service.New("StringValue", gear).Name = Variables.CodeName..gear.Name
-						for i, v in pairs(service.GetPlayers(plr, args[1])) do
+						for i, v in service.GetPlayers(plr, args[1]) do
 							if v:FindFirstChild("StarterGear") then
 								gear:Clone().Parent = v.StarterGear
 							end
@@ -4754,7 +4758,7 @@ return function(Vargs, env)
 
 					if gear:IsA("BackpackItem") then
 						service.New("StringValue", gear).Name = Variables.CodeName..gear.Name
-						for i, v in pairs(service.GetPlayers(plr, args[1])) do
+						for i, v in service.GetPlayers(plr, args[1]) do
 							if v:FindFirstChild("Backpack") then
 								gear:Clone().Parent = v.Backpack
 							end
@@ -4781,7 +4785,7 @@ return function(Vargs, env)
 
 				scr.Name = "ADONIS_IceSkates"
 
-				for i, v in pairs(service.GetPlayers(plr, args[1]:lower())) do
+				for i, v in service.GetPlayers(plr, args[1]:lower()) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						local vel = vel:Clone()
 						vel.Parent = v.Character.HumanoidRootPart
@@ -4803,7 +4807,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1]:lower())) do
+				for i, v in service.GetPlayers(plr, args[1]:lower()) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						local scr = v.Character.HumanoidRootPart:FindFirstChild("ADONIS_IceSkates")
 						local vel = v.Character.HumanoidRootPart:FindFirstChild("ADONIS_IceVelocity")
@@ -4822,8 +4826,8 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
-					for i2, v2 in pairs(service.GetPlayers(plr, args[2])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
+					for i2, v2 in service.GetPlayers(plr, args[2]) do
 						local temptools = service.New("Model")
 						local tempcloths = service.New("Model")
 						local vpos = v.Character.HumanoidRootPart.CFrame
@@ -4832,30 +4836,30 @@ return function(Vargs, env)
 						local v2face = v2.Character.Head.face
 						vface.Parent = v2.Character.Head
 						v2face.Parent = v.Character.Head
-						for k, p in pairs(v.Character:GetChildren()) do
+						for k, p in v.Character:GetChildren() do
 							if p:IsA("BodyColors") or p:IsA("CharacterMesh") or p:IsA("Pants") or p:IsA("Shirt") or p:IsA("Accessory") then
 								p.Parent = tempcloths
 							elseif p:IsA("Tool") then
 								p.Parent = temptools
 							end
 						end
-						for k, p in pairs(v.Backpack:GetChildren()) do
+						for k, p in v.Backpack:GetChildren() do
 							p.Parent = temptools
 						end
-						for k, p in pairs(v2.Character:GetChildren()) do
+						for k, p in v2.Character:GetChildren() do
 							if p:IsA("BodyColors") or p:IsA("CharacterMesh") or p:IsA("Pants") or p:IsA("Shirt") or p:IsA("Accessory") then
 								p.Parent = v.Character
 							elseif p:IsA("Tool") then
 								p.Parent = v.Backpack
 							end
 						end
-						for k, p in pairs(tempcloths:GetChildren()) do
+						for k, p in tempcloths:GetChildren() do
 							p.Parent = v2.Character
 						end
-						for k, p in pairs(v2.Backpack:GetChildren()) do
+						for k, p in v2.Backpack:GetChildren() do
 							p.Parent = v.Backpack
 						end
-						for k, p in pairs(temptools:GetChildren()) do
+						for k, p in temptools:GetChildren() do
 							p.Parent = v2.Backpack
 						end
 						v2.Character.HumanoidRootPart.CFrame = vpos
@@ -4873,12 +4877,12 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v1 in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v1 in service.GetPlayers(plr, args[1]) do
 					if not v1.Character then continue end
 					local v1hum = v1.Character:FindFirstChildOfClass("Humanoid")
 					local v1desc = v1hum:GetAppliedDescription()
 
-					for _, v2 in pairs(service.GetPlayers(plr, args[2])) do
+					for _, v2 in service.GetPlayers(plr, args[2]) do
 						if not v2.Character then continue end
 						local v2hum = v1.Character:FindFirstChildOfClass("Humanoid")
 						local v2desc = v2hum:GetAppliedDescription()
@@ -4889,12 +4893,12 @@ return function(Vargs, env)
 						v2hum:UnequipTools()
 						local v1tools, v2tools = v1.Backpack:GetChildren(), v2.Backpack:GetChildren()
 
-						for _, t in ipairs(v1tools) do
+						for _, t in v1tools do
 							if t:IsA("Tool") then
 								t.Parent = v2.Backpack
 							end
 						end
-						for _, t in pairs(v2tools) do
+						for _, t in v2tools do
 							if t:IsA("Tool") then
 								t.Parent = v1.Backpack
 							end
@@ -4918,7 +4922,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character.PrimaryPart then
 						service.New("Explosion", {
 							Archivable = false;
@@ -4942,7 +4946,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local angle = 130 or args[2]
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						v.Character.HumanoidRootPart.CFrame = v.Character.HumanoidRootPart.CFrame * CFrame.Angles(0, 0, math.rad(angle))
 					end
@@ -4958,7 +4962,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Admin.RunCommand(Settings.Prefix.."char", v.Name, "51310503")
 				end
 			end
@@ -4972,7 +4976,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Admin.RunCommand(Settings.Prefix.."char", v.Name, "userid-1237666")
 				end
 			end
@@ -4986,7 +4990,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.NewLocal(v, "ColorCorrectionEffect", {
 						Name = "WINDOW_THERMAL",
 						Brightness = 1,
@@ -5012,7 +5016,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.RemoveLocal(v, "WINDOW_THERMAL", "Camera")
 				end
 			end
@@ -5050,7 +5054,7 @@ return function(Vargs, env)
 					if args[1] then
 						local nam = args[1]
 
-						for i, v in pairs(server.Variables.MusicList)do
+						for i, v in Variables.MusicList do
 							if string.lower(v.Name) == string.lower(nam)then
 								return v.ID
 							end

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -154,7 +154,7 @@ return function(Vargs, env)
 			AdminLevel = "HeadAdmins";
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing target user (argument #1)")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local ret = Admin.RemoveBan(v.Name, true)
 					if ret then
 						if type(ret) == "table" then
@@ -177,7 +177,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string}, data: {})
 				assert(args[1], "Missing target player (argument #1)")
 				local senderLevel = data.PlayerData.Level
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if senderLevel > Admin.GetLevel(v) then
 						Admin.AddAdmin(v, "Admins", true)
 						Remote.MakeGui(v, "Notification", {
@@ -204,7 +204,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string}, data: {})
 				assert(args[1], "Missing target player (argument #1)")
 				local senderLevel = data.PlayerData.Level
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if senderLevel > Admin.GetLevel(v) then
 						Admin.AddAdmin(v, "Admins")
 						Remote.MakeGui(v, "Notification", {
@@ -287,7 +287,7 @@ return function(Vargs, env)
 
 				local cards = trello.Lists.GetCards(list.id)
 				local temp = table.create(#cards)
-				for _, v in pairs(cards) do
+				for _, v in cards do
 					table.insert(temp, {Text = v.name, Desc = v.desc})
 				end
 				Remote.MakeGui(plr, "List", {Title = list.name; Tab = temp})
@@ -314,12 +314,12 @@ return function(Vargs, env)
 			AdminLevel = "HeadAdmins";
 			Function = function(plr: Player, args: {string})
 				local objects = service.GetAdonisObjects()
-				for i, v in pairs(objects) do
+				for i, v in objects do
 					v:Destroy()
 				end
 				table.clear(objects)
 
-				--for i, v in pairs(Functions.GetPlayers()) do
+				--for i, v in Functions.GetPlayers() do
 				--	Remote.Send(v, "Function", "ClearAllInstances")
 				--end
 			end
@@ -352,7 +352,7 @@ return function(Vargs, env)
 				local tempmodel = service.New("Model", {
 					Name = "BACKUP_MAP_MODEL"
 				})
-				for _, v in ipairs(workspace:GetChildren()) do
+				for _, v in workspace:GetChildren() do
 					if v.ClassName ~= "Terrain" and not service.Players:GetPlayerFromCharacter(v) then
 						local archive = v.Archivable
 						v.Archivable = true
@@ -399,7 +399,7 @@ return function(Vargs, env)
 			Description = "Opens the friend invitation popup for the target player(s), same as them running !invite";
 			AdminLevel = "HeadAdmins";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					service.SocialService:PromptGameInvite(v)
 				end
 			end
@@ -409,7 +409,7 @@ return function(Vargs, env)
 			Prefix = Settings.Prefix;
 			Commands = {"forcerejoin"};
 			Args = {"player"};
-			Description = "Forces target player(s) to rejoin the server; same as them running !rejoin";
+			Description = "Forces target player(s) to rejoin the server; same as them running "..Settings.PlayerPrefix.."rejoin";
 			NoStudio = true;
 			AdminLevel = "HeadAdmins";
 			Function = function(plr: Player, args: {string})
@@ -451,17 +451,17 @@ return function(Vargs, env)
 			AdminLevel = "HeadAdmins";
 			Hidden = true;
 			Function = function(plr: Player, args: {string})
-				for _, v: Player in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v: Player in service.GetPlayers(plr, args[1]) do
 					if Variables.IncognitoPlayers[v] then
 						Functions.Hint(service.FormatPlayer(v).." is already incognito.", {plr})
 						continue
 					end
 					Variables.IncognitoPlayers[v] = os.time()
 					local n = 0
-					for _, otherPlr: Player in ipairs(service.Players:GetPlayers()) do
+					for _, otherPlr: Player in service.Players:GetPlayers() do
 						if otherPlr == v then continue end
 						Remote.LoadCode(otherPlr, [[
-					for _, p in pairs(service.Players:GetPlayers()) do
+					for _, p in service.Players:GetPlayers() do
 						if p.UserId == ]]..v.UserId..[[ then
 							if p:FindFirstChild("leaderstats") then p.leaderstats:Destroy() end
 							p:Destroy()
@@ -507,7 +507,7 @@ return function(Vargs, env)
 					Variables.BadgeInfoCache[tostring(badgeId)] = assert(success and badgeInfo, "Unable to retrieve badge information; please try again")
 				end
 
-				for _, v: Player in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v: Player in service.GetPlayers(plr, args[1]) do
 					local success, hasBadge = nil, nil
 					local tries = 0
 					repeat

--- a/MainModule/Server/Commands/HeadAdmins.lua
+++ b/MainModule/Server/Commands/HeadAdmins.lua
@@ -40,12 +40,13 @@ return function(Vargs, env)
 				local level = data.PlayerData.Level
 				local reason = args[3] or "No reason provided"
 
-				for _, v in pairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = true;
-					})) do
+					})
+				do
 					if level > Admin.GetLevel(v) then
 						Admin.AddTimeBan(v, tonumber(time), reason, plr)
 						Functions.Hint("Time-banned "..service.FormatPlayer(v).." for ".. args[2], {plr})
@@ -130,12 +131,13 @@ return function(Vargs, env)
 				local level = data.PlayerData.Level
 				local reason = args[2] or "No reason provided"
 
-				for _, v in pairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = true;
-					})) do
+					})
+				do
 					if level > Admin.GetLevel(v) then
 						Admin.AddBan(v, reason, true, plr)
 						Functions.Hint("Game-banned "..tostring(v), {plr})

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -22,12 +22,13 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string}, data: {})
 				local plrLevel = data.PlayerData.Level
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = true;
-					})) do
+					})
+				do
 					if plrLevel > Admin.GetLevel(v) then
 						local playerName = service.FormatPlayer(v)
 						if not service.Players:FindFirstChild(v.Name) then
@@ -367,12 +368,12 @@ return function(Vargs, env)
 				local reason = assert(args[2], "Missing reason (argument #2)")
 				local plrLevel = data.PlayerData.Level
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = false;
 					UseFakePlayer = true;
-					}))
+					})
 				do
 					if plrLevel > Admin.GetLevel(v) then
 						local playerData = Core.GetPlayer(v)
@@ -416,12 +417,12 @@ return function(Vargs, env)
 
 				local plrLevel = data.PlayerData.Level
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = true;
 					UseFakePlayer = false;
-					}))
+					})
 				do
 					if plrLevel > Admin.GetLevel(v) then
 						local playerData = Core.GetPlayer(v)
@@ -460,12 +461,12 @@ return function(Vargs, env)
 
 				local plrLevel = data.PlayerData.Level
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = false;
 					UseFakePlayer = true;
-					}))
+					})
 				do
 					if plrLevel > Admin.GetLevel(v) then
 						local playerData = Core.GetPlayer(v)
@@ -523,12 +524,12 @@ return function(Vargs, env)
 			Description = "Shows a list of warnings a player has";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1], {
+				for _, v in service.GetPlayers(plr, args[1], {
 					DontError = false;
 					IsServer = false;
 					IsKicking = false;
 					UseFakePlayer = true;
-					}))
+					})
 				do
 					local data = Core.GetPlayer(v)
 					local tab = {}

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -54,7 +54,7 @@ return function(Vargs, env)
 				Remote.Send(plr, "Function", "CharacterESP", false)
 
 				if args[1] then
-					for _2, v2 in ipairs(service.GetPlayers(plr, args[1])) do
+					for _2, v2 in service.GetPlayers(plr, args[1]) do
 						if not v2.Character then
 							continue
 						end
@@ -111,7 +111,7 @@ return function(Vargs, env)
 				local variables = Core.Variables
 				local timeBans = Core.Variables.TimeBans or {}
 
-				for ind, v in pairs(timeBans) do
+				for ind, v in timeBans do
 					local timeLeft = v.EndTime - os.time()
 					local minutes = Functions.RoundToPlace(timeLeft / 60, 2)
 
@@ -140,7 +140,7 @@ return function(Vargs, env)
 				assert(args[1], "Missing player name")
 				assert(args[2], "Missing message")
 
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Notification", {
 						Title = "Notification";
 						Message = service.Filter(args[2], plr, v);
@@ -179,7 +179,7 @@ return function(Vargs, env)
 				local num = assert(tonumber(args[1]), "Missing or invalid time value (must be a number)")
 				assert(num <= 1000, "Countdown cannot be longer than 1000 seconds.")
 				assert(num >= 0, "Countdown cannot be negative.")
-				for _, v in ipairs(service.GetPlayers()) do
+				for _, v in service.GetPlayers() do
 					Remote.MakeGui(v, "Countdown", {
 						Time = math.round(num);
 					})
@@ -203,7 +203,7 @@ return function(Vargs, env)
 				local num = assert(tonumber(args[2]), "Missing or invalid time value (must be a number)")
 				assert(num <= 1000, "Countdown cannot be longer than 1000 seconds.")
 				assert(num >= 0, "Countdown cannot be negative.")
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Countdown", {
 						Time = math.round(num);
 					})
@@ -238,7 +238,7 @@ return function(Vargs, env)
 			Description = "Stops all currently running countdowns";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.RemoveGui(v, "Countdown")
 				end
 				service.StopLoop("HintCountdown")
@@ -286,7 +286,7 @@ return function(Vargs, env)
 				assert(args[2], "Missing message")
 
 				local Sender = string.format("Message from %s", service.FormatPlayer(plr))
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Functions.Message(Sender, service.Filter(args[2], plr, v), {v}, true)
 				end
 			end
@@ -316,7 +316,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing player name")
 				assert(args[2], "Missing message")
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.RemoveGui(v, "Notify")
 					Remote.MakeGui(v, "Notify", {
 						Title = "Message from "..service.FormatPlayer(plr);
@@ -472,7 +472,7 @@ return function(Vargs, env)
 						local playerWarnings = playerData.Warnings
 
 						local count = 0
-						for i, playerWarning in ipairs(playerWarnings) do
+						for i, playerWarning in playerWarnings do
 							if string.match(string.lower(playerWarning.Message), "^"..reason) then
 								service.Events.PlayerWarningRemoved:Fire(v, playerWarning.Message, plr)
 								table.remove(playerWarnings, i)
@@ -501,7 +501,7 @@ return function(Vargs, env)
 			Description = "Clears any warnings on a player";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local data = Core.GetPlayer(v)
 					table.clear(data.Warnings)
 
@@ -534,7 +534,7 @@ return function(Vargs, env)
 					local tab = {}
 
 					if data.Warnings then
-						for k, m in pairs(data.Warnings) do
+						for k, m in data.Warnings do
 							table.insert(tab, {
 								Text = "["..k.."] "..m.Message;
 								Desc = "Given by: "..m.From.."; "..m.Message;
@@ -563,7 +563,7 @@ return function(Vargs, env)
 			Description = "Makes a message in the target player(s)'s chat window";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "ChatMessage", service.Filter(args[2], plr, v), Color3.fromRGB(255, 64, 77))
 				end
 			end
@@ -576,7 +576,7 @@ return function(Vargs, env)
 			Description = "Gives a force field to the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						service.New("ForceField", v.Character).Visible = if args[2] and args[2]:lower() == "false" then false else true
 					end
@@ -591,10 +591,10 @@ return function(Vargs, env)
 			Description = "Removes force fields on the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						Routine(function()
-							for _, c in ipairs(v.Character:GetChildren()) do
+							for _, c in v.Character:GetChildren() do
 								if c:IsA("ForceField") and c.Name ~= "ADONIS_FULLGOD" then
 									c:Destroy()
 								end
@@ -612,7 +612,7 @@ return function(Vargs, env)
 			Description = "Removes the target player(s)'s character";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local char = v.Character
 					if char then
 						Remote.LoadCode(v, [[service.StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.Backpack, false)]])
@@ -629,7 +629,7 @@ return function(Vargs, env)
 			Description = "UnPunishes the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1]))  do
+				for _, v in service.GetPlayers(plr, args[1])  do
 					local char = v.Character
 					if char then
 						char.Parent = workspace
@@ -647,10 +647,10 @@ return function(Vargs, env)
 			Description = "Freezes the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						if v.Character then
-							for a, obj in ipairs(v.Character:GetChildren()) do
+							for a, obj in v.Character:GetChildren() do
 								if obj:IsA("BasePart") and obj.Name ~= "HumanoidRootPart" then obj.Anchored = true end
 							end
 						end
@@ -666,7 +666,7 @@ return function(Vargs, env)
 			Description = "UnFreezes the target players, thaws them out";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 							local ice = v.Character:FindFirstChild("Adonis_Ice")
@@ -695,7 +695,7 @@ return function(Vargs, env)
 								ice:Destroy()
 							end
 
-							for _, obj in ipairs(v.Character:GetChildren()) do
+							for _, obj in v.Character:GetChildren() do
 								if obj:IsA("BasePart") and obj.Name ~= "HumanoidRootPart" and obj ~= plate then
 									obj.Anchored = false
 								end
@@ -715,7 +715,7 @@ return function(Vargs, env)
 			Description = "FFs, Gods, Names, Freezes, and removes the target player's tools until they jump.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						local ff = service.New("ForceField", v.Character)
 						local hum = v.Character.Humanoid
@@ -724,7 +724,7 @@ return function(Vargs, env)
 						hum.MaxHealth = math.huge
 						wait()
 						hum.Health = hum.MaxHealth
-						for k, t in pairs(v.Backpack:GetChildren()) do
+						for k, t in v.Backpack:GetChildren() do
 							t.Parent = tools
 						end
 						Admin.RunCommand(Settings.Prefix.."name", v.Name, "-AFK-_"..service.FormatPlayer(v).."_-AFK-")
@@ -737,7 +737,7 @@ return function(Vargs, env)
 							ff:Destroy()
 							hum.Health = orig
 							hum.MaxHealth = orig
-							for k, t in ipairs(tools:GetChildren()) do
+							for k, t in tools:GetChildren() do
 								t.Parent = v.Backpack
 							end
 							Admin.RunCommand(Settings.Prefix.."unname", v.Name)
@@ -756,7 +756,7 @@ return function(Vargs, env)
 			Description = "Heals the target player(s) (Regens their health)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.Health = hum.MaxHealth
@@ -772,7 +772,7 @@ return function(Vargs, env)
 			Description = "Makes the target player(s) immortal, makes their health so high that normal non-explosive weapons can't kill them";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.MaxHealth = math.huge
@@ -792,7 +792,7 @@ return function(Vargs, env)
 			Description = "Makes the target player(s) mortal again";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.MaxHealth = 100
@@ -816,7 +816,7 @@ return function(Vargs, env)
 			Description = "Same as "..server.Settings.Prefix.."god, but also provides blast protection";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.MaxHealth = math.huge
@@ -841,12 +841,12 @@ return function(Vargs, env)
 			Description = "Removes any hats the target is currently wearing and from their HumanoidDescription.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, p in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, p in service.GetPlayers(plr, args[1]) do
 					local humanoid: Humanoid? = p.Character and p.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
 						local DescsToRemove = {"HatAccessory","HairAccessory","FaceAccessory","NeckAccessory","ShouldersAccessory","FrontAccessory","BackAccessory","WaistAccessory"}
-						for _, prop in ipairs(DescsToRemove) do
+						for _, prop in DescsToRemove do
 							humanoidDesc[prop] = ""
 						end
 						humanoid:ApplyDescription(humanoidDesc)
@@ -864,9 +864,9 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				-- TODO: HumanoidDescription
 				assert(args[2], "Argument(s) missing or nil")
-				for _, p in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, p in service.GetPlayers(plr, args[1]) do
 					if not p.Character then continue end
-					for _, v in pairs(p.Character:GetChildren()) do
+					for _, v in p.Character:GetChildren() do
 						if v:IsA("Accessory") and v.Name:lower() == args[2]:lower() then
 							v:Destroy()
 						end
@@ -893,7 +893,7 @@ return function(Vargs, env)
 
 				local function getPeerList()
 					local peers = {}
-					for peer in pairs(newSession.Users) do
+					for peer in newSession.Users do
 						table.insert(peers, {
 							Name = peer.Name;
 							DisplayName = peer.DisplayName;
@@ -988,7 +988,7 @@ return function(Vargs, env)
 							local peer = args[1];
 
 							if peer then
-								for pr in pairs(newSession.Users) do
+								for pr in newSession.Users do
 									if peer.UserId and peer.UserId == pr.UserId then
 										newSession:SendToUser(pr, "RemovedFromSession")
 										newSession:RemoveUser(pr)
@@ -1031,7 +1031,7 @@ return function(Vargs, env)
 					CanManageUsers = true;
 				})
 
-				for i, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v ~= plr then
 						newSession:AddUser(v)
 
@@ -1057,7 +1057,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing player name")
 				assert(args[2], "Missing message")
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local replyTicket = Functions.GetRandom()
 					Variables.PMtickets[replyTicket] = plr
 
@@ -1079,7 +1079,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Hidden = not Settings.CustomChat;
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Chat")
 				end
 			end
@@ -1093,7 +1093,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Hidden = not Settings.CustomChat;
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.RemoveGui(v, "Chat")
 				end
 			end
@@ -1106,7 +1106,7 @@ return function(Vargs, env)
 			Description = "UnColorCorrection the target player's screen";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, p in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, p in service.GetPlayers(plr, args[1]) do
 					Remote.RemoveLocal(p, "WINDOW_COLORCORRECTION", "Camera")
 				end
 			end
@@ -1119,7 +1119,7 @@ return function(Vargs, env)
 			Description = "UnSunrays the target player's screen";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.RemoveLocal(v, "WINDOW_SUNRAYS", "Camera")
 				end
 			end
@@ -1132,7 +1132,7 @@ return function(Vargs, env)
 			Description = "UnBloom the target player's screen";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.RemoveLocal(v, "WINDOW_BLOOM", "Camera")
 				end
 			end
@@ -1145,7 +1145,7 @@ return function(Vargs, env)
 			Description = "UnBlur the target player's screen";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.RemoveLocal(v, "WINDOW_BLUR", "Camera")
 				end
 			end
@@ -1158,8 +1158,8 @@ return function(Vargs, env)
 			Description = "Remove admin made lighting effects from the target player's screen";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
-					for _, e in ipairs({"BLUR", "BLOOM", "THERMAL", "SUNRAYS", "COLORCORRECTION"}) do
+				for _, v in service.GetPlayers(plr, args[1]) do
+					for _, e in {"BLUR", "BLOOM", "THERMAL", "SUNRAYS", "COLORCORRECTION"} do
 						Remote.RemoveLocal(v, "WINDOW_"..e, "Camera")
 					end
 				end
@@ -1175,7 +1175,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			ListUpdater = function(plr: Player)
 				local tab = {}
-				for _, banData in ipairs(HTTP.Trello.Bans) do
+				for _, banData in HTTP.Trello.Bans do
 					table.insert(tab, {
 						Text = banData.Name,
 						Desc = banData.Reason or "No reason specified",
@@ -1251,7 +1251,7 @@ return function(Vargs, env)
 				end
 				local backpack = target:FindFirstChildOfClass("Backpack")
 				if backpack then
-					for _, t in ipairs(backpack:GetChildren()) do
+					for _, t in backpack:GetChildren() do
 						table.insert(tab, {
 							Text = t.Name;
 							Desc = if t:IsA("BackpackItem") then
@@ -1265,7 +1265,7 @@ return function(Vargs, env)
 				return tab
 			end;
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						Remote.MakeGui(plr, "List", {
 							Title = service.FormatPlayer(v).."'s tools";
@@ -1309,7 +1309,7 @@ return function(Vargs, env)
 					"# Players: " .. #players,
 					"―――――――――――――――――――――――",
 				}
-				for _, v in pairs(players) do
+				for _, v in players do
 					cPcall(function()
 						if type(v) == "string" and v == "NoPlayer" then
 							table.insert(tab, {
@@ -1389,7 +1389,7 @@ return function(Vargs, env)
 			Description = "Deletes the waypoint named <name> if it exist";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(Variables.Waypoints) do
+				for i, v in Variables.Waypoints do
 					if string.sub(string.lower(i), 1, #args[1])==string.lower(args[1]) or string.lower(args[1])=="all" then
 						Variables.Waypoints[i]=nil
 						Functions.Hint("Deleted waypoint "..i, {plr})
@@ -1406,7 +1406,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local temp={}
-				for i, v in pairs(Variables.Waypoints) do
+				for i, v in Variables.Waypoints do
 					local x, y, z=tostring(v):match("(.*),(.*),(.*)")
 					table.insert(temp, {Text=i, Desc="X:"..x.." Y:"..y.." Z:"..z})
 				end
@@ -1426,7 +1426,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local tab = {}
-				for _, v in pairs(Variables.Cameras) do
+				for _, v in Variables.Cameras do
 					table.insert(tab, {Text = v.Name, Desc = "Pos: "..tostring(v.Brick.Position)})
 				end
 				Remote.MakeGui(plr, "List", {Title = "Cameras", Tab = tab})
@@ -1478,7 +1478,7 @@ return function(Vargs, env)
 			Description = "Makes you view the target player";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(Variables.Cameras) do
+				for i, v in Variables.Cameras do
 					if string.sub(v.Name, 1, #args[1]) == args[1] then
 						Remote.Send(plr, "Function", "SetView", v.Brick)
 					end
@@ -1494,8 +1494,8 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local targets = service.GetPlayers(plr, args[2])
-				for _, viewer in pairs(service.GetPlayers(plr, args[1])) do
-					for _, target in pairs(targets) do
+				for _, viewer in service.GetPlayers(plr, args[1]) do
+					for _, target in targets do
 						local targetHum = target.Character and target.Character:FindFirstChildOfClass("Humanoid")
 						if not targetHum then continue end
 						local rootPart = target.Character.PrimaryPart
@@ -1516,7 +1516,7 @@ return function(Vargs, env)
 			Description = "Makes you view the target player";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if not hum then
 						Functions.Hint(service.FormatPlayer(v).." doesn't have a character humanoid", {plr})
@@ -1541,7 +1541,7 @@ return function(Vargs, env)
 			Description = "Makes a viewport of the target player<s>";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v and v.Character:FindFirstChildOfClass("Humanoid") then
 						Remote.MakeGui(plr, "Viewport", {Subject = v.Character.HumanoidRootPart});
 					end
@@ -1556,7 +1556,7 @@ return function(Vargs, env)
 			Description = "Resets your view";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character.PrimaryPart then
 						Functions.ResetReplicationFocus(v)
 					else
@@ -1575,7 +1575,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local p
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					p = v
 				end
 				if p then
@@ -1600,7 +1600,7 @@ return function(Vargs, env)
 		};
 
 		Clean = {
-			Prefix = Settings.PlayerPrefix;
+			Prefix = Settings.Prefix;
 			Commands = {"clean"};
 			Args = {};
 			Description = "Cleans some useless junk out of workspace";
@@ -1651,7 +1651,7 @@ return function(Vargs, env)
 				if name=="me" then
 					Variables.CommandLoops[string.lower(plr.Name)..args[2]] = nil
 				elseif name=="all" then
-					for i, v in pairs(Variables.CommandLoops) do
+					for i, v in Variables.CommandLoops do
 						Variables.CommandLoops[i] = nil
 					end
 				elseif args[2] then
@@ -1670,13 +1670,13 @@ return function(Vargs, env)
 				local name = args[1] and string.lower(args[1])
 
 				if name and name=="me" then
-					for i, v in ipairs(Variables.CommandLoops) do
+					for i, v in Variables.CommandLoops do
 						if string.lower(string.sub(i, 1, plr.Name)) == string.lower(plr.Name) then
 							Variables.CommandLoops[string.lower(plr.Name)..args[2]] = nil
 						end
 					end
 				elseif name and name=="all" then
-					for i, v in ipairs(Variables.CommandLoops) do
+					for i, v in Variables.CommandLoops do
 						Variables.CommandLoops[string.lower(plr.Name)..args[2]] = nil
 					end
 				elseif args[2] then
@@ -1686,7 +1686,7 @@ return function(Vargs, env)
 						Remote.MakeGui(plr, "Output", {Title = "Output"; Message = "No loops relating to your search"})
 					end
 				else
-					for i, v in ipairs(Variables.CommandLoops) do
+					for i, v in Variables.CommandLoops do
 						Variables.CommandLoops[i] = nil
 					end
 				end
@@ -1750,7 +1750,7 @@ return function(Vargs, env)
 			Description = "Shows the target player's ping";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Functions.Hint(service.FormatPlayer(v).."'s Ping is "..Remote.Get(v, "Ping").."ms", {plr})
 				end
 			end
@@ -1764,7 +1764,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			ListUpdater = function(plr: Player, target)
 				if target then
-					for _, v in pairs(Functions.GetPlayers(plr, target)) do
+					for _, v in Functions.GetPlayers(plr, target) do
 						local temp = {}
 						local cTasks = Remote.Get(v, "TaskManager", "GetTasks") or {}
 
@@ -1772,7 +1772,7 @@ return function(Vargs, env)
 							Text = "Client Tasks",
 							Desc = "Tasks their client is performing"})
 
-						for _, t in pairs(cTasks) do
+						for _, t in cTasks do
 							table.insert(temp, {
 								Text = tostring(t.Name or t.Function).. "- Status: "..t.Status.." - Elapsed: ".. t.CurrentTime - t.Created;
 								Desc = tostring(t.Function);
@@ -1788,7 +1788,7 @@ return function(Vargs, env)
 
 					table.insert(temp, {Text = "Server Tasks"; Desc = "Tasks the server is performing";})
 
-					for _, v in pairs(tasks) do
+					for _, v in tasks do
 						table.insert(temp, {
 							Text = tostring(v.Name or v.Function).." - Status: "..v.Status.." - Elapsed: "..(os.time()-v.Created);
 							Desc = tostring(v.Function);
@@ -1801,7 +1801,7 @@ return function(Vargs, env)
 						Desc = "Tasks your client is performing"
 					})
 
-					for _, v in pairs(cTasks) do
+					for _, v in cTasks do
 						table.insert(temp, {
 							Text = tostring(v.Name or v.Function).." - Status: "..v.Status.." - Elapsed: "..(v.CurrentTime-v.Created);
 							Desc = tostring(v.Function);
@@ -1813,7 +1813,7 @@ return function(Vargs, env)
 			end;
 			Function = function(plr: Player, args: {string})
 				if args[1] then
-					for i, v in ipairs(service.GetPlayers(plr, args[1])) do
+					for i, v in service.GetPlayers(plr, args[1]) do
 						Remote.MakeGui(plr, "List", {
 							Title = v.Name.."'s Tasks";
 							Table = Logs.ListUpdaters.ShowTasks(plr, v);
@@ -1871,7 +1871,7 @@ return function(Vargs, env)
 
 				table.insert(temptable, "<b><font color='rgb(60, 180, 0)'>Admins In-Game:</font></b>")
 
-				for _, v in ipairs(service.GetPlayers()) do
+				for _, v in service.GetPlayers() do
 					local level, rankName = Admin.GetLevel(v);
 					if level > 0 then
 						table.insert(unsorted, {
@@ -1886,7 +1886,7 @@ return function(Vargs, env)
 					return one.SortLevel > two.SortLevel
 				end)
 
-				for _, v in ipairs(unsorted) do
+				for _, v in unsorted do
 					v.SortLevel = nil
 					table.insert(temptable, v)
 				end
@@ -1896,7 +1896,7 @@ return function(Vargs, env)
 				table.insert(temptable, "")
 				table.insert(temptable, "<b><font color='rgb(180, 60, 0)'>All Admins:</font></b>")
 
-				for rank, data in pairs(Settings.Ranks) do
+				for rank, data in Settings.Ranks do
 					if not data.Hidden then
 						table.insert(unsorted, {
 							Text = string.format(RANK_RICHTEXT, rank, data.Level);
@@ -1912,7 +1912,7 @@ return function(Vargs, env)
 					return one.Level > two.Level
 				end)
 
-				for _, v in ipairs(unsorted) do
+				for _, v in unsorted do
 					local Users = v.Users or {};
 					local Level = v.Level or 0;
 					local Rank = v.Rank or "Unknown";
@@ -1923,7 +1923,7 @@ return function(Vargs, env)
 
 					table.insert(temptable, v)
 
-					for _, user in ipairs(Users) do
+					for _, user in Users do
 						table.insert(temptable, {
 							Text = "  ".. user;
 							Desc = string.format(RANK_DESCRIPTION_FORMAT, Rank, Level);
@@ -1954,7 +1954,7 @@ return function(Vargs, env)
 			ListUpdater = function(plr: Player)
 				local tab = {}
 				local count = 0
-				for _, v in pairs(Settings.Banned) do
+				for _, v in Settings.Banned do
 					local entry = type(v) == "string" and v
 					local reason = "No reason provided"
 					local moderator = "%UNKNOWN%"
@@ -2020,12 +2020,12 @@ return function(Vargs, env)
 						"Time Left: ".. math.max(0, 120 - (os.time()-startTime));
 					}
 
-					for i, v in pairs(responses) do
+					for i, v in responses do
 						if not results[v] then results[v] = 0 end
 						results[v] += 1
 					end
 
-					for i, v in pairs(anstab) do
+					for i, v in anstab do
 						local ans = v
 						local num = results[v]
 						local percent
@@ -2052,7 +2052,7 @@ return function(Vargs, env)
 					end
 				end
 
-				for i, v in pairs(players) do
+				for i, v in players do
 					Routine(function()
 						local response = Remote.GetGui(v, "Vote", {Question = question; Answers = anstab;})
 						if response then
@@ -2082,7 +2082,7 @@ return function(Vargs, env)
 				local responses = {}
 				local players = service.GetPlayers(plr, args[1])
 
-				for i, v in pairs(players) do
+				for i, v in players do
 					Routine(function()
 						local response = Remote.GetGui(v, "Vote", {Question = question; Answers = anstab;})
 						if response then
@@ -2096,7 +2096,7 @@ return function(Vargs, env)
 
 				local results = {}
 
-				for i, v in pairs(responses) do
+				for i, v in responses do
 					if not results[v] then results[v] = 0 end
 					results[v] = results[v]+1
 				end
@@ -2107,7 +2107,7 @@ return function(Vargs, env)
 					"Total Responses: "..total;
 					"Didn't Vote: "..#players-total;
 				}
-				for i, v in pairs(anstab) do
+				for i, v in anstab do
 					local ans = v
 					local num = results[v]
 					local percent
@@ -2138,12 +2138,12 @@ return function(Vargs, env)
 					SplitKey = Settings.SplitKey;
 					SpecialPrefix = Settings.SpecialPrefix;
 				}
-				for _, tool in ipairs(if Settings.RecursiveTools then Settings.Storage:GetDescendants() else Settings.Storage:GetChildren()) do
+				for _, tool in if Settings.RecursiveTools then Settings.Storage:GetDescendants() else Settings.Storage:GetChildren() do
 					if tool:IsA("BackpackItem") and not Variables.SavedTools[tool] then
 						table.insert(data.Tools, tool.Name)
 					end
 				end
-				for tool, pName in pairs(Variables.SavedTools) do
+				for tool, pName in Variables.SavedTools do
 					table.insert(data.SavedTools, {ToolName = tool.Name, AddedBy = pName})
 				end
 				return data
@@ -2160,7 +2160,7 @@ return function(Vargs, env)
 			Description = "Gives you a playable keyboard piano. Credit to NickPatella.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local Dropper = v:FindFirstChildOfClass("PlayerGui") or v:FindFirstChildOfClass("Backpack")
 					if Dropper then
 						local piano = Deps.Assets.Piano:clone()
@@ -2179,9 +2179,9 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local tab = {}
-				for _, v in pairs(Variables.InsertList) do table.insert(tab, v) end
-				for _, v in pairs(HTTP.Trello.InsertList) do table.insert(tab, v) end
-				for i, v in pairs(tab) do
+				for _, v in Variables.InsertList do table.insert(tab, v) end
+				for _, v in HTTP.Trello.InsertList do table.insert(tab, v) end
+				for i, v in tab do
 					tab[i] = {Text = v.Name .." - "..v.ID; Desc = v.ID;}
 				end
 				Remote.MakeGui(plr, "List", {Title = "Insert List", Table = tab; TextSelectable = true})
@@ -2195,7 +2195,7 @@ return function(Vargs, env)
 			Description = "Removes inserted objects";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(Variables.InsertedObjects) do
+				for i, v in Variables.InsertedObjects do
 					v:Destroy()
 					table.remove(Variables.InsertedObjects, i)
 				end
@@ -2210,21 +2210,21 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				service.StopLoop("ChickenSpam")
-				for _, v in pairs(Variables.Objects) do
+				for _, v in Variables.Objects do
 					if v.ClassName == "Script" or v.ClassName == "LocalScript" then
 						v.Disabled = true
 					end
 					v:Destroy()
 				end
 
-				for i, v in pairs(Variables.Cameras) do
+				for i, v in Variables.Cameras do
 					if v then
 						table.remove(Variables.Cameras, i)
 						v:Destroy()
 					end
 				end
 
-				for _, v in pairs(Variables.Jails) do
+				for _, v in Variables.Jails do
 					if not v.Player or not v.Player.Parent then
 						local ind = v.Index
 						service.StopLoop(ind.."JAIL")
@@ -2233,7 +2233,7 @@ return function(Vargs, env)
 					end
 				end
 
-				for _, v in ipairs(workspace:GetChildren()) do
+				for _, v in workspace:GetChildren() do
 					if v.ClassName == "Message" or v.ClassName == "Hint" then
 						v:Destroy()
 					end
@@ -2257,7 +2257,7 @@ return function(Vargs, env)
 			ListUpdater = function(plr: Player, updateArgs)
 				local objects = service.GetAdonisObjects()
 				local tab = {}
-				for _, v in pairs(objects) do
+				for _, v in objects do
 					table.insert(tab, {
 						Text = v:GetFullName();
 						Desc = "Class: "..v.ClassName;
@@ -2291,7 +2291,7 @@ return function(Vargs, env)
 				else
 					local objects = service.GetAdonisObjects()
 					local temp = {}
-					for _, v in pairs(objects) do
+					for _, v in objects do
 						table.insert(temp, {
 							Text = v:GetFullName();
 							Desc = v.ClassName;
@@ -2301,7 +2301,7 @@ return function(Vargs, env)
 				end
 			end;
 			Function = function(plr: Player, args: {string})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(plr, "List", {
 						Title = service.FormatPlayer(v).."'s Client Instances";
 						Table = Logs.ListUpdaters.ShowClientInstances(plr, v);
@@ -2321,12 +2321,12 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local deleteAll = args[2] and (args[2]:lower() == "true" or args[2]:lower() == "yes")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if deleteAll then
 						Routine(Remote.RemoveGui, v, true)
 					else
 						Routine(function()
-							for _, guiName in ipairs({"Message", "Hint", "Notify", "Effect", "Alert"}) do
+							for _, guiName in {"Message", "Hint", "Notify", "Effect", "Alert"} do
 								Remote.RemoveGui(v, guiName)
 							end
 						end)
@@ -2342,7 +2342,7 @@ return function(Vargs, env)
 			Description = "Removes all screen UI effects such as Spooky, Clown, ScreenImage, ScreenVideo, etc.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1] or "all")) do
+				for _, v in service.GetPlayers(plr, args[1] or "all") do
 					Remote.RemoveGui(v, "Effect")
 				end
 			end
@@ -2356,12 +2356,12 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				service.StopLoop("LightingTask")
-				for i, v in pairs(Variables.OriginalLightingSettings) do
+				for i, v in Variables.OriginalLightingSettings do
 					if i ~= "Sky" and service.Lighting[i] ~= nil then
 						Functions.SetLighting(i, v)
 					end
 				end
-				for i, v in ipairs(service.Lighting:GetChildren()) do
+				for i, v in service.Lighting:GetChildren() do
 					if v.ClassName == "Sky" then
 						service.Delete(v)
 					end
@@ -2379,8 +2379,8 @@ return function(Vargs, env)
 			Description = "Sets the player's lighting to match the server's";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
-					for prop, val in pairs(Variables.LightingSettings) do
+				for _, v in service.GetPlayers(plr, args[1]) do
+					for prop, val in Variables.LightingSettings do
 						Remote.SetLighting(v, prop, val)
 					end
 				end
@@ -2394,10 +2394,10 @@ return function(Vargs, env)
 			Description = "Sets target player(s)'s leader stats to 0";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, string.lower(args[1]))) do
+				for _, v in service.GetPlayers(plr, string.lower(args[1])) do
 					cPcall(function()
 						if v and v:FindFirstChild("leaderstats") then
-							for a, q in pairs(v.leaderstats:GetChildren()) do
+							for a, q in v.leaderstats:GetChildren() do
 								if q:IsA("IntValue") or q:IsA("NumberValue") then q.Value = 0 end
 							end
 						end
@@ -2413,7 +2413,7 @@ return function(Vargs, env)
 			Description = "Prompts the player(s) to buy the product belonging to the ID you supply";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					service.MarketPlace:PromptPurchase(v, tonumber(args[2]), false)
 				end
 			end
@@ -2427,7 +2427,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local list = {}
-				for _, v in pairs(Variables.Capes) do
+				for _, v in Variables.Capes do
 					table.insert(list, v.Name)
 				end
 				Remote.MakeGui(plr, "List", {Title = "Cape List", Tab = list;})
@@ -2447,7 +2447,7 @@ return function(Vargs, env)
 				local ref = args[4]
 				local id = args[5]
 				if args[2] and not args[3] then
-					for k, cape in pairs(Variables.Capes) do
+					for k, cape in Variables.Capes do
 						if string.lower(args[2])==string.lower(cape.Name) then
 							color = cape.Color
 							mat = cape.Material
@@ -2456,7 +2456,7 @@ return function(Vargs, env)
 						end
 					end
 				end
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Functions.Cape(v, false, mat, color, id, ref)
 				end
 			end
@@ -2469,7 +2469,7 @@ return function(Vargs, env)
 			Description = "Removes the target player(s)'s cape";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Functions.UnCape(v)
 				end
 			end
@@ -2485,7 +2485,7 @@ return function(Vargs, env)
 				local clipper = Deps.Assets.Clipper:Clone()
 				clipper.Name = "ADONIS_NoClip"
 
-				for i, p in pairs(service.GetPlayers(plr, args[1])) do
+				for i, p in service.GetPlayers(plr, args[1]) do
 					Admin.RunCommand(Settings.Prefix.."clip", p.Name)
 					local new = clipper:Clone()
 					new.Parent = p.Character.Humanoid
@@ -2504,7 +2504,7 @@ return function(Vargs, env)
 			Description = "Flying noclip";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, p in pairs(service.GetPlayers(plr, args[1])) do
+				for i, p in service.GetPlayers(plr, args[1]) do
 					Commands.Fly.Function(p, args, true)
 				end
 			end
@@ -2517,7 +2517,7 @@ return function(Vargs, env)
 			Description = "Un-NoClips the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, p in pairs(service.GetPlayers(plr, args[1])) do
+				for i, p in service.GetPlayers(plr, args[1]) do
 					local old = p.Character.Humanoid:FindFirstChild("ADONIS_NoClip")
 					if old then
 						local enabled = old:FindFirstChild("Enabled")
@@ -2552,7 +2552,7 @@ return function(Vargs, env)
 					end
 				end
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local cHumanoidRootPart	= v.Character and v.Character.PrimaryPart or v.Character and v.Character:FindFirstChild("HumanoidRootPart")
 					if cHumanoidRootPart then
 
@@ -2652,7 +2652,7 @@ return function(Vargs, env)
 
 						local Backpack = v:FindFirstChildOfClass("Backpack")
 						if Backpack then
-							for _, k in ipairs(Backpack:GetChildren()) do
+							for _, k in Backpack:GetChildren() do
 								if k:IsA("BackpackItem") then
 									table.insert(jail.Tools,k)
 									k.Parent = nil
@@ -2674,7 +2674,7 @@ return function(Vargs, env)
 
 											local Backpack = v:FindFirstChildOfClass("Backpack")
 											if Backpack then
-												for _, k in ipairs(Backpack:GetChildren()) do
+												for _, k in Backpack:GetChildren() do
 													if k:IsA("BackpackItem") then
 														table.insert(jail.Tools, k)
 														k.Parent = nil
@@ -2711,13 +2711,13 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local found = false
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local ind = tostring(v.UserId)
 					local jail = Variables.Jails[ind]
 					if jail then
 						--service.StopLoop(ind.."JAIL")
 						Pcall(function()
-							for _, tool in pairs(jail.Tools) do
+							for _, tool in jail.Tools do
 								tool.Parent = v.Backpack
 							end
 						end)
@@ -2728,7 +2728,7 @@ return function(Vargs, env)
 				end
 
 				if not found then
-					for i, v in pairs(Variables.Jails) do
+					for i, v in Variables.Jails do
 						if string.sub(string.lower(v.Name), 1, #args[1]) == string.lower(args[1]) then
 							local ind = v.Index
 							service.StopLoop(ind.."JAIL")
@@ -2755,7 +2755,7 @@ return function(Vargs, env)
 					off = "off"
 				}
 				local chatColor = args[2] and CHAT_COLORS[args[2]:lower()] or CHAT_COLORS.red
-				for _, v in ipairs(service.GetPlayers(plr,(args[1] or plr.Name))) do
+				for _, v in service.GetPlayers(plr,(args[1] or plr.Name)) do
 					Remote.MakeGui(v, "BubbleChat", {Color = chatColor;})
 				end
 			end
@@ -2776,7 +2776,7 @@ return function(Vargs, env)
 					Variables.TrackingTable[plr.Name] = {}
 				end
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if persistent then
 						Variables.TrackingTable[plr.Name][v] = true
 					end
@@ -2860,7 +2860,7 @@ return function(Vargs, env)
 					Variables.TrackingTable[plr.Name] = nil
 				else
 					local trackTargets = Variables.TrackingTable[plr.Name]
-					for _, v in pairs(service.GetPlayers(plr, args[1])) do
+					for _, v in service.GetPlayers(plr, args[1]) do
 						Remote.RemoveLocal(plr, v.Name.."Tracker")
 						if trackTargets then
 							trackTargets[v] = nil
@@ -2877,7 +2877,7 @@ return function(Vargs, env)
 			Description = "Makes the player(s) character completely local";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeLocal(v, v.Character)
 				end
 			end
@@ -2890,7 +2890,7 @@ return function(Vargs, env)
 			Description = "UnPhases the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.MoveLocal(v, v.Character.Name, false, workspace)
 					v.Character.Parent = workspace
 				end
@@ -2904,10 +2904,10 @@ return function(Vargs, env)
 			Description = "Gives the target player(s) tools that are in the game's StarterPack";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local Backpack = v:FindFirstChildOfClass("Backpack")
 					if Backpack then
-						for a, q in ipairs(service.StarterPack:GetChildren()) do
+						for a, q in service.StarterPack:GetChildren() do
 							local q = q:Clone()
 							if not q:FindFirstChild(Variables.CodeName) then
 								service.New("StringValue", q).Name = Variables.CodeName
@@ -2931,7 +2931,7 @@ return function(Vargs, env)
 				if config then
 					config.CanTeamkill.Value = if args[2] and args[2]:lower() == "false" then false else true
 				end
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local Backpack = v:FindFirstChildOfClass("Backpack")
 					if Backpack then
 						sword:Clone().Parent = Backpack
@@ -2943,14 +2943,14 @@ return function(Vargs, env)
 		Clone = {
 			Prefix = Settings.Prefix;
 			Commands = {"clone", "cloneplayer", "duplicate"};
-			Args = {"player", "copies (max: 50 | default: 1)"};
+			Args = {"player", "copies (max: 50)"};
 			Description = "Clones the character of the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local num = tonumber(args[2] or 1)
 				assert(num <= 50, "Cannot make more than 50 clones")
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local char = v.Character
 					local hum = char and char:FindFirstChildOfClass("Humanoid")
 					if not hum then
@@ -2968,7 +2968,7 @@ return function(Vargs, env)
 							if anim then
 								animate = hum.RigType == Enum.HumanoidRigType.R15 and Deps.Assets.R15Animate:Clone() or Deps.Assets.R6Animate:Clone()
 								animate:ClearAllChildren()
-								for _, v in ipairs(anim:GetChildren()) do
+								for _, v in anim:GetChildren() do
 									v.Parent = animate
 								end
 								anim:Destroy()
@@ -3018,12 +3018,12 @@ return function(Vargs, env)
 				target_humandescrip.Archivable = true
 				target_humandescrip = target_humandescrip:Clone()
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						if (v and v.Character and v.Character:FindFirstChildOfClass("Humanoid")) and (target and target.Character and target.Character:FindFirstChildOfClass"Humanoid") then
 							v.Character.Archivable = true
 
-							for _, a in pairs(v.Character:GetChildren()) do
+							for _, a in v.Character:GetChildren() do
 								if a:IsA("Accessory") then
 									a:Destroy()
 								end
@@ -3033,7 +3033,7 @@ return function(Vargs, env)
 							cl.Parent = v.Character:FindFirstChildOfClass("Humanoid")
 							pcall(function() v.Character:FindFirstChildOfClass("Humanoid"):ApplyDescription(cl) end)
 
-							for _, a in pairs(target_character:GetChildren()) do
+							for _, a in target_character:GetChildren() do
 								if a:IsA("Accessory") then
 									a:Clone().Parent = v.Character
 								end
@@ -3052,7 +3052,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local plrBackpack = assert(plr:FindFirstChildOfClass("Backpack"), "You have no backpack")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local scr = Deps.Assets.ClickTeleport:Clone()
 					scr.Mode.Value = "Teleport"
 					scr.Target.Value = v.Name
@@ -3077,7 +3077,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local plrBackpack = assert(plr:FindFirstChildOfClass("Backpack"), "You have no backpack")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local scr = Deps.Assets.ClickTeleport:Clone()
 					scr.Mode.Value = "Walk"
 					scr.Target.Value = v.Name
@@ -3101,7 +3101,7 @@ return function(Vargs, env)
 			Description = "Lets you take control of the target player";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						v.Character.Humanoid.PlatformStand = true
 						local w = service.New("Weld", plr.Character.HumanoidRootPart )
@@ -3123,12 +3123,12 @@ return function(Vargs, env)
 						w6.Part0 = plr.Character:FindFirstChild("Left Leg")
 						w6.Part1 = v.Character:FindFirstChild("Left Leg")
 						plr.Character.Head.face:Destroy()
-						for _, p in pairs(v.Character:GetChildren()) do
+						for _, p in v.Character:GetChildren() do
 							if p:IsA("BasePart") then
 								p.CanCollide = false
 							end
 						end
-						for _, p in pairs(plr.Character:GetChildren()) do
+						for _, p in plr.Character:GetChildren() do
 							if p:IsA("BasePart") then
 								p.Transparency = 1
 							elseif p:IsA("Accoutrement") then
@@ -3149,7 +3149,7 @@ return function(Vargs, env)
 			Description = "Refreshes the target player(s)'s character";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, p in ipairs(service.GetPlayers(plr, args[1])) do
+				for i, p in service.GetPlayers(plr, args[1]) do
 					task.defer(function()
 						local oChar = p.Character;
 						local oTools, pBackpack, oHumanoid, oPrimary, oPos;
@@ -3175,7 +3175,7 @@ return function(Vargs, env)
 							end)
 
 							if oHumanoid then oHumanoid:UnequipTools() end
-							for _, child in ipairs(pBackpack:GetChildren()) do
+							for _, child in pBackpack:GetChildren() do
 								table.insert(oTools, child)
 								child.Parent = nil
 							end
@@ -3213,7 +3213,7 @@ return function(Vargs, env)
 						local newBackpack = p:FindFirstChildOfClass("Backpack")
 						if newBackpack and oTools then
 							newBackpack:ClearAllChildren();
-							for _, t in ipairs(oTools) do
+							for _, t in oTools do
 								t.Parent = newBackpack
 							end
 						end
@@ -3229,7 +3229,7 @@ return function(Vargs, env)
 			Description = "Kills the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local hum = v.Character:FindFirstChildOfClass("Humanoid")
 						if hum then
@@ -3248,7 +3248,7 @@ return function(Vargs, env)
 			Description = "Respawns the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					task.defer(function()
 						pcall(v.LoadCharacter, v)
 						Remote.Send(v, "Function", "SetView", "reset")
@@ -3264,7 +3264,7 @@ return function(Vargs, env)
 			Description = "Converts players' character to R6";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					task.defer(Functions.ConvertPlayerCharacterToRig, v, "R6")
 				end
 			end
@@ -3277,7 +3277,7 @@ return function(Vargs, env)
 			Description = "Converts players' character to R15";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Functions.ConvertPlayerCharacterToRig(v, "R15")
 				end
 			end
@@ -3290,7 +3290,7 @@ return function(Vargs, env)
 			Description = "Stuns the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local Humanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 
 					if Humanoid then
@@ -3307,7 +3307,7 @@ return function(Vargs, env)
 			Description = "UnStuns the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local Humanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 
 					if Humanoid then
@@ -3324,7 +3324,7 @@ return function(Vargs, env)
 			Description = "Forces the target player(s) to jump";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local Humanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if Humanoid then
 						Humanoid.Jump = true
@@ -3340,7 +3340,7 @@ return function(Vargs, env)
 			Description = "Forces the target player(s) to sit";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local Humanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if Humanoid then
 						Humanoid.Sit = true
@@ -3356,20 +3356,20 @@ return function(Vargs, env)
 			Description = "Set the transparency of the target's character";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for k, p in pairs(v.Character:GetChildren()) do
+						for k, p in v.Character:GetChildren() do
 							if p:IsA("BasePart") and p.Name ~= "HumanoidRootPart" then
 								p.Transparency = args[2]
 								if p.Name == "Head" then
-									for _, v2 in pairs(p:GetChildren()) do
+									for _, v2 in p:GetChildren() do
 										if v2:IsA("Decal") then
 											v2.Transparency = args[2]
 										end
 									end
 								end
 							elseif p:IsA("Accessory") and #p:GetChildren() ~= 0 then
-								for _, v2 in pairs(p:GetChildren()) do
+								for _, v2 in p:GetChildren() do
 									if v2:IsA("BasePart") then
 										v2.Transparency = args[2]
 									end
@@ -3388,7 +3388,7 @@ return function(Vargs, env)
 			Description = "Set the transparency of the target's character's parts, including accessories; supports a comma-separated list of part names";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, player in pairs(service.GetPlayers(plr, args[1])) do
+				for i, player in service.GetPlayers(plr, args[1]) do
 					if player.Character then
 						local humanoid = player.Character:FindFirstChildOfClass("Humanoid")
 						if humanoid then
@@ -3412,7 +3412,7 @@ return function(Vargs, env)
 							if not (args[2]) then
 								--assert(args[2], "No parts specified. See developer console for possible inputs.")
 								local tab = {}
-								for _,v in pairs(usageText) do
+								for _,v in usageText do
 									table.insert(tab, {
 										Text = v;
 										Desc = v;
@@ -3429,7 +3429,7 @@ return function(Vargs, env)
 							local partInput = {}
 							local inputs = string.split(args[2], ",")
 
-							for _, v in pairs(inputs) do
+							for _, v in inputs do
 								if v ~= "" then
 									if v == "all" then
 										partInput = "all"
@@ -3442,7 +3442,7 @@ return function(Vargs, env)
 									else
 										local found = false
 										while found ~= true do
-											for _,v2 in pairs(GroupPartInputs) do
+											for _,v2 in GroupPartInputs do
 												if v == v2 then
 													table.insert(partInput, v)
 													found = true
@@ -3450,7 +3450,7 @@ return function(Vargs, env)
 												end
 											end
 
-											for _,v2 in pairs(PartInputs) do
+											for _,v2 in PartInputs do
 												if v == v2 then
 													table.insert(partInput, v)
 													found = true
@@ -3474,7 +3474,7 @@ return function(Vargs, env)
 								local hash = {}
 
 								-- Check for duplicates
-								for i,v in pairs(partInput) do
+								for i,v in partInput do
 									if not (hash[v]) then
 										hash[v] = i -- Store into table to check for duplicates.
 									else
@@ -3489,14 +3489,14 @@ return function(Vargs, env)
 									for i = #partInput, 1, -1 do
 										if partInput[i] == "RightArm" then
 											local foundKeys = {}
-											for k2, v2 in pairs(partInput) do
+											for k2, v2 in partInput do
 												if v2 == "RightUpperArm" or v2 == "RightLowerArm" or v2 == "RightHand" then
 													table.insert(foundKeys, k2)
 												end
 											end
 											-- If not all keys were found just remove all keys and add them manually
 											if #foundKeys ~= 3 then
-												for _, foundKey in pairs(foundKeys) do
+												for _, foundKey in foundKeys do
 													table.remove(partInput, foundKey)
 												end
 												table.insert(partInput, "RightUpperArm")
@@ -3507,14 +3507,14 @@ return function(Vargs, env)
 
 										elseif partInput[i] == "LeftArm" then
 											local foundKeys = {}
-											for k2, v2 in pairs(partInput) do
+											for k2, v2 in partInput do
 												if v2 == "LeftUpperArm" or v2 == "LeftLowerArm" or v2 == "LeftHand" then
 													table.insert(foundKeys, k2)
 												end
 											end
 
 											if #foundKeys ~= 3 then
-												for _, foundKey in pairs(foundKeys) do
+												for _, foundKey in foundKeys do
 													table.remove(partInput, foundKey)
 												end
 												table.insert(partInput, "LeftUpperArm")
@@ -3530,7 +3530,7 @@ return function(Vargs, env)
 												end
 											end
 											if #foundKeys ~= 3 then
-												for _, foundKey in pairs(foundKeys) do
+												for _, foundKey in foundKeys do
 													table.remove(partInput, foundKey)
 												end
 												table.insert(partInput, "RightUpperLeg")
@@ -3540,14 +3540,14 @@ return function(Vargs, env)
 											table.remove(partInput, i)
 										elseif partInput[i] == "LeftLeg" then
 											local foundKeys = {}
-											for k2, v2 in pairs(partInput) do
+											for k2, v2 in partInput do
 												if v2 == "LeftUpperLeg" or v2 == "LeftLowerLeg" or v2 == "LeftFoot" then
 													table.insert(foundKeys, k2)
 												end
 											end
 
 											if #foundKeys ~= 3 then
-												for _, foundKey in pairs(foundKeys) do
+												for _, foundKey in foundKeys do
 													table.remove(partInput, foundKey)
 												end
 												table.insert(partInput, "LeftUpperLeg")
@@ -3557,13 +3557,13 @@ return function(Vargs, env)
 											table.remove(partInput, i)
 										elseif partInput[i] == "Torso" then
 											local foundKeys = {}
-											for k2, v2 in pairs(partInput) do
+											for k2, v2 in partInput do
 												if v2 == "UpperTorso" or v2 == "LowerTorso" then
 													table.insert(foundKeys, k2)
 												end
 											end
 											if #foundKeys ~= 2 then
-												for _, foundKey in pairs(foundKeys) do
+												for _, foundKey in foundKeys do
 													table.remove(partInput, foundKey)
 												end
 												table.insert(partInput, "UpperTorso")
@@ -3592,7 +3592,7 @@ return function(Vargs, env)
 
 
 								-- Make chosen parts transparent
-								for k, v in pairs(partInput) do
+								for k, v in partInput do
 									if not (v == "limbs" or v == "face" or v == "accessories") then
 										local part = player.Character:FindFirstChild(v)
 										if part ~= nil and part:IsA("BasePart") then
@@ -3600,7 +3600,7 @@ return function(Vargs, env)
 										end
 
 									elseif v == "limbs" then
-										for key, part in pairs(player.Character:GetChildren()) do
+										for key, part in player.Character:GetChildren() do
 											if part:IsA("BasePart") and part.Name ~= "HumanoidRootPart" then
 												part.Transparency = args[3]
 											end
@@ -3608,16 +3608,16 @@ return function(Vargs, env)
 
 									elseif v == "face" then
 										local headPart = player.Character:FindFirstChild("Head")
-										for _, v2 in pairs(headPart:GetChildren()) do
+										for _, v2 in headPart:GetChildren() do
 											if v2:IsA("Decal") then
 												v2.Transparency = args[3]
 											end
 										end
 
 									elseif v == "accessories" then
-										for key, part in pairs(player.Character:GetChildren()) do
+										for key, part in player.Character:GetChildren() do
 											if part:IsA("Accessory") then
-												for _, v2 in pairs(part:GetChildren()) do
+												for _, v2 in part:GetChildren() do
 													if v2:IsA("BasePart") then
 														v2.Transparency = args[3]
 													end
@@ -3627,21 +3627,19 @@ return function(Vargs, env)
 									end
 								end
 
-
-								-- If "all" is specified
 							elseif partInput == "all" then
-								for k, p in pairs(player.Character:GetChildren()) do
+								for k, p in player.Character:GetChildren() do
 									if p:IsA("BasePart") and p.Name ~= "HumanoidRootPart" then
 										p.Transparency = args[3]
 										if p.Name == "Head" then
-											for _, v2 in pairs(p:GetChildren()) do
+											for _, v2 in p:GetChildren() do
 												if v2:IsA("Decal") then
 													v2.Transparency = args[3]
 												end
 											end
 										end
 									elseif p:IsA("Accessory") and #p:GetChildren() ~= 0 then
-										for _, v2 in pairs(p:GetChildren()) do
+										for _, v2 in p:GetChildren() do
 											if v2:IsA("BasePart") then
 												v2.Transparency = args[3]
 											end
@@ -3662,9 +3660,9 @@ return function(Vargs, env)
 			Description = "Makes the target player(s) invisible";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for a, obj in ipairs(v.Character:GetChildren()) do
+						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") then
 								obj.Transparency = 1
 								if obj:FindFirstChild("face") then
@@ -3693,9 +3691,9 @@ return function(Vargs, env)
 			Description = "Makes the target player(s) visible";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for a, obj in ipairs(v.Character:GetChildren()) do
+						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") and obj.Name~="HumanoidRootPart" then
 								obj.Transparency = 0
 								if obj:FindFirstChild("face") then
@@ -3736,12 +3734,12 @@ return function(Vargs, env)
 					assert(color, "Invalid color provided")
 				end
 
-				for _, v: Player in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v: Player in service.GetPlayers(plr, args[1]) do
 					local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
 
-						for _, property in ipairs(BodyColorProperties) do
+						for _, property in BodyColorProperties do
 							humanoidDesc[property] = color
 						end
 
@@ -3758,9 +3756,9 @@ return function(Vargs, env)
 			Description = "Locks the target player(s), preventing the use of btools on the character";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for a, obj in pairs(v.Character:GetChildren()) do
+						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") then
 								obj.Locked = true
 							elseif obj:IsA("Accoutrement") and obj:FindFirstChild("Handle") then
@@ -3779,9 +3777,9 @@ return function(Vargs, env)
 			Description = "UnLocks the the target player(s), makes it so you can use btools on them";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for a, obj in pairs(v.Character:GetChildren()) do
+						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") then
 								obj.Locked = false
 							elseif obj:IsA("Accoutrement") and obj:FindFirstChild("Handle") then
@@ -3802,7 +3800,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local color = Functions.ParseColor3(args[2]) or BrickColor.new("Bright blue").Color
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						Functions.NewParticle(v.Character.HumanoidRootPart, "PointLight", {
 							Name = "ADONIS_LIGHT";
@@ -3822,7 +3820,7 @@ return function(Vargs, env)
 			Description = "UnLights the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						Functions.RemoveParticle(v.Character.HumanoidRootPart, "ADONIS_LIGHT")
 					end
@@ -3843,7 +3841,7 @@ return function(Vargs, env)
 				assert(color, "Invalid color provided")
 
 				if args[2] then
-					for _, v in pairs(service.GetPlayers(plr, args[2])) do
+					for _, v in service.GetPlayers(plr, args[2]) do
 						Remote.SetLighting(v, "Ambient", color)
 					end
 				else
@@ -3865,7 +3863,7 @@ return function(Vargs, env)
 				assert(color, "Invalid color provided")
 
 				if args[2] then
-					for _, v in pairs(service.GetPlayers(plr, args[2])) do
+					for _, v in service.GetPlayers(plr, args[2]) do
 						Remote.SetLighting(v, "OutdoorAmbient", color)
 					end
 				else
@@ -3882,7 +3880,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				if args[1] then
-					for _, v in pairs(service.GetPlayers(plr, args[1])) do
+					for _, v in service.GetPlayers(plr, args[1]) do
 						Remote.SetLighting(v, "FogEnd", 1000000000000)
 					end
 				else
@@ -3900,7 +3898,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				if string.lower(args[1])=="on" or string.lower(args[1])=="true" then
 					if args[2] then
-						for _, v in pairs(service.GetPlayers(plr, args[2])) do
+						for _, v in service.GetPlayers(plr, args[2]) do
 							Remote.SetLighting(v, "GlobalShadows", true)
 						end
 					else
@@ -3908,7 +3906,7 @@ return function(Vargs, env)
 					end
 				elseif string.lower(args[1])=="off" or string.lower(args[1])=="false" then
 					if args[2] then
-						for _, v in pairs(service.GetPlayers(plr, args[2])) do
+						for _, v in service.GetPlayers(plr, args[2]) do
 							Remote.SetLighting(v, "GlobalShadows", false)
 						end
 					else
@@ -3926,7 +3924,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				if args[2] then
-					for _, v in pairs(service.GetPlayers(plr, args[2])) do
+					for _, v in service.GetPlayers(plr, args[2]) do
 						Remote.SetLighting(v, "Brightness", args[1])
 					end
 				else
@@ -3943,7 +3941,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				if args[2] then
-					for _, v in pairs(service.GetPlayers(plr, args[2])) do
+					for _, v in service.GetPlayers(plr, args[2]) do
 						Remote.SetLighting(v, "TimeOfDay", args[1])
 					end
 				else
@@ -3966,7 +3964,7 @@ return function(Vargs, env)
 				assert(color, "Invalid color provided")
 
 				if args[2] then
-					for _, v in pairs(service.GetPlayers(plr, args[2])) do
+					for _, v in service.GetPlayers(plr, args[2]) do
 						Remote.SetLighting(v, "FogColor", color)
 					end
 				else
@@ -3983,7 +3981,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				if args[3] then
-					for _, v in pairs(service.GetPlayers(plr, args[3])) do
+					for _, v in service.GetPlayers(plr, args[3]) do
 						Remote.SetLighting(v, "FogEnd", args[2])
 						Remote.SetLighting(v, "FogStart", args[1])
 					end
@@ -4005,7 +4003,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local found = {}
 				local temp = service.New("Folder")
-				for _, tool in pairs(if Settings.RecursiveTools then Settings.Storage:GetDescendants() else Settings.Storage:GetChildren()) do
+				for _, tool in if Settings.RecursiveTools then Settings.Storage:GetDescendants() else Settings.Storage:GetChildren() do
 					if tool:IsA("BackpackItem") then
 						if string.lower(args[2]) == "all" or string.sub(string.lower(tool.Name),1, #args[2])==string.lower(args[2]) then
 							tool.Archivable = true
@@ -4019,8 +4017,8 @@ return function(Vargs, env)
 					end
 				end
 				if #found > 0 then
-					for _, v in pairs(service.GetPlayers(plr, args[1])) do
-						for k, t in pairs(found) do
+					for _, v in service.GetPlayers(plr, args[1]) do
+						for k, t in found do
 							t:Clone().Parent = v.StarterGear
 						end
 					end
@@ -4040,10 +4038,10 @@ return function(Vargs, env)
 			Description = "Removes the desired tool from the target player(s)'s StarterPack";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, string.lower(args[1]))) do
+				for _, v in service.GetPlayers(plr, string.lower(args[1])) do
 					local StarterGear = v:FindFirstChildOfClass("StarterGear")
 					if StarterGear then
-						for _, tool in ipairs(StarterGear:GetChildren()) do
+						for _, tool in StarterGear:GetChildren() do
 							if tool:IsA("BackpackItem") then
 								if string.lower(args[2]) == "all" or string.find(string.lower(tool.Name), string.lower(args[2])) == 1 then
 									tool:Destroy()
@@ -4058,61 +4056,36 @@ return function(Vargs, env)
 		Give = {
 			Prefix = Settings.Prefix;
 			Commands = {"give", "tool"};
-			Args = {"player", "tool names(s) or 'all' or 'random'"};
-			Description = "Gives the target player(s) the desired tool(s) (refer to "..Settings.Prefix.."tools for a list of available tools)";
+			Args = {"player", "tool"};
+			Description = "Gives the target player(s) the desired tool(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				assert(args[2], "Missing tool name(s) (argument #2)")
-
-				local players = service.GetPlayers(plr, args[1])
-
-				local tools = {}
+				local found = {}
+				local temp = service.New("Folder")
 				for _, tool in if Settings.RecursiveTools then Settings.Storage:GetDescendants() else Settings.Storage:GetChildren() do
 					if tool:IsA("BackpackItem") then
-						table.insert(tools, tool)
-					end
-				end
-
-				local found
-				if args[2]:lower() == "all" then
-					found = tools
-				elseif args[2]:lower() == "random" then
-					found = {tools[math.random(1, #tools)]}
-				else
-					found = {}
-					for _, toolName in args[2]:split(",") do
-						local didFind = false
-						for _, tool in tools do
-							if tool.Name == toolName then
-								table.insert(found, tool)
-								didFind = true
-								break --// Break on absolute match
-							elseif tool.Name:lower():match("^"..toolName:lower()) then
-								table.insert(found, tool)
-								didFind = true
-							end
-						end
-						if not didFind then
-							Functions.Hint("No tools matching the name '"..toolName.."' were found in storage", {plr})
-						end
-					end
-				end
-
-				assert(#found > 0, "Couldn't find anything to give")
-
-				for _, v in players do
-					local backpack = v:FindFirstChildOfClass("Backpack")
-					if not backpack then
-						continue
-					end
-					for _, tool in found do
-						local toolArchivable = tool.Archivable
-						if not toolArchivable then
+						if string.lower(args[2]) == "all" or string.sub(string.lower(tool.Name), 1, #args[2])==string.lower(args[2]) then
 							tool.Archivable = true
+							local parent = tool.Parent
+							if not parent.Archivable then
+								tool.Parent = temp
+							end
+							table.insert(found, tool:Clone())
+							tool.Parent = parent
 						end
-						tool:Clone().Parent = backpack
-						tool.Archivable = toolArchivable
 					end
+				end
+				if #found > 0 then
+					for _, v in service.GetPlayers(plr, args[1]) do
+						for k, t in found do
+							t:Clone().Parent = v.Backpack
+						end
+					end
+				else
+					error("Couldn't find anything to give")
+				end
+				if temp then
+					temp:Destroy()
 				end
 			end
 		};
@@ -4126,16 +4099,16 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local victims = service.GetPlayers(plr, args[1])
 				local stealers = service.GetPlayers(plr, args[2])
-				for _, victim in pairs(victims) do
+				for _, victim in victims do
 					local backpack = victim:FindFirstChildOfClass("Backpack")
 					if not backpack then continue end
 					task.defer(function()
 						local hum = victim.Character and victim.Character:FindFirstChildOfClass("Humanoid")
 						if hum then hum:UnequipTools() end
-						for _, p in pairs(stealers) do
+						for _, p in stealers do
 							local destination = p:FindFirstChildOfClass("Backpack")
 							if not destination then continue end
-							for _, tool in pairs(backpack:GetChildren()) do
+							for _, tool in backpack:GetChildren() do
 								if #stealers > 1 then
 									tool:Clone().Parent = destination
 								else
@@ -4158,11 +4131,11 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local p1 = service.GetPlayers(plr, args[1])
 				local p2 = service.GetPlayers(plr, args[2])
-				for _, v in pairs(p1) do
+				for _, v in p1 do
 					local backpack = v:FindFirstChildOfClass("Backpack")
 					if not backpack then continue end
-					for _, m in pairs(p2) do
-						for _, n in pairs(backpack:GetChildren()) do
+					for _, m in p2 do
+						for _, n in backpack:GetChildren() do
 							n:Clone().Parent = m:FindFirstChildOfClass("Backpack")
 						end
 					end
@@ -4177,8 +4150,8 @@ return function(Vargs, env)
 			Description = "Removes all of the target player(s)'s on-screen GUIs except Adonis GUIs";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
-					Remote.LoadCode(v, [[for i, v in pairs(service.PlayerGui:GetChildren()) do if not client.Core.GetGui(v) then pcall(v.Destroy, v) end end]])
+				for _, v in service.GetPlayers(plr, args[1]) do
+					Remote.LoadCode(v, [[for i, v in service.PlayerGui:GetChildren()) do if not client.Core.GetGui(v) then pcall(v.Destroy, v) end end]])
 				end
 			end
 		};
@@ -4190,17 +4163,17 @@ return function(Vargs, env)
 			Description = "Remove the target player(s)'s tools";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local hum = v.Character:FindFirstChildOfClass("Humanoid")
 						if hum then hum:UnequipTools() end
-						for _, tool in pairs(v.Character:GetChildren()) do
+						for _, tool in v.Character:GetChildren() do
 							if tool:IsA("BackpackItem") then tool:Destroy() end
 						end
 					end
 					local backpack = v:FindFirstChildOfClass("Backpack")
 					if backpack then
-						for _, tool in pairs(backpack:GetChildren()) do
+						for _, tool in backpack:GetChildren() do
 							if tool:IsA("BackpackItem") then tool:Destroy() end
 						end
 					end
@@ -4215,9 +4188,9 @@ return function(Vargs, env)
 			Description = "Remove a specified tool from the target player(s)'s backpack";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
-						for _, tool in pairs(v.Character:GetChildren()) do
+						for _, tool in v.Character:GetChildren() do
 							if tool:IsA("BackpackItem") and string.sub(tool.Name:lower(), 1, #args[2])== args[2]:lower() then
 								local hum = v.Character:FindFirstChildOfClass("Humanoid")
 								if hum then hum:UnequipTools() end
@@ -4227,7 +4200,7 @@ return function(Vargs, env)
 					end
 					local backpack = v:FindFirstChildOfClass("Backpack")
 					if backpack then
-						for _, tool in pairs(backpack:GetChildren()) do
+						for _, tool in backpack:GetChildren() do
 							if tool:IsA("BackpackItem") and string.sub(tool.Name:lower(), 1, #args[2])== args[2]:lower() then
 								tool:Destroy()
 							end
@@ -4245,7 +4218,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				assert(args[2], "Missing group name (argument #2)")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local groupInfo = Admin.GetPlayerGroup(v, args[2])
 					if groupInfo then
 						Functions.Hint(string.format("%s has rank [%d] %s in %s", service.FormatPlayer(v), groupInfo.Rank, groupInfo.Role, groupInfo.Name), {plr})
@@ -4263,7 +4236,7 @@ return function(Vargs, env)
 			Description = "Removes <number> HP from the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum:TakeDamage(args[2])
@@ -4279,7 +4252,7 @@ return function(Vargs, env)
 			Description = "Set the target player(s)'s health and max health to <number>";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.MaxHealth = args[2]
@@ -4296,7 +4269,7 @@ return function(Vargs, env)
 			Description = "Set the target player(s)'s jump power to <number>";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.JumpPower = args[2] or 50
@@ -4313,7 +4286,7 @@ return function(Vargs, env)
 			Description = "Set the target player(s)'s jump height to <number>";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.JumpHeight = args[2] or 7.2
@@ -4333,7 +4306,7 @@ return function(Vargs, env)
 				assert(not args[2] or args[2]:lower() ~= "inf", "Speed cannot be infinite")
 				local speed = tonumber(args[2]) or 16
 				assert(speed >= 0, "Speed cannot be negative")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.WalkSpeed = speed
@@ -4358,8 +4331,8 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing player name")
 				assert(args[2], "Missing team name")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
-					for a, tm in ipairs(service.Teams:GetChildren()) do
+				for _, v in service.GetPlayers(plr, args[1]) do
+					for a, tm in service.Teams:GetChildren() do
 						if string.sub(string.lower(tm.Name), 1, #args[2]) == string.lower(args[2]) then
 							v.Team = tm
 							if Settings.CommandFeedback then
@@ -4410,9 +4383,9 @@ return function(Vargs, env)
 				end
 
 
-				for i, team in ipairs(service.Teams:GetChildren()) do
+				for i, team in service.Teams:GetChildren() do
 					if #tArgs > 0 then
-						for ind, check in pairs(tArgs) do
+						for ind, check in tArgs do
 							if string.sub(string.lower(team.Name), 1, #check) == string.lower(check) then
 								table.insert(teams, team)
 							end
@@ -4436,7 +4409,7 @@ return function(Vargs, env)
 			Description = "Takes the target player(s) off of a team and sets them to 'Neutral' ";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, player in ipairs(Functions.GetPlayers(plr, args[1])) do
+				for _, player in Functions.GetPlayers(plr, args[1]) do
 					player.Neutral = true
 					player.Team = nil
 					player.TeamColor = BrickColor.new(194) -- Neutral Team
@@ -4469,7 +4442,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing player name")
 				assert(args[2] and tonumber(args[2]), "Missing or invalid FOV number")
-				for i, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.LoadCode(v,[[workspace.CurrentCamera.FieldOfView=]].. math.clamp(tonumber(args[2]), 1, 120))
 				end
 			end
@@ -4488,7 +4461,7 @@ return function(Vargs, env)
 				local teleportOptions = if reservedServerInfo then service.New("TeleportOptions", {
 					ReservedServerAccessCode = reservedServerInfo.Code
 				}) else nil
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						if
 							Remote.MakeGuiGet(v, "Notification", {
@@ -4552,7 +4525,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local servers = Core.GetData("PrivateServers") or {}
 				local tab = {}
-				for i, v in pairs(servers) do
+				for i, v in servers do
 					table.insert(tab, {Text = i, Desc = "Place: "..v.ID.." | Code: "..v.Code})
 				end
 				Remote.MakeGui(plr, "List", {Title = "Servers"; Table = tab;})
@@ -4568,7 +4541,7 @@ return function(Vargs, env)
 			Hidden = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Notification", {
 						Title = "Teleport";
 						Text = "Click to teleport to GRP";
@@ -4590,13 +4563,13 @@ return function(Vargs, env)
 					local m = string.match(args[2], "^waypoint%-(.*)") or string.match(args[2], "wp%-(.*)")
 					local point
 
-					for i, v in pairs(Variables.Waypoints) do
+					for i, v in Variables.Waypoints do
 						if string.sub(string.lower(i), 1, #m)==string.lower(m) then
 							point=v
 						end
 					end
 
-					for _, v in pairs(service.GetPlayers(plr, args[1])) do
+					for _, v in service.GetPlayers(plr, args[1]) do
 						if point then
 							if not v.Character then
 								continue
@@ -4636,7 +4609,7 @@ return function(Vargs, env)
 					if not point then Functions.Hint("Waypoint "..m.." was not found.", {plr}) end
 				elseif string.find(args[2], ",") then
 					local x, y, z = string.match(args[2], "(.*),(.*),(.*)")
-					for _, v in pairs(service.GetPlayers(plr, args[1])) do
+					for _, v in service.GetPlayers(plr, args[1]) do
 						if not v.Character or not v.Character:FindFirstChild("HumanoidRootPart") then continue end
 
 						if workspace.StreamingEnabled == true then
@@ -4704,7 +4677,7 @@ return function(Vargs, env)
 					else
 						local targ_root = target.Character and target.Character:FindFirstChild("HumanoidRootPart")
 						if targ_root then
-							for k, n in pairs(players) do
+							for k, n in players do
 								if n ~= target then
 									local Character = n.Character
 									if not Character then continue end
@@ -4760,7 +4733,7 @@ return function(Vargs, env)
 					Question = "Would you like to use "..Settings.Prefix.."massbring instead? (Arranges the "..#players.." players in rows.)";
 					}) ~= "Yes"
 				then
-					for _, v in ipairs(players) do
+					for _, v in players do
 						task.defer(Commands.Teleport.Function, plr, {v.Name, plr.Name})
 					end
 				else
@@ -4776,7 +4749,7 @@ return function(Vargs, env)
 			Description = "Teleport you to the target";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					task.defer(Commands.Teleport.Function, plr, {plr.Name, v.Name})
 				end
 			end
@@ -4817,7 +4790,7 @@ return function(Vargs, env)
 							rootPart.CFrame = (
 								plrRootPart.CFrame
 									* CFrame.Angles(0, math.rad(90), 0)
-									*CFrame.new(5 + ((i-1) - (l-1)*math.floor(numPlayers/lines))*2, 0, offsetX)
+									* CFrame.new(5 + ((i-1) - (l-1) * math.floor(numPlayers/lines)) * 2, 0, offsetX)
 							) * CFrame.Angles(0, math.rad(90), 0)
 						end
 					end
@@ -4865,14 +4838,14 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local statName = assert(args[2], "Missing stat name (argument #2)")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local leaderstats = v:FindFirstChild("leaderstats")
 					if leaderstats then
 						local absoluteMatch = leaderstats:FindFirstChild(statName)
 						if absoluteMatch and absoluteMatch:IsA("ValueBase") then
 							absoluteMatch.Value = args[3]
 						else
-							for _, st in ipairs(leaderstats:GetChildren()) do
+							for _, st in leaderstats:GetChildren() do
 								if st:IsA("ValueBase") and string.match(st.Name:lower(), "^"..statName:lower()) then
 									st.Value = args[3]
 								end
@@ -4894,14 +4867,14 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local statName = assert(args[2], "Missing stat name (argument #2)")
 				local valueToAdd = assert(tonumber(args[3]), "Missing/invalid numerical value to add (argument #3)")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local leaderstats = v:FindFirstChild("leaderstats")
 					if leaderstats then
 						local absoluteMatch = leaderstats:FindFirstChild(statName)
 						if absoluteMatch and (absoluteMatch:IsA("IntValue") or absoluteMatch:IsA("NumberValue")) then
 							absoluteMatch.Value += valueToAdd
 						else
-							for _, st in ipairs(leaderstats:GetChildren()) do
+							for _, st in leaderstats:GetChildren() do
 								if (st:IsA("IntValue") or st:IsA("NumberValue")) and string.match(st.Name:lower(), "^"..statName:lower()) then
 									st.Value += valueToAdd
 								end
@@ -4923,14 +4896,14 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local statName = assert(args[2], "Missing stat name (argument #2)")
 				local valueToSubtract = assert(tonumber(args[3]), "Missing/invalid numerical value to subtract (argument #3)")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local leaderstats = v:FindFirstChild("leaderstats")
 					if leaderstats then
 						local absoluteMatch = leaderstats:FindFirstChild(statName)
 						if absoluteMatch and (absoluteMatch:IsA("IntValue") or absoluteMatch:IsA("NumberValue")) then
 							absoluteMatch.Value -= valueToSubtract
 						else
-							for _, st in ipairs(leaderstats:GetChildren()) do
+							for _, st in leaderstats:GetChildren() do
 								if (st:IsA("IntValue") or st:IsA("NumberValue")) and string.match(st.Name:lower(), "^"..statName:lower()) then
 									st.Value -= valueToSubtract
 								end
@@ -4952,20 +4925,69 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {[number]:string})
 				local ClothingId = tonumber(args[2])
 				local AssetIdType = service.MarketPlace:GetProductInfo(ClothingId).AssetTypeId
-				local Shirt = ((AssetIdType == 11 or AssetIdType == 2) and service.Insert(ClothingId)) or (AssetIdType == 1 and Functions.CreateClothingFromImageId("ShirtGraphic", ClothingId)) or error("Item ID passed has invalid item type")
-				assert(Shirt, "Could not retrieve t-shirt asset for the supplied ID")
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
-					if v.Character then
-						for g, k in pairs(v.Character:GetChildren()) do
-							if k:IsA("ShirtGraphic") then k:Destroy() end
-						end
-						--[[local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
-						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
+				local TShirt = ((AssetIdType == 11 or AssetIdType == 2) and service.Insert(ClothingId)) or (AssetIdType == 1 and Functions.CreateClothingFromImageId("ShirtGraphic", ClothingId)) or error("Item ID passed has invalid item type")
+				assert(TShirt, "Could not retrieve t-shirt asset for the supplied ID")
 
-						if humandescrip then
-							humandescrip.GraphicTShirt = ClothingId
-						end]]
-						Shirt:Clone().Parent = v.Character
+				local clothingTemplate = "rbxassetid://"..ClothingId
+
+				for i, v in service.GetPlayers(plr, args[1]) do
+					if v.Character then
+						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
+						local bCreateNewDefaultClothing = false
+
+						if (humanoid) then
+							local humanoidAppliedDesc = humanoid:GetAppliedDescription()
+							if (humanoidAppliedDesc) then
+								-- Check if the player already has a specified clothing instance.
+								local prePlayerShirtGraphic = v.Character:FindFirstChildOfClass("ShirtGraphic")
+
+								-- If the character has the specified clothing.
+								if (prePlayerShirtGraphic) then
+									-- Check the humanoid description for clothing ID.
+									if (humanoidAppliedDesc.GraphicTShirt == 0) then
+										-- Remove all the specified clothings, assuming it was manually created.
+										for k,v in v.Character:GetChildren() do
+											if (v:IsA("ShirtGraphic")) then
+												v:Destroy()
+											end
+										end
+
+										bCreateNewDefaultClothing = true
+									end
+								else -- If the specified clothing was not found.
+									if (humanoidAppliedDesc.GraphicTShirt == 0) then
+										bCreateNewDefaultClothing = true
+									else
+										-- If there was ment to be a specified clothing, but it doesn't exist anymore,
+										-- then just create a default clothing as well.
+										bCreateNewDefaultClothing = true
+									end
+								end
+
+
+								if (bCreateNewDefaultClothing) then
+									-- Set a new specified clothing.
+									local humDescClone = humanoidAppliedDesc:Clone()
+
+									humDescClone.GraphicTShirt = 6901238398 -- Some template shirt graphic
+									v.Character.Humanoid:ApplyDescription(humDescClone)
+									humDescClone:Destroy()
+								end
+
+								-- Set the specified clothing.
+								local playerShirtGraphicInstance = v.Character:FindFirstChildOfClass("ShirtGraphic")
+
+								if (playerShirtGraphicInstance) then
+									playerShirtGraphicInstance.Graphic = clothingTemplate
+								else
+									-- Incase something went wrong
+									TShirt:Clone().Parent = v.Character
+								end
+							else 
+								-- If no HumanoidDescription
+								TShirt:Clone().Parent = v.Character
+							end
+						end
 					end
 				end
 			end
@@ -4982,18 +5004,68 @@ return function(Vargs, env)
 				local AssetIdType = service.MarketPlace:GetProductInfo(ClothingId).AssetTypeId
 				local Shirt = AssetIdType == 11 and service.Insert(ClothingId) or AssetIdType == 1 and Functions.CreateClothingFromImageId("Shirt", ClothingId) or error("Item ID passed has invalid item type")
 				assert(Shirt, "Unexpected error occured; clothing is missing")
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
-					if v.Character then
-						for g, k in pairs(v.Character:GetChildren()) do
-							if k:IsA("Shirt") then k:Destroy() end
-						end
-						--[[local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
-						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
 
-						if humandescrip then
-							humandescrip.Shirt = ClothingId
-						end]]
-						Shirt:Clone().Parent = v.Character
+				local clothingTemplate = "rbxassetid://"..ClothingId
+
+				for i, v in service.GetPlayers(plr, args[1]) do
+					if v.Character then
+						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
+						local bCreateNewDefaultClothing = false
+
+						if (humanoid) then
+							local humanoidAppliedDesc = humanoid:GetAppliedDescription()
+							if (humanoidAppliedDesc) then
+								-- Check if the player already has a specified clothing instance.
+								local prePlayerShirt = v.Character:FindFirstChildOfClass("Shirt")
+
+								-- If the character has the specified clothing.
+								if (prePlayerShirt) then
+									-- Check the humanoid description for clothing ID.
+									if (humanoidAppliedDesc.Shirt == 0) then
+										-- Remove all the specified clothings, assuming it was manually created.
+										for k,v in v.Character:GetChildren() do
+											if (v:IsA("Shirt")) then
+												v:Destroy()
+											end
+										end
+
+										bCreateNewDefaultClothing = true
+									end
+								else -- If the specified clothing was not found.
+									if (humanoidAppliedDesc.Shirt == 0) then
+										bCreateNewDefaultClothing = true
+									else
+										-- If there was ment to be a specified clothing, but it doesn't exist anymore,
+										-- then just create a default clothing as well.
+										bCreateNewDefaultClothing = true
+									end
+								end
+
+
+								if (bCreateNewDefaultClothing) then
+									-- Set a new specified clothing.
+									local humDescClone = humanoidAppliedDesc:Clone()
+
+									-- Default Shirt ID 855777286, given when no valid shirt was set with HumanoidDescription
+									humDescClone.Shirt = 855777286 -- Default shirt TODO: You want to change this because the ID put here can't be given with the command if already ran.
+									v.Character.Humanoid:ApplyDescription(humDescClone)
+									humDescClone:Destroy()
+								end
+
+								-- Set the specified clothing.
+								local playerShirtInstance = v.Character:FindFirstChildOfClass("Shirt")
+
+								if (playerShirtInstance) then
+									playerShirtInstance.ShirtTemplate = clothingTemplate
+								else
+									-- Incase something went wrong
+									Shirt:Clone().Parent = v.Character
+								end
+							else 
+								-- If no HumanoidDescription
+								Shirt:Clone().Parent = v.Character
+							end
+						end
 					end
 				end
 			end
@@ -5010,18 +5082,68 @@ return function(Vargs, env)
 				local AssetIdType = service.MarketPlace:GetProductInfo(ClothingId).AssetTypeId
 				local Pants = AssetIdType == 12 and service.Insert(ClothingId) or AssetIdType == 1 and Functions.CreateClothingFromImageId("Pants", ClothingId) or error("Item ID passed has invalid item type")
 				assert(Pants, "Unexpected error occured; clothing is missing")
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
-					if v.Character then
-						for g, k in pairs(v.Character:GetChildren()) do
-							if k:IsA("Pants") then k:Destroy() end
-						end
-						--[[local humanoid = plr.Character:FindFirstChildOfClass("Humanoid")
-						local humandescrip = humanoid and humanoid:FindFirstChildOfClass("HumanoidDescription")
 
-						if humandescrip then
-							humandescrip.Pants = ClothingId
-						end]]
-						Pants:Clone().Parent = v.Character
+				local clothingTemplate = "rbxassetid://"..ClothingId
+
+				for i, v in service.GetPlayers(plr, args[1]) do
+					if v.Character then
+						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
+						local bCreateNewDefaultClothing = false
+
+						if (humanoid) then
+							local humanoidAppliedDesc = humanoid:GetAppliedDescription()
+							if (humanoidAppliedDesc) then
+								-- Check if the player already has a specified clothing instance.
+								local prePlayerPants = v.Character:FindFirstChildOfClass("Pants")
+
+								-- If the character has the specified clothing.
+								if (prePlayerPants) then
+									-- Check the humanoid description for clothing ID.
+									if (humanoidAppliedDesc.Pants == 0) then
+										-- Remove all the specified clothings, assuming it was manually created.
+										for k,v in v.Character:GetChildren() do
+											if (v:IsA("Pants")) then
+												v:Destroy()
+											end
+										end
+
+										bCreateNewDefaultClothing = true
+									end
+								else -- If the specified clothing was not found.
+									if (humanoidAppliedDesc.Pants == 0) then
+										bCreateNewDefaultClothing = true
+									else
+										-- If there was ment to be a specified clothing, but it doesn't exist anymore,
+										-- then just create a default clothing as well.
+										bCreateNewDefaultClothing = true
+									end
+								end
+
+
+								if (bCreateNewDefaultClothing) then
+									-- Set a new specified clothing.
+									local humDescClone = humanoidAppliedDesc:Clone()
+
+									-- Default Pants ID 855782781, given when no valid pants was set with HumanoidDescription
+									humDescClone.Pants = 855782781 -- Default pants
+									v.Character.Humanoid:ApplyDescription(humDescClone)
+									humDescClone:Destroy()
+								end
+
+								-- Set the specified clothing.
+								local playerPantsInstance = v.Character:FindFirstChildOfClass("Pants")
+
+								if (playerPantsInstance) then
+									playerPantsInstance.PantsTemplate = clothingTemplate
+								else
+									-- Incase something went wrong
+									Pants:Clone().Parent = v.Character
+								end
+							else 
+								-- If no HumanoidDescription
+								Pants:Clone().Parent = v.Character
+							end
+						end
 					end
 				end
 			end
@@ -5056,7 +5178,7 @@ return function(Vargs, env)
 					error("Invalid face(Image/robloxFace)", 0)
 				end
 
-				for i, v in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local Head = v.Character and v.Character:FindFirstChild("Head")
 					local face = Head and Head:FindFirstChild("face")
 
@@ -5130,7 +5252,7 @@ return function(Vargs, env)
 					[72] = Enum.AccessoryType.DressSkirt,
 				}
 
-				for _, v: Player in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v: Player in service.GetPlayers(plr, args[1]) do
 					local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
@@ -5167,7 +5289,7 @@ return function(Vargs, env)
 			Description = "Remove any t-shirt(s) worn by the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 						if humanoid then
@@ -5187,7 +5309,7 @@ return function(Vargs, env)
 			Description = "Remove any shirt(s) worn by the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})
-				for _, v: Player in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v: Player in service.GetPlayers(plr, args[1]) do
 					local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
@@ -5205,7 +5327,7 @@ return function(Vargs, env)
 			Description = "Remove any pants(s) worn by the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})
-				for _, v: Player in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v: Player in service.GetPlayers(plr, args[1]) do
 					local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
@@ -5232,7 +5354,7 @@ return function(Vargs, env)
 				local pitch = 1 --tonumber(args[4]) or 1
 				local loop = true
 
-				for i, v in pairs(Variables.MusicList) do
+				for i, v in Variables.MusicList do
 					if id==string.lower(v.Name) then
 						id = v.ID
 						if v.Pitch then
@@ -5245,7 +5367,7 @@ return function(Vargs, env)
 				end
 
 				if #HTTP.Trello.Music ~= 0 then
-					for i, v in pairs(HTTP.Trello.Music) do
+					for i, v in HTTP.Trello.Music do
 						if id==string.lower(v.Name) then
 							id = v.ID
 							if v.Pitch then
@@ -5263,7 +5385,7 @@ return function(Vargs, env)
 				pitch = tonumber(args[4]) or pitch
 
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "PlayAudio", id, volume, pitch, loop)
 
 				end
@@ -5278,7 +5400,7 @@ return function(Vargs, env)
 			Description = "Stops audio playing on the specified player's client";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string}, data: {})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "StopAudio", "all")
 
 				end
@@ -5317,7 +5439,7 @@ return function(Vargs, env)
 					SoundId = "rbxassetid://"..args[2];
 				})
 
-				for i, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local char = v.Character
 					local rootPart = char and char:FindFirstChild("HumanoidRootPart")
 					if rootPart then
@@ -5343,7 +5465,7 @@ return function(Vargs, env)
 			Description = "Removes audio placed into character via "..Settings.Prefix.."charaudio command";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local char = v.Character
 					local rootPart = char and char:FindFirstChild("HumanoidRootPart")
 					if rootPart then
@@ -5364,7 +5486,7 @@ return function(Vargs, env)
 			Description = "Pauses the current playing song";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string}, data: {})
-				for i, v in ipairs(workspace:GetChildren()) do
+				for i, v in workspace:GetChildren() do
 					if v.Name=="ADONIS_SOUND" then
 						if v.IsPaused == false then
 							v:Pause()
@@ -5385,7 +5507,7 @@ return function(Vargs, env)
 			Description = "Resumes the current playing song";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string}, data: {})
-				for i, v in ipairs(workspace:GetChildren()) do
+				for i, v in workspace:GetChildren() do
 					if v.Name=="ADONIS_SOUND" then
 						if v.IsPaused == true then
 							v:Resume()
@@ -5407,7 +5529,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local pitch = args[1]
-				for i, v in ipairs(workspace:GetChildren()) do
+				for i, v in workspace:GetChildren() do
 					if v.Name=="ADONIS_SOUND" then
 						if string.sub(args[1], 1, 1) == "+" then
 							v.Pitch=v.Pitch+tonumber(string.sub(args[1], 2))
@@ -5431,7 +5553,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local volume = tonumber(args[1])
 				assert(volume, "Volume must be a valid number")
-				for i, v in ipairs(workspace:GetChildren()) do
+				for i, v in workspace:GetChildren() do
 					if v.Name=="ADONIS_SOUND" then
 						if string.sub(args[1], 1, 1) == "+" then
 							v.Volume=v.Volume+tonumber(string.sub(args[1], 2))
@@ -5526,7 +5648,7 @@ return function(Vargs, env)
 						looped = true
 					end
 
-					for i, v in pairs(Variables.MusicList) do
+					for i, v in Variables.MusicList do
 						if id == string.lower(v.Name) then
 							id = v.ID
 
@@ -5539,7 +5661,7 @@ return function(Vargs, env)
 						end
 					end
 
-					for i, v in pairs(HTTP.Trello.Music) do
+					for i, v in HTTP.Trello.Music do
 						if id == string.lower(v.Name) then
 							id = v.ID
 
@@ -5565,7 +5687,7 @@ return function(Vargs, env)
 						Functions.Hint(name, service.GetPlayers())
 					end
 
-					for i, v in ipairs(workspace:GetChildren()) do
+					for i, v in workspace:GetChildren() do
 						if v.ClassName == "Sound" and v.Name == "ADONIS_SOUND" then
 							if v.IsPaused == true then
 								local ans,event = Remote.GetGui(plr, "YesNoPrompt", {
@@ -5593,7 +5715,7 @@ return function(Vargs, env)
 					wait(0.5)
 					s:Play()
 				elseif id == "off" or id == "0" then
-					for i, v in ipairs(workspace:GetChildren()) do
+					for i, v in workspace:GetChildren() do
 						if v.ClassName == "Sound" and v.Name == "ADONIS_SOUND" then
 							v:Destroy()
 						end
@@ -5609,7 +5731,7 @@ return function(Vargs, env)
 			Description = "Stop the currently playing song";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in ipairs(workspace:GetChildren()) do
+				for i, v in workspace:GetChildren() do
 					if v.Name=="ADONIS_SOUND" then
 						v:Destroy()
 					end
@@ -5625,9 +5747,9 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local tab = {}
-				for _, v in pairs(Variables.MusicList) do table.insert(tab, v) end
-				for _, v in pairs(HTTP.Trello.Music) do table.insert(tab, v) end
-				for i, v in pairs(tab) do
+				for _, v in Variables.MusicList do table.insert(tab, v) end
+				for _, v in HTTP.Trello.Music do table.insert(tab, v) end
+				for i, v in tab do
 					tab[i] = {Text = v.Name .." - "..v.ID; Desc = v.ID;}
 				end
 				Remote.MakeGui(plr, "List", {Title = "Music List", Table = tab, TextSelectable = true})
@@ -5656,7 +5778,7 @@ return function(Vargs, env)
 
 				scr.Name = "ADONIS_FLIGHT"
 
-				for i, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local part = v.Character:FindFirstChild("HumanoidRootPart")
 					if part then
 						local oldp = part:FindFirstChild("ADONIS_FLIGHT_POSITION")
@@ -5701,7 +5823,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local speed = tonumber(args[2])
 
-				for i, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					local part = v.Character:FindFirstChild("HumanoidRootPart")
 					if part then
 						local scr = part:FindFirstChild("ADONIS_FLIGHT")
@@ -5730,7 +5852,7 @@ return function(Vargs, env)
 			Description = "Removes the target player(s)'s ability to fly";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local part = v.Character:FindFirstChild("HumanoidRootPart")
 					if part then
 						local oldp = part:FindFirstChild("ADONIS_FLIGHT_POSITION")
@@ -5751,7 +5873,7 @@ return function(Vargs, env)
 			Description = "Fling the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						if v.Character and v.Character:FindFirstChild("HumanoidRootPart") and v.Character:FindFirstChild("Humanoid") then
 							local xran local zran
@@ -5780,7 +5902,7 @@ return function(Vargs, env)
 				local scr = Deps.Assets.Sfling:Clone()
 				scr.Strength.Value = strength
 				scr.Name = "SUPER_FLING"
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local new = scr:Clone()
 					new.Parent = v.Character.HumanoidRootPart
 					new.Disabled = false
@@ -5802,7 +5924,7 @@ return function(Vargs, env)
 				if service.RunService:IsStudio() then
 					table.insert(temp, {Text="!! The string has not been filtered !!", Desc="Text filtering does not work in studio"})
 				end
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					table.insert(temp, {Text = "-- "..v.DisplayName.." --", Desc = v.UserId.." ("..v.Name..")"})
 					table.insert(temp, {Text = "ChatForUser: "..service.TextService:FilterStringAsync(args[2], v.UserId):GetChatForUserAsync(v.UserId)})
 					table.insert(temp, {Text = "NonChatForBroadcast: "..service.TextService:FilterStringAsync(args[2], v.UserId):GetNonChatStringForBroadcastAsync()})
@@ -5821,7 +5943,7 @@ return function(Vargs, env)
 			Description = "Name the target player(s) <name> or say hide to hide their character name";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local char = v.Character;
 					local human = char and char:FindFirstChildOfClass("Humanoid");
 					if human then
@@ -5852,7 +5974,7 @@ return function(Vargs, env)
 			Description = "Put the target player(s)'s back to normal";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local char = v.Character;
 					local human = char and char:FindFirstChildOfClass("Humanoid");
 					if human then
@@ -5875,9 +5997,9 @@ return function(Vargs, env)
 			Description = "Name the target player(s) <name> or say hide to hide their character name";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("Head") then
-						for a, mod in pairs(v.Character:GetChildren()) do
+						for a, mod in v.Character:GetChildren() do
 							if mod:FindFirstChild("NameTag") then
 								v.Character.Head.Transparency = 0
 								mod:Destroy()
@@ -5923,9 +6045,9 @@ return function(Vargs, env)
 			Description = "Put the target player(s)'s back to normal";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("Head") then
-						for a, mod in pairs(v.Character:GetChildren()) do
+						for a, mod in v.Character:GetChildren() do
 							if mod:FindFirstChild("NameTag") then
 								v.Character.Head.Transparency = 0
 								mod:Destroy()
@@ -5943,13 +6065,13 @@ return function(Vargs, env)
 			Description = "Removes the target player(s)'s Package";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if v.Character then
 						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
 						if humanoid then
 							local rigType = humanoid.RigType
 							if rigType == Enum.HumanoidRigType.R6 then
-								for _, x in pairs(v.Character:GetChildren()) do
+								for _, x in v.Character:GetChildren() do
 									if x:IsA("CharacterMesh") then
 										x:Destroy()
 									end
@@ -5958,10 +6080,10 @@ return function(Vargs, env)
 								local rig = Deps.Assets.RigR15
 								local rigHumanoid = rig.Humanoid
 								local validParts = {}
-								for _, x in pairs(Enum.BodyPartR15:GetEnumItems()) do
+								for _, x in Enum.BodyPartR15:GetEnumItems() do
 									validParts[x.Name] = x.Value
 								end
-								for _, x in pairs(rig:GetChildren()) do
+								for _, x in rig:GetChildren() do
 									if x:IsA("BasePart") and validParts[x.Name] then
 										humanoid:ReplaceBodyPartR15(validParts[x.Name], x:Clone())
 									end
@@ -5996,7 +6118,7 @@ return function(Vargs, env)
 					local suc,ers = pcall(function() return service.AssetService:GetBundleDetailsAsync(id) end)
 
 					if suc then
-						for _, item in pairs(ers.Items) do
+						for _, item in ers.Items do
 							if item.Type == "UserOutfit" then
 								local s, r = pcall(function() return service.Players:GetHumanoidDescriptionFromOutfitId(item.Id) end)
 								Variables.BundleCache[id] = r
@@ -6014,7 +6136,7 @@ return function(Vargs, env)
 					end
 				end
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local char = v.Character
 
 					if char then
@@ -6025,7 +6147,7 @@ return function(Vargs, env)
 						else
 							local newDescription = humanoid:GetAppliedDescription()
 							local defaultDescription = Instance.new("HumanoidDescription")
-							for _, property in ipairs({"BackAccessory", "BodyTypeScale", "ClimbAnimation", "DepthScale", "Face", "FaceAccessory", "FallAnimation", "FrontAccessory", "GraphicTShirt", "HairAccessory", "HatAccessory", "Head", "HeadColor", "HeadScale", "HeightScale", "IdleAnimation", "JumpAnimation", "LeftArm", "LeftArmColor", "LeftLeg", "LeftLegColor", "NeckAccessory", "Pants", "ProportionScale", "RightArm", "RightArmColor", "RightLeg", "RightLegColor", "RunAnimation", "Shirt", "ShouldersAccessory", "SwimAnimation", "Torso", "TorsoColor", "WaistAccessory", "WalkAnimation", "WidthScale"}) do
+							for _, property in {"BackAccessory", "BodyTypeScale", "ClimbAnimation", "DepthScale", "Face", "FaceAccessory", "FallAnimation", "FrontAccessory", "GraphicTShirt", "HairAccessory", "HatAccessory", "Head", "HeadColor", "HeadScale", "HeightScale", "IdleAnimation", "JumpAnimation", "LeftArm", "LeftArmColor", "LeftLeg", "LeftLegColor", "NeckAccessory", "Pants", "ProportionScale", "RightArm", "RightArmColor", "RightLeg", "RightLegColor", "RunAnimation", "Shirt", "ShouldersAccessory", "SwimAnimation", "Torso", "TorsoColor", "WaistAccessory", "WalkAnimation", "WidthScale"} do
 								if assetHD[property] ~= defaultDescription[property] then
 									newDescription[property] = assetHD[property]
 								end
@@ -6063,7 +6185,7 @@ return function(Vargs, env)
 					local success, desc = pcall(service.Players.GetHumanoidDescriptionFromUserId, service.Players, target)
 
 					if success then
-						for _, v in pairs(service.GetPlayers(plr, args[1])) do
+						for _, v in service.GetPlayers(plr, args[1]) do
 							v.CharacterAppearanceId = target
 
 							if v.Character and v.Character:FindFirstChildOfClass("Humanoid") then
@@ -6084,7 +6206,7 @@ return function(Vargs, env)
 			Description = "Put the target player(s)'s character appearence back to normal";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Routine(function()
 						v.CharacterAppearanceId = v.UserId
 
@@ -6111,7 +6233,7 @@ return function(Vargs, env)
 			Description = "Continuously heals the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					task.defer(function()
 						service.StartLoop(v.UserId .. "LOOPHEAL", 0.1, function()
 							if not v or v.Parent ~= service.Players then
@@ -6138,7 +6260,7 @@ return function(Vargs, env)
 			Description = "Undoes "..Settings.Prefix.."loopheal";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					service.StopLoop(v.UserId.."LOOPHEAL")
 				end
 			end
@@ -6161,7 +6283,7 @@ return function(Vargs, env)
 				local logHistory: {{message: string, messageType: Enum.MessageType, timestamp: number}} = service.LogService:GetLogHistory()
 				for i = #logHistory, 1, -1 do
 					local log = logHistory[i]
-					for i, v in ipairs(service.ExtractLines(log.message)) do
+					for i, v in service.ExtractLines(log.message) do
 						table.insert(tab, {
 							Text = v;
 							Time = if i == 1 then log.timestamp else nil;
@@ -6196,7 +6318,7 @@ return function(Vargs, env)
 				return if target and target.Parent then Remote.Get(target, "ClientLog") else {"Player is currently unreachable"}
 			end;
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(plr, "List", {
 						Title = service.FormatPlayer(v).."'s Local Log";
 						Table = Logs.ListUpdaters.LocalLog(plr, v);
@@ -6219,7 +6341,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			ListUpdater = function(plr: Player)
 				local tab = {}
-				for i, v in ipairs(Logs.Errors) do
+				for i, v in Logs.Errors do
 					tab[i] = {
 						Time = v.Time;
 						Text = v.Text..": "..tostring(v.Desc);
@@ -6366,7 +6488,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			ListUpdater = function(plr: Player)
 				local tab = {}
-				for i, v in ipairs(Logs.Commands) do
+				for i, v in Logs.Commands do
 					tab[i] = {
 						Time = v.Time;
 						Text = v.Text..": "..v.Desc;
@@ -6399,7 +6521,7 @@ return function(Vargs, env)
 					local tab = {}
 					local data = Core.GetData("OldCommandLogs")
 					if data then
-						for i, v in ipairs(data) do
+						for i, v in data do
 							tab[i] = {
 								Time = v.Time;
 								Text = v.Text..": "..v.Desc;
@@ -6435,7 +6557,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local str = Settings.Prefix.."logs"..(args[2] or "")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Admin.RunCommandAsPlayer(str, v)
 				end
 			end
@@ -6448,11 +6570,11 @@ return function(Vargs, env)
 			Description = "Makes it so the target player(s) can't talk";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string}, data: {})
-				for _, v in ipairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					if data.PlayerData.Level > Admin.GetLevel(v) then
 						--Remote.LoadCode(v,[[service.StarterGui:SetCoreGuiEnabled("Chat", false) client.Variables.ChatEnabled = false client.Variables.Muted = true]])
 						local check = true
-						for _, m in pairs(Settings.Muted) do
+						for _, m in Settings.Muted do
 							if Admin.DoCheck(v, m) then
 								check = false
 							end
@@ -6473,8 +6595,8 @@ return function(Vargs, env)
 			Description = "Makes it so the target player(s) can talk again. No effect if on Trello mute list.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
-					for k, m in pairs(Settings.Muted) do
+				for _, v in service.GetPlayers(plr, args[1]) do
+					for k, m in Settings.Muted do
 						if Admin.DoCheck(v, m) then
 							table.remove(Settings.Muted, k)
 							--Remote.LoadCode(v,[[if not client.Variables.CustomChat then service.StarterGui:SetCoreGuiEnabled("Chat", true) client.Variables.ChatEnabled = false end client.Variables.Muted = true]])
@@ -6492,10 +6614,10 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local list = {}
-				for _, v in pairs(Settings.Muted) do
+				for _, v in Settings.Muted do
 					table.insert(list, v)
 				end
-				for _, v in pairs(HTTP.Trello.Mutes) do
+				for _, v in HTTP.Trello.Mutes do
 					table.insert(list, "[Trello] "..v)
 				end
 				Remote.MakeGui(plr, "List", {Title = "Mute List"; Table = list;})
@@ -6509,7 +6631,7 @@ return function(Vargs, env)
 			Description = "Makes it so the target player(s)'s cam can move around freely (Press Space or Shift+P to toggle freecam)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local plrgui = v:FindFirstChildOfClass("PlayerGui")
 
 					if not plrgui or plrgui:FindFirstChild("Freecam") then
@@ -6539,7 +6661,7 @@ return function(Vargs, env)
 			Description = "UnFreecam";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local plrgui = v:FindFirstChildOfClass("PlayerGui")
 					local freecam = plrgui and plrgui:FindFirstChild("Freecam")
 					if freecam then
@@ -6569,7 +6691,7 @@ return function(Vargs, env)
 			Description = "Toggles Freecam";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					local plrgui = v:FindFirstChildOfClass("PlayerGui")
 					local freecam = plrgui and plrgui:FindFirstChild("Freecam")
 					if freecam then
@@ -6676,7 +6798,7 @@ return function(Vargs, env)
 					end
 				end
 
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					makeBot(v)
 				end
 			end
@@ -6690,7 +6812,7 @@ return function(Vargs, env)
 			Description = "[Experimental] Says aloud the supplied text";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "TextToSpeech", args[2])
 				end
 			end
@@ -6713,7 +6835,7 @@ return function(Vargs, env)
 
 					local tab = {}
 					table.insert(tab, {Text = "Note: Argument is CASE SENSITIVE"})
-					for _, v in pairs(reverbs) do
+					for _, v in reverbs do
 						table.insert(tab, {Text = v.Name})
 					end
 					Remote.MakeGui(plr, "List", {Title = "Reverbs"; Table = tab;})
@@ -6722,7 +6844,7 @@ return function(Vargs, env)
 				end
 
 				if args[2] then
-					for _, v in pairs(service.GetPlayers(plr, args[2])) do
+					for _, v in service.GetPlayers(plr, args[2]) do
 						Remote.LoadCode(v, "game:GetService(\"SoundService\").AmbientReverb = Enum.ReverbType["..rev.."]")
 					end
 
@@ -6744,7 +6866,7 @@ return function(Vargs, env)
 				assert(args[1], "Missing target player")
 				args[2] = string.lower(assert(args[2], "Missing argument #2 (boolean expected)"))
 				assert(args[2] == "true" or args[2] == "false", "Invalid argument #2 (boolean expected)")
-				for _, v in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "SetCore", "ResetButtonCallback", if args[2] == "true" then true else false)
 				end
 			end
@@ -6770,7 +6892,7 @@ return function(Vargs, env)
 					{"PhysicsStepTimeMs"; "How long it takes for the physics engine to update its current state, in milliseconds"},
 					{"PrimitivesCount"; "How many physically simulated components currently exist in the game world"},
 				};
-				for _, v in ipairs(perfStats) do
+				for _, v in perfStats do
 					table.insert(tab, {Text = v[1]..": "..tostring(service.Stats[v[1]]):sub(1, 7); Desc = v[2];})
 				end
 				return tab
@@ -6801,7 +6923,7 @@ return function(Vargs, env)
 					"# Players: "..#players,
 					"―――――――――――――――――――――――",
 				}
-				for _, v: Player in pairs(players) do
+				for _, v: Player in players do
 					table.insert(tab, {
 						Text = service.FormatPlayer(v);
 						Desc = "ID: "..v.UserId;

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -4936,19 +4936,19 @@ return function(Vargs, env)
 						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
 						local bCreateNewDefaultClothing = false
 
-						if (humanoid) then
+						if humanoid then
 							local humanoidAppliedDesc = humanoid:GetAppliedDescription()
-							if (humanoidAppliedDesc) then
+							if humanoidAppliedDesc then
 								-- Check if the player already has a specified clothing instance.
 								local prePlayerShirtGraphic = v.Character:FindFirstChildOfClass("ShirtGraphic")
 
 								-- If the character has the specified clothing.
-								if (prePlayerShirtGraphic) then
+								if prePlayerShirtGraphic then
 									-- Check the humanoid description for clothing ID.
-									if (humanoidAppliedDesc.GraphicTShirt == 0) then
+									if humanoidAppliedDesc.GraphicTShirt == 0 then
 										-- Remove all the specified clothings, assuming it was manually created.
-										for k,v in v.Character:GetChildren() do
-											if (v:IsA("ShirtGraphic")) then
+										for _, v in v.Character:GetChildren() do
+											if v:IsA("ShirtGraphic") then
 												v:Destroy()
 											end
 										end
@@ -4956,7 +4956,7 @@ return function(Vargs, env)
 										bCreateNewDefaultClothing = true
 									end
 								else -- If the specified clothing was not found.
-									if (humanoidAppliedDesc.GraphicTShirt == 0) then
+									if humanoidAppliedDesc.GraphicTShirt == 0 then
 										bCreateNewDefaultClothing = true
 									else
 										-- If there was ment to be a specified clothing, but it doesn't exist anymore,
@@ -4966,7 +4966,7 @@ return function(Vargs, env)
 								end
 
 
-								if (bCreateNewDefaultClothing) then
+								if bCreateNewDefaultClothing then
 									-- Set a new specified clothing.
 									local humDescClone = humanoidAppliedDesc:Clone()
 
@@ -4978,7 +4978,7 @@ return function(Vargs, env)
 								-- Set the specified clothing.
 								local playerShirtGraphicInstance = v.Character:FindFirstChildOfClass("ShirtGraphic")
 
-								if (playerShirtGraphicInstance) then
+								if playerShirtGraphicInstance then
 									playerShirtGraphicInstance.Graphic = clothingTemplate
 								else
 									-- Incase something went wrong
@@ -5013,19 +5013,19 @@ return function(Vargs, env)
 						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
 						local bCreateNewDefaultClothing = false
 
-						if (humanoid) then
+						if humanoid then
 							local humanoidAppliedDesc = humanoid:GetAppliedDescription()
-							if (humanoidAppliedDesc) then
+							if humanoidAppliedDesc then
 								-- Check if the player already has a specified clothing instance.
 								local prePlayerShirt = v.Character:FindFirstChildOfClass("Shirt")
 
 								-- If the character has the specified clothing.
-								if (prePlayerShirt) then
+								if prePlayerShirt then
 									-- Check the humanoid description for clothing ID.
-									if (humanoidAppliedDesc.Shirt == 0) then
+									if humanoidAppliedDesc.Shirt == 0 then
 										-- Remove all the specified clothings, assuming it was manually created.
-										for k,v in v.Character:GetChildren() do
-											if (v:IsA("Shirt")) then
+										for _, v in v.Character:GetChildren() do
+											if v:IsA("Shirt") then
 												v:Destroy()
 											end
 										end
@@ -5033,7 +5033,7 @@ return function(Vargs, env)
 										bCreateNewDefaultClothing = true
 									end
 								else -- If the specified clothing was not found.
-									if (humanoidAppliedDesc.Shirt == 0) then
+									if humanoidAppliedDesc.Shirt == 0 then
 										bCreateNewDefaultClothing = true
 									else
 										-- If there was ment to be a specified clothing, but it doesn't exist anymore,
@@ -5043,7 +5043,7 @@ return function(Vargs, env)
 								end
 
 
-								if (bCreateNewDefaultClothing) then
+								if bCreateNewDefaultClothing then
 									-- Set a new specified clothing.
 									local humDescClone = humanoidAppliedDesc:Clone()
 
@@ -5056,7 +5056,7 @@ return function(Vargs, env)
 								-- Set the specified clothing.
 								local playerShirtInstance = v.Character:FindFirstChildOfClass("Shirt")
 
-								if (playerShirtInstance) then
+								if playerShirtInstance then
 									playerShirtInstance.ShirtTemplate = clothingTemplate
 								else
 									-- Incase something went wrong
@@ -5091,19 +5091,19 @@ return function(Vargs, env)
 						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
 						local bCreateNewDefaultClothing = false
 
-						if (humanoid) then
+						if humanoid then
 							local humanoidAppliedDesc = humanoid:GetAppliedDescription()
-							if (humanoidAppliedDesc) then
+							if humanoidAppliedDesc then
 								-- Check if the player already has a specified clothing instance.
 								local prePlayerPants = v.Character:FindFirstChildOfClass("Pants")
 
 								-- If the character has the specified clothing.
-								if (prePlayerPants) then
+								if prePlayerPants then
 									-- Check the humanoid description for clothing ID.
-									if (humanoidAppliedDesc.Pants == 0) then
+									if humanoidAppliedDesc.Pants == 0 then
 										-- Remove all the specified clothings, assuming it was manually created.
-										for k,v in v.Character:GetChildren() do
-											if (v:IsA("Pants")) then
+										for _, v in v.Character:GetChildren() do
+											if v:IsA("Pants") then
 												v:Destroy()
 											end
 										end
@@ -5111,7 +5111,7 @@ return function(Vargs, env)
 										bCreateNewDefaultClothing = true
 									end
 								else -- If the specified clothing was not found.
-									if (humanoidAppliedDesc.Pants == 0) then
+									if humanoidAppliedDesc.Pants == 0 then
 										bCreateNewDefaultClothing = true
 									else
 										-- If there was ment to be a specified clothing, but it doesn't exist anymore,
@@ -5121,7 +5121,7 @@ return function(Vargs, env)
 								end
 
 
-								if (bCreateNewDefaultClothing) then
+								if bCreateNewDefaultClothing then
 									-- Set a new specified clothing.
 									local humDescClone = humanoidAppliedDesc:Clone()
 
@@ -5134,7 +5134,7 @@ return function(Vargs, env)
 								-- Set the specified clothing.
 								local playerPantsInstance = v.Character:FindFirstChildOfClass("Pants")
 
-								if (playerPantsInstance) then
+								if playerPantsInstance then
 									playerPantsInstance.PantsTemplate = clothingTemplate
 								else
 									-- Incase something went wrong

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -23,7 +23,7 @@ return function(Vargs, env)
 				local tab = {}
 				local cmdCount = 0
 
-				for _, cmd in pairs(Admin.SearchCommands(plr, "all")) do
+				for _, cmd in Admin.SearchCommands(plr, "all") do
 					if cmd.Hidden or cmd.Disabled then
 						continue
 					end
@@ -37,7 +37,7 @@ return function(Vargs, env)
 					cmdCount += 1
 				end
 
-				for alias, command in pairs(Core.GetPlayer(plr).Aliases or {}) do
+				for alias, command in Core.GetPlayer(plr).Aliases or {} do
 					table.insert(tab, {
 						Text = alias,
 						Desc = "[User Alias] "..command,
@@ -71,8 +71,8 @@ return function(Vargs, env)
 				assert(args[1], "No command provided")
 
 				local cmd, ind
-				for i, v in pairs(Admin.SearchCommands(plr, "all")) do
-					for _, p in ipairs(v.Commands) do
+				for i, v in Admin.SearchCommands(plr, "all") do
+					for _, p in v.Commands do
 						if (v.Prefix or "")..string.lower(p) == string.lower(args[1]) then
 							cmd, ind = v, i
 							break
@@ -87,7 +87,7 @@ return function(Vargs, env)
 				local cmdArgs = Admin.FormatCommandArguments(cmd)
 
 				local cmdAttribs = {}
-				for _, key in ipairs({"Disabled", "Fun", "Hidden", "NoStudio", "NonChattable", "CrossServerDenied", "AllowDonors"}) do
+				for _, key in {"Disabled", "Fun", "Hidden", "NoStudio", "NonChattable", "CrossServerDenied", "AllowDonors"} do
 					if cmd[key] then
 						table.insert(cmdAttribs, key)
 					end
@@ -212,7 +212,7 @@ return function(Vargs, env)
 				end
 				table.sort(brickColorNames)
 
-				for i, bc in ipairs(brickColorNames) do
+				for i, bc in brickColorNames do
 					bc = BrickColor.new(bc)
 					table.insert(children, {
 						Class = "TextLabel";
@@ -259,7 +259,7 @@ return function(Vargs, env)
 					--, "Rock", "Glacier", "Snow", "Sandstone", "Mud", "Basalt", "Ground", "CrackedLava", "Asphalt", "LeafyGrass", "Salt", "Limestone", "Pavement"
 					--Beta Features Materials
 				}
-				for i, mat in ipairs(mats) do
+				for i, mat in mats do
 					mats[i] = {Text = mat; Desc = "Enum value: "..Enum.Material[mat].Value}
 				end
 				Remote.MakeGui(plr, "List", {Title = "Materials"; Tab = mats;})
@@ -329,7 +329,7 @@ return function(Vargs, env)
 			AdminLevel = "Players";
 			ListUpdater = function(plr: Player)
 				local tab = {}
-				for _, v in ipairs(service.Players:GetPlayers()) do
+				for _, v in service.Players:GetPlayers() do
 					if not Variables.IncognitoPlayers[v] and Admin.CheckDonor(v) then
 						table.insert(tab, service.FormatPlayer(v))
 					end
@@ -379,7 +379,7 @@ return function(Vargs, env)
 
 							Variables.HelpRequests[plr.Name] = pending;
 
-							for ind, p in ipairs(service.Players:GetPlayers()) do
+							for ind, p in service.Players:GetPlayers() do
 								Routine(function()
 									if Admin.CheckAdmin(p) then
 										local ret = Remote.MakeGuiGet(p, "Notification", {
@@ -484,7 +484,7 @@ return function(Vargs, env)
 				assert(#args[1] <= 20 and args[1]:match("^[%a%d_]+$"), "Invalid username provided")
 				local success, userId = pcall(service.Players.GetUserIdFromNameAsync, service.Players, args[1])
 				if success and userId then
-					for _, v in ipairs(plr:GetFriendsOnline()) do
+					for _, v in plr:GetFriendsOnline() do
 						if v.VisitorId == userId then
 							if v.IsOnline and v.PlaceId and v.GameId then
 								service.TeleportService:TeleportAsync(v.PlaceId, {plr})
@@ -717,7 +717,7 @@ return function(Vargs, env)
 			Hidden = true;
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
-				for _, v: Player in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v: Player in service.GetPlayers(plr, args[1]) do
 					assert(v ~= plr, "Cannot friend yourself!")
 					assert(not plr:IsFriendsWith(v.UserId), "You are already friends with "..v.Name)
 					Remote.Send(plr, "Function", "SetCore", "PromptSendFriendRequest", v)
@@ -733,7 +733,7 @@ return function(Vargs, env)
 			Hidden = true;
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
-				for i, v: Player in pairs(service.GetPlayers(plr, args[1])) do
+				for i, v: Player in service.GetPlayers(plr, args[1]) do
 					assert(v ~= plr, "Cannot unfriend yourself!")
 					assert(plr:IsFriendsWith(v.UserId), "You are not currently friends with "..v.Name)
 					Remote.Send(plr, "Function", "SetCore", "PromptUnfriend", v)
@@ -748,7 +748,7 @@ return function(Vargs, env)
 			Description = "Opens the Roblox avatar inspect menu for the specified player";
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
-				for _, v: Player in pairs(service.GetPlayers(plr, args[1])) do
+				for _, v: Player in service.GetPlayers(plr, args[1]) do
 					Remote.LoadCode(plr, "service.GuiService:InspectPlayerFromUserId("..v.UserId..")")
 				end
 			end
@@ -774,7 +774,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local num = 0
 				local nilNum = 0
-				for _, v in ipairs(service.GetPlayers()) do
+				for _, v in service.GetPlayers() do
 					if v.Parent ~= service.Players then
 						nilNum += 1
 					end
@@ -815,7 +815,7 @@ return function(Vargs, env)
 					{"Day of the month"; os.date("%d", ostime)},
 					{Text = "―――――――――――――――――――――――"},
 				}
-				for i, v in ipairs(tab) do
+				for i, v in tab do
 					if not v[2] then continue end
 					tab[i] = {Text = "<b>"..v[1]..":</b> "..v[2]; Desc = v[2];}
 				end
@@ -863,7 +863,7 @@ return function(Vargs, env)
 					Functions.Hint(string.format("Loading profile data for %d players... [This may take a while]", #players), {plr})
 				end
 
-				for _, v: Player in pairs(players) do
+				for _, v: Player in players do
 					task.defer(function()
 						local gameData
 
@@ -874,7 +874,7 @@ return function(Vargs, env)
 								AdminLevel = "[".. level .."] ".. (rank or "Unknown");
 								SourcePlaceId = v:GetJoinData().SourcePlaceId or "N/A";
 							}
-							for k, d in pairs(Remote.Get(v, "Function", "GetUserInputServiceData")) do
+							for k, d in Remote.Get(v, "Function", "GetUserInputServiceData") do
 								gameData[k] = d
 							end
 						end
@@ -911,7 +911,7 @@ return function(Vargs, env)
 				local data = {}
 
 				local donorList = {}
-				for _, v in ipairs(service.GetPlayers()) do
+				for _, v in service.GetPlayers() do
 					if not Variables.IncognitoPlayers[v] and Admin.CheckDonor(v) then
 						table.insert(donorList, v.Name)
 					end
@@ -920,14 +920,14 @@ return function(Vargs, env)
 				local adminDictionary, workspaceInfo
 				if elevated then
 					adminDictionary = {}
-					for _, v in ipairs(service.GetPlayers()) do
+					for _, v in service.GetPlayers() do
 						local level, rank = Admin.GetLevel(v)
 						if level > 0 then
 							adminDictionary[v.Name] = rank or "Unknown"
 						end
 					end
 					local nilPlayers = 0
-					for _, v in ipairs(service.NetworkServer:GetChildren()) do
+					for _, v in service.NetworkServer:GetChildren() do
 						if v and v:GetPlayer() and not service.Players:FindFirstChild(v:GetPlayer().Name) then
 							nilPlayers += 1
 						end
@@ -989,13 +989,13 @@ return function(Vargs, env)
 					if groupInfo.Owner then string.format("Owner: %s [%d]", groupInfo.Owner.Name or "???", groupInfo.Owner.Id) else "[No Owner]",
 					{Text = string.format("――― Roles (%d): ―――――――――――――――――", #groupInfo.Roles)},
 				}
-				for _, role in ipairs(groupInfo.Roles) do
+				for _, role in groupInfo.Roles do
 					table.insert(tab, string.format("[%d] %s", role.Rank, role.Name))
 				end
 
 				local function getPageItems(pages: StandardPages, res: {any})
 					res = res or {}
-					for _, item in ipairs(pages:GetCurrentPage()) do
+					for _, item in pages:GetCurrentPage() do
 						table.insert(res, item)
 					end
 					if not pages.IsFinished then
@@ -1012,12 +1012,12 @@ return function(Vargs, env)
 					table.insert(tab, {Text = string.format("――― Allies (%d): ―――――――――――――――――", #allies)})
 					if #allies > 0 then
 						local names, refs = {}, {}
-						for _, grp in ipairs(allies) do
+						for _, grp in allies do
 							table.insert(names, grp.Name)
 							refs[grp.Name] = grp
 						end
 						table.sort(names)
-						for _, name in ipairs(names) do
+						for _, name in names do
 							local grp = refs[name]
 							table.insert(tab, {Text = string.format("[#%d] %s", grp.Id, name), Desc = "Owner: "..if grp.Owner then string.format("%s [%d]", grp.Owner.Name or "???", grp.Owner.Id) else "[No Owner]"})
 						end
@@ -1029,12 +1029,12 @@ return function(Vargs, env)
 					table.insert(tab, {Text = string.format("――― Enemies (%d): ―――――――――――――――――", #enemies)})
 					if #enemies > 0 then
 						local names, refs = {}, {}
-						for _, grp in ipairs(enemies) do
+						for _, grp in enemies do
 							table.insert(names, grp.Name)
 							refs[grp.Name] = grp
 						end
 						table.sort(names)
-						for _, name in ipairs(names) do
+						for _, name in names do
 							local grp = refs[name]
 							table.insert(tab, {Text = string.format("[#%d] %s", grp.Id, name), Desc = "Owner: "..if grp.Owner then string.format("%s [%d]", grp.Owner.Name or "???", grp.Owner.Id) else "[No Owner]"})
 						end
@@ -1086,7 +1086,7 @@ return function(Vargs, env)
 			Hidden = true;
 			Function = function(plr: Player, args: {string})
 				local list = {}
-				for code, name in pairs(require(server.Shared.CountryRegionCodes)) do
+				for code, name in require(server.Shared.CountryRegionCodes) do
 					table.insert(list, code.." - "..name)
 				end
 				table.sort(list)

--- a/MainModule/Server/Core/Anti.lua
+++ b/MainModule/Server/Core/Anti.lua
@@ -56,7 +56,7 @@ return function(Vargs, GetEnv)
 			return
 		end
 
-		for _, v in ipairs(service.Players:GetPlayers()) do
+		for _, v in service.Players:GetPlayers() do
 			task.spawn(onPlayerAdded, v)
 		end
 		service.Players.PlayerAdded:Connect(onPlayerAdded)
@@ -129,7 +129,7 @@ return function(Vargs, GetEnv)
 							if handle and handle:CanSetNetworkOwnership() then
 								handle:SetNetworkOwner(nil)
 							end
-							
+
 							Logs.AddLog(Logs.Script, {
 								Text = "AE: Hat joint deletion reset network ownership for player: "..tostring(player);
 								Desc = "The AE reset joint handle network ownership for player: "..tostring(player);
@@ -160,7 +160,7 @@ return function(Vargs, GetEnv)
 			local function onCharacterAdded(character)
 				charGood = true
 
-				for _, v in ipairs(character:GetChildren()) do
+				for _, v in character:GetChildren() do
 					if v:IsA("Accoutrement") and Settings.ProtectHats == true then
 						coroutine.wrap(protectHat)(v)
 					end
@@ -173,13 +173,13 @@ return function(Vargs, GetEnv)
 						local count = 0
 
 						task.defer(function()
-							for _, v in ipairs(character:GetChildren()) do
+							for _, v in character:GetChildren() do
 								if v:IsA("BackpackItem") then
 									count += 1
 									if count > 1 then
 										local backpack = player:FindFirstChildOfClass("Backpack") or Instance.new("Backpack")
 										if not backpack.Parent then
-											backpack.Parent = player 
+											backpack.Parent = player
 										end
 										v.Parent = backpack
 										Detected(player, "log", "Multiple tools equipped at the same time")
@@ -255,7 +255,7 @@ return function(Vargs, GetEnv)
 								return
 							end
 
-							for _, v in ipairs(connections) do
+							for _, v in connections do
 								v:Disconnect()
 							end
 
@@ -302,7 +302,7 @@ return function(Vargs, GetEnv)
 					Desc = "Making sure all clients are active";
 				})
 
-				for ind,p in ipairs(service.Players:GetPlayers()) do
+				for ind,p in service.Players:GetPlayers() do
 					if p and p:IsA("Player") then
 						local key = tostring(p.UserId)
 						local client = Remote.Clients[key]
@@ -346,7 +346,7 @@ return function(Vargs, GetEnv)
 				end
 			end
 		end;
-		
+
 		CheckBackpack = function(p, obj)
 			local ran, err = pcall(function()
 				return p:WaitForChild("Backpack", 60):FindFirstChild(obj)
@@ -417,7 +417,7 @@ return function(Vargs, GetEnv)
 					return
 				end
 
-				for _, plr in ipairs(service.Players:GetPlayers()) do
+				for _, plr in service.Players:GetPlayers() do
 					if Admin.GetLevel(plr) >= Settings.Ranks.Moderators.Level then
 						Remote.MakeGui(plr, "Notification", {
 							Title = "Notification",

--- a/MainModule/Server/Core/Commands.lua
+++ b/MainModule/Server/Core/Commands.lua
@@ -63,7 +63,7 @@ return function(Vargs, GetEnv)
 				return
 			end
 
-			for opt, default in pairs({
+			for opt, default in {
 				Prefix = Settings.Prefix;
 				Commands = {};
 				Description = "(No description)";
@@ -80,7 +80,7 @@ return function(Vargs, GetEnv)
 				Function = function(plr)
 					Remote.MakeGui(plr, "Output", {Message = "No command implementation"})
 				end
-				})
+				}
 			do
 				if cmd[opt] == nil then
 					cmd[opt] = default
@@ -95,7 +95,7 @@ return function(Vargs, GetEnv)
 
 			Admin.PrefixCache[cmd.Prefix] = true
 
-			for _, v in ipairs(cmd.Commands) do
+			for _, v in cmd.Commands do
 				Admin.CommandCache[string.lower(cmd.Prefix..v)] = ind
 			end
 
@@ -105,7 +105,7 @@ return function(Vargs, GetEnv)
 			if type(lvl) == "string" and lvl ~= "Donors" then
 				cmd.AdminLevel = Admin.StringToComLevel(lvl)
 			elseif type(lvl) == "table" then
-				for b, v in ipairs(lvl) do
+				for b, v in lvl do
 					lvl[b] = Admin.StringToComLevel(v)
 				end
 			elseif type(lvl) == "nil" then
@@ -162,12 +162,12 @@ return function(Vargs, GetEnv)
 		--// Load command modules
 		if server.CommandModules then
 			local env = GetEnv()
-			for i, module in ipairs(server.CommandModules:GetChildren()) do
+			for i, module in server.CommandModules:GetChildren() do
 				local func = require(module)
 				local ran, tab = pcall(func, Vargs, env)
 
 				if ran and tab and type(tab) == "table" then
-					for ind, cmd in pairs(tab) do
+					for ind, cmd in tab do
 						Commands[ind] = cmd
 					end
 
@@ -193,7 +193,7 @@ return function(Vargs, GetEnv)
 		local commandEnv = GetEnv(nil, {
 			script = server.Config and server.Config:FindFirstChild("Settings") or script;
 		})
-		for ind, cmd in pairs(Settings.Commands or {}) do
+		for ind, cmd in Settings.Commands or {} do
 			if type(cmd) == "table" and cmd.Function then
 				setfenv(cmd.Function, commandEnv)
 				Commands[ind] = cmd
@@ -202,7 +202,7 @@ return function(Vargs, GetEnv)
 
 		--// Change command permissions based on settings
 		local Trim = service.Trim
-		for ind, cmd in pairs(Settings.Permissions or {}) do
+		for ind, cmd in Settings.Permissions or {} do
 			local com, level = string.match(cmd, "^(.*):(.*)")
 			if com and level then
 				if string.find(level, ",") then
@@ -218,7 +218,7 @@ return function(Vargs, GetEnv)
 			end
 		end
 
-		for ind, cmd in pairs(Commands) do
+		for ind, cmd in Commands do
 			RegisterCommandDefinition(ind, cmd)
 		end
 

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -57,7 +57,7 @@ return function(Vargs, GetEnv)
 		service.DataStoreService = require(Deps.MockDataStoreService)(Settings.LocalDatastore)
 
 		local function disableAllGuis(folder: Folder)
-			for _, v in ipairs(folder:GetChildren()) do
+			for _, v in folder:GetChildren() do
 				if v:IsA("ScreenGui") then
 					v.Enabled = false
 				elseif v:IsA("Folder") or v:IsA("Model") then
@@ -81,7 +81,7 @@ return function(Vargs, GetEnv)
 
 		local remoteParent = service.ReplicatedStorage;
 		remoteParent.ChildRemoved:Connect(function(c)
-			if server.Core.RemoteEvent and not Core.FixingEvent and (function() for i,v in pairs(Core.RemoteEvent) do if c == v then return true end end end)() then
+			if server.Core.RemoteEvent and not Core.FixingEvent and (function() for i,v in Core.RemoteEvent do if c == v then return true end end end)() then
 				wait();
 				Core.MakeEvent()
 			end
@@ -197,7 +197,7 @@ return function(Vargs, GetEnv)
 			if Core.RemoteEvent and not Core.FixingEvent then
 				Core.FixingEvent = true
 
-				for name,event in pairs(Core.RemoteEvent.Events) do
+				for name,event in Core.RemoteEvent.Events do
 					event:Disconnect()
 				end
 
@@ -268,7 +268,7 @@ return function(Vargs, GetEnv)
 
 		UpdateConnections = function()
 			if service.NetworkServer then
-				for _, cli in ipairs(service.NetworkServer:GetChildren()) do
+				for _, cli in service.NetworkServer:GetChildren() do
 					if cli:IsA("NetworkReplicator") then
 						Core.Connections[cli] = cli:GetPlayer()
 					end
@@ -278,7 +278,7 @@ return function(Vargs, GetEnv)
 
 		UpdateConnection = function(p)
 			if service.NetworkServer then
-				for _, cli in ipairs(service.NetworkServer:GetChildren()) do
+				for _, cli in service.NetworkServer:GetChildren() do
 					if cli:IsA("NetworkReplicator") and cli:GetPlayer() == p then
 						Core.Connections[cli] = p
 					end
@@ -288,7 +288,7 @@ return function(Vargs, GetEnv)
 
 		GetNetworkClient = function(p)
 			if service.NetworkServer then
-				for _, cli in ipairs(service.NetworkServer:GetChildren()) do
+				for _, cli in service.NetworkServer:GetChildren() do
 					if cli:IsA("NetworkReplicator") and cli:GetPlayer() == p then
 						return cli
 					end
@@ -301,7 +301,7 @@ return function(Vargs, GetEnv)
 				local loader = Core.ClientLoader
 				loader.Removing = true
 
-				for _, v in pairs(loader.Events) do
+				for _, v in loader.Events do
 					v:Disconnect()
 				end
 
@@ -351,7 +351,7 @@ return function(Vargs, GetEnv)
 					end
 				end)
 
-				for _, child in ipairs(folder:GetDescendants()) do
+				for _, child in folder:GetDescendants() do
 					local oParent = child.Parent
 					local oName = child.Name
 
@@ -490,7 +490,7 @@ return function(Vargs, GetEnv)
 		ExecutePermission = function(scr, code, isLocal)
 			local fixscr = service.UnWrap(scr)
 
-			for _, val in pairs(Core.ExecuteScripts) do
+			for _, val in Core.ExecuteScripts do
 				if not isLocal or (isLocal and val.Type == "LocalScript") then
 					if (service.UnWrap(val.Script) == fixscr or code == val.Code) and (not val.runLimit or (val.runLimit ~= nil and val.Executions <= val.runLimit)) then
 						val.Executions += 1
@@ -507,7 +507,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		GetScript = function(scr, code)
-			for i, val in pairs(Core.ExecuteScripts) do
+			for i, val in Core.ExecuteScripts do
 				if val.Script == scr or code == val.Code then
 					return val, i
 				end
@@ -515,7 +515,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		UnRegisterScript = function(scr)
-			for i, dat in pairs(Core.ExecuteScripts) do
+			for i, dat in Core.ExecuteScripts do
 				if dat.Script == scr or dat == scr then
 					table.remove(Core.ExecuteScripts, i)
 					return dat
@@ -538,7 +538,7 @@ return function(Vargs, GetEnv)
 				})
 			end)
 
-			for ind,scr in pairs(Core.ExecuteScripts) do
+			for ind,scr in Core.ExecuteScripts do
 				if scr.Script == data.Script then
 					return scr.Wrapped or scr.Script
 				end
@@ -639,7 +639,7 @@ return function(Vargs, GetEnv)
 						data.Warnings = if data.Warnings then Functions.DSKeyNormalize(data.Warnings, true) else {}
 
 						local BLOCKED_SETTINGS = Core.PlayerDataKeyBlacklist
-						for i, v in pairs(data) do
+						for i, v in data do
 							if not BLOCKED_SETTINGS[i] then
 								PlayerData[i] = v
 							end
@@ -687,7 +687,7 @@ return function(Vargs, GetEnv)
 
 		SaveAllPlayerData = function(queueWaitTime)
 			local TrackTask = service.TrackTask
-			for key,pdata in pairs(Core.PlayerData) do
+			for key,pdata in Core.PlayerData do
 				local id = tonumber(key);
 				local player = id and service.Players:GetPlayerByUserId(id);
 				if player and (not pdata.LastDataSave or os.time() - pdata.LastDataSave >= Core.DS_AllPlayerDataSaveInterval)  then
@@ -903,7 +903,7 @@ return function(Vargs, GetEnv)
 				local curTable = server
 				local curName = "Server"
 
-				for _, ind in ipairs(tableAncestry) do
+				for _, ind in tableAncestry do
 					curTable = curTable[ind]
 					curName = ind
 
@@ -933,7 +933,7 @@ return function(Vargs, GetEnv)
 		ClearAllData = function()
 			local tabs = Core.GetData("SavedTables") or {}
 
-			for _, v in pairs(tabs) do
+			for _, v in tabs do
 				if v.TableKey then
 					Core.RemoveData(v.TableKey)
 				end
@@ -950,7 +950,7 @@ return function(Vargs, GetEnv)
 
 			local foundTable = nil
 
-			for _, v in pairs(tabs) do
+			for _, v in tabs do
 				if type(v) == "table" and v.TableName and v.TableName == tableName then
 					foundTable = v
 					break
@@ -1003,7 +1003,7 @@ return function(Vargs, GetEnv)
 				Core.UpdateData(key, function(sets)
 					sets = sets or {}
 
-					for i, v in pairs(sets) do
+					for i, v in sets do
 						if type(i) ~= "number" then
 							sets[i] = nil
 						elseif CheckMatch(tab, v.Table) and CheckMatch(v.Value, val) then
@@ -1017,7 +1017,7 @@ return function(Vargs, GetEnv)
 					if tab[1] == "Settings" or tab[2] == "Settings" then
 						local indClone = table.clone(tab)
 						indClone[1] = "OriginalSettings"
-						for _, v in pairs(Core.IndexPathToTable(indClone) or {}) do
+						for _, v in Core.IndexPathToTable(indClone) or {} do
 							if CheckMatch(v, val) then
 								continueOperation = true
 								break
@@ -1051,7 +1051,7 @@ return function(Vargs, GetEnv)
 				Core.UpdateData(key, function(sets)
 					sets = sets or {}
 
-					for i, v in pairs(sets) do
+					for i, v in sets do
 						if type(i) ~= "number" then
 							sets[i] = nil
 						elseif CheckMatch(tab, v.Table) and CheckMatch(v.Value, val) then
@@ -1065,7 +1065,7 @@ return function(Vargs, GetEnv)
 					if tab[1] == "Settings" or tab[2] == "Settings" then
 						local indClone = table.clone(tab)
 						indClone[1] = "OriginalSettings"
-						for _, v in pairs(Core.IndexPathToTable(indClone) or {}) do
+						for _, v in Core.IndexPathToTable(indClone) or {} do
 							if CheckMatch(v, val) then
 								continueOperation = false
 								break
@@ -1128,7 +1128,7 @@ return function(Vargs, GetEnv)
 				end
 
 				if realTable and data.Action == "Add" then
-					for i, v in pairs(realTable) do
+					for i, v in realTable do
 						if CheckMatch(v, data.Value) then
 							table.remove(realTable, i)
 						end
@@ -1141,7 +1141,7 @@ return function(Vargs, GetEnv)
 
 					table.insert(realTable, data.Value)
 				elseif realTable and data.Action == "Remove" then
-					for i, v in pairs(realTable) do
+					for i, v in realTable do
 						if CheckMatch(v, data.Value) then
 							AddLog("Script", {
 								Text = "Removed value from ".. displayName;
@@ -1209,11 +1209,11 @@ return function(Vargs, GetEnv)
 					end
 
 					if SavedSettings then
-						for setting,value in pairs(SavedSettings) do
+						for setting,value in SavedSettings do
 							if not ds_blacklist[setting] then
 								if setting == "Prefix" or setting == "AnyPrefix" or setting == "SpecialPrefix" then
 									local orig = Settings[setting]
-									for _, cmd in pairs(server.Commands) do
+									for _, cmd in server.Commands do
 										if cmd.Prefix == orig then
 											cmd.Prefix = value
 										end
@@ -1226,11 +1226,11 @@ return function(Vargs, GetEnv)
 					end
 
 					if SavedTables then
-						for _, tData in pairs(SavedTables) do
+						for _, tData in SavedTables do
 							if tData.TableName and tData.TableKey and not ds_blacklist[tData.tableName] then
 								local data = GetData(tData.TableKey)
 								if data then
-									for _, v in ipairs(data) do
+									for _, v in data do
 										LoadData("TableUpdate", v)
 									end
 								end
@@ -1240,7 +1240,7 @@ return function(Vargs, GetEnv)
 						end
 
 						if Core.Variables.TimeBans then
-							for i, v in pairs(Core.Variables.TimeBans) do
+							for i, v in Core.Variables.TimeBans do
 								if v.EndTime - os.time() <= 0 then
 									table.remove(Core.Variables.TimeBans, i)
 									DoSave({
@@ -1364,7 +1364,7 @@ return function(Vargs, GetEnv)
 					ExecutePermission = MetaFunc(function(srcScript, code)
 						local exists;
 
-						for _, v in pairs(Core.ScriptCache) do
+						for _, v in Core.ScriptCache do
 							if v.Script == srcScript then
 								exists = v
 							end

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -60,7 +60,7 @@ return function(Vargs, GetEnv)
 						local lower = string.lower
 						local sub = string.sub
 
-						for _,v in ipairs(parent:GetChildren()) do
+						for _,v in parent:GetChildren() do
 							local p = getplr(v)
 							if p and sub(lower(p.Name), 1, #msg)==lower(msg) then
 								everyone = false
@@ -71,7 +71,7 @@ return function(Vargs, GetEnv)
 					end
 
 					if everyone then
-						for _,v in ipairs(parent:GetChildren()) do
+						for _,v in parent:GetChildren() do
 							local p = getplr(v)
 							if p then
 								table.insert(players,p)
@@ -96,7 +96,7 @@ return function(Vargs, GetEnv)
 				Prefix = true;
 				Absolute = true;
 				Function = function(msg, plr, parent, players, getplr, plus, isKicking)
-					for _,v in ipairs(parent:GetChildren()) do
+					for _,v in parent:GetChildren() do
 						local p = getplr(v)
 						if p and p ~= plr then
 							table.insert(players,p)
@@ -116,7 +116,7 @@ return function(Vargs, GetEnv)
 					local rand = children[math.random(#children)]
 					local p = getplr(rand)
 
-					for _,v in ipairs(players) do
+					for _,v in players do
 						if v.Name == p.Name then
 							Functions.PlayerFinders.random.Function(msg, plr, parent, players, getplr, plus, isKicking)
 							return;
@@ -133,7 +133,7 @@ return function(Vargs, GetEnv)
 				Prefix = true;
 				Absolute = true;
 				Function = function(msg, plr, parent, players, getplr, plus, isKicking)
-					for _,v in ipairs(parent:GetChildren()) do
+					for _,v in parent:GetChildren() do
 						local p = getplr(v)
 						if p and Admin.CheckAdmin(p,false) then
 							table.insert(players, p)
@@ -148,7 +148,7 @@ return function(Vargs, GetEnv)
 				Prefix = true;
 				Absolute = true;
 				Function = function(msg, plr, parent, players, getplr, plus, isKicking)
-					for _,v in ipairs(parent:GetChildren()) do
+					for _,v in parent:GetChildren() do
 						local p = getplr(v)
 						if p and not Admin.CheckAdmin(p,false) then
 							table.insert(players,p)
@@ -163,7 +163,7 @@ return function(Vargs, GetEnv)
 				Prefix = true;
 				Absolute = true;
 				Function = function(msg, plr, parent, players, getplr, plus, isKicking)
-					for _,v in ipairs(parent:GetChildren()) do
+					for _,v in parent:GetChildren() do
 						local p = getplr(v)
 						if p and p:IsFriendsWith(plr.UserId) then
 							table.insert(players,p)
@@ -181,7 +181,7 @@ return function(Vargs, GetEnv)
 					local foundNum = 0
 
 					if matched then
-						for _,v in ipairs(parent:GetChildren()) do
+						for _,v in parent:GetChildren() do
 							local p = getplr(v)
 							if p and p.Name == matched then
 								table.insert(players,p)
@@ -202,9 +202,9 @@ return function(Vargs, GetEnv)
 					local sub = string.sub
 
 					if matched then
-						for _,v in ipairs(service.Teams:GetChildren()) do
+						for _,v in service.Teams:GetChildren() do
 							if sub(lower(v.Name), 1, #matched) == lower(matched) then
-								for _,m in ipairs(parent:GetChildren()) do
+								for _,m in parent:GetChildren() do
 									local p = getplr(m)
 									if p and p.TeamColor == v.TeamColor then
 										table.insert(players,p)
@@ -222,7 +222,7 @@ return function(Vargs, GetEnv)
 				Function = function(msg, plr, parent, players, getplr, plus, isKicking)
 					local matched = string.match(msg, "%$(.*)")
 					if matched and tonumber(matched) then
-						for _,v in ipairs(parent:GetChildren()) do
+						for _,v in parent:GetChildren() do
 							local p = getplr(v)
 							if p and p:IsInGroup(tonumber(matched)) then
 								table.insert(players,p)
@@ -239,7 +239,7 @@ return function(Vargs, GetEnv)
 					local matched = tonumber(string.match(msg, "id%-(.*)"))
 					local foundNum = 0
 					if matched then
-						for _,v in ipairs(parent:GetChildren()) do
+						for _,v in parent:GetChildren() do
 							local p = getplr(v)
 							if p and p.UserId == matched then
 								table.insert(players,p)
@@ -273,7 +273,7 @@ return function(Vargs, GetEnv)
 					local foundNum = 0
 
 					if matched then
-						for _,v in ipairs(parent:GetChildren()) do
+						for _,v in parent:GetChildren() do
 							local p = getplr(v)
 							if p and p.DisplayName == matched then
 								table.insert(players,p)
@@ -293,9 +293,9 @@ return function(Vargs, GetEnv)
 
 					local matched = string.match(msg, "team%-(.*)")
 					if matched then
-						for _,v in ipairs(service.Teams:GetChildren()) do
+						for _,v in service.Teams:GetChildren() do
 							if sub(lower(v.Name), 1, #matched) == lower(matched) then
-								for _,m in ipairs(parent:GetChildren()) do
+								for _,m in parent:GetChildren() do
 									local p = getplr(m)
 									if p and p.TeamColor == v.TeamColor then
 										table.insert(players, p)
@@ -315,7 +315,7 @@ return function(Vargs, GetEnv)
 					matched = tonumber(matched)
 
 					if matched then
-						for _,v in ipairs(parent:GetChildren()) do
+						for _,v in parent:GetChildren() do
 							local p = getplr(v)
 							if p and p:IsInGroup(matched) then
 								table.insert(players,p)
@@ -335,8 +335,8 @@ return function(Vargs, GetEnv)
 							DontError = true;
 						})
 
-						for i,v in pairs(players) do
-							for k,p in pairs(removes) do
+						for i,v in players do
+							for k,p in removes do
 								if p and v.Name == p.Name then
 									table.remove(players,i)
 									plus()
@@ -376,7 +376,7 @@ return function(Vargs, GetEnv)
 							return;
 						end
 
-						for _,v in ipairs(parent:GetChildren()) do
+						for _,v in parent:GetChildren() do
 							local p = getplr(v)
 							if p and p ~= plr and plr:DistanceFromCharacter(p.Character.Head.Position) <= num then
 								table.insert(players,p)
@@ -424,14 +424,14 @@ return function(Vargs, GetEnv)
 				IsA = function(_, className) return className == "Player" end;
 			}
 
-			for i, v in pairs(options) do
+			for i, v in options do
 				data[i] = v
 			end
 
 			data.userId = data.UserId
 			data.ToString = data.Name
 
-			for i, v in pairs(data) do
+			for i, v in data do
 				fakePlayer:SetSpecial(i, v)
 			end
 
@@ -448,7 +448,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		IsClass = function(obj, classList)
-			for _,class in pairs(classList) do
+			for _,class in classList do
 				if obj:IsA(class) then
 					return true
 				end
@@ -457,7 +457,7 @@ return function(Vargs, GetEnv)
 
 		ArgsToString = function(args)
 			local str = ""
-			for i, arg in pairs(args) do
+			for i, arg in args do
 				str ..= "Arg"..tostring(i)..": "..tostring(arg).."; "
 			end
 			return str:sub(1, -3)
@@ -498,7 +498,7 @@ return function(Vargs, GetEnv)
 				local doReturn
 				local PlrLevel = if plr then Admin.GetLevel(plr) else 0
 
-				for ind, data in pairs(Functions.PlayerFinders) do
+				for ind, data in Functions.PlayerFinders do
 					if not data.Level or (data.Level and PlrLevel >= data.Level) then
 						local check = ((data.Prefix and Settings.SpecialPrefix) or "")..data.Match
 						if (data.Absolute and lower(msg) == check) or (not data.Absolute and sub(lower(msg), 1, #check) == lower(check)) then
@@ -515,7 +515,7 @@ return function(Vargs, GetEnv)
 			end
 
 			if plr == nil then
-				for _, v in ipairs(parent:GetChildren()) do
+				for _, v in parent:GetChildren() do
 					local p = getplr(v)
 					if p then
 						table.insert(players, p)
@@ -535,7 +535,7 @@ return function(Vargs, GetEnv)
 						if matchFunc and not noSelectors then
 							matchFunc.Function(s, plr, parent, players, getplr, plus, isKicking, isServer, dontError)
 						else
-							for _, v in ipairs(parent:GetChildren()) do
+							for _, v in parent:GetChildren() do
 								local p = getplr(v)
 								if p and p.ClassName == "Player" and sub(lower(p.DisplayName), 1, #s) == lower(s) then
 									table.insert(players, p)
@@ -544,7 +544,7 @@ return function(Vargs, GetEnv)
 							end
 
 							if plrs == 0 then
-								for _, v in ipairs(parent:GetChildren()) do
+								for _, v in parent:GetChildren() do
 									local p = getplr(v)
 									if p and p.ClassName == "Player" and sub(lower(p.Name), 1, #s) == lower(s) then
 										table.insert(players, p)
@@ -585,7 +585,7 @@ return function(Vargs, GetEnv)
 			local filteredList = {}
 			local checkList = {}
 
-			for _, v in pairs(players) do
+			for _, v in players do
 				if not checkList[v] then
 					table.insert(filteredList, v)
 					checkList[v] = true
@@ -794,7 +794,7 @@ return function(Vargs, GetEnv)
 		Hint = function(message, players, time)
 			time = time or (#tostring(message) / 19 + 2.5);
 
-			for _, v in ipairs(players) do
+			for _, v in players do
 				Remote.MakeGui(v, "Hint", {
 					Message = message;
 					Time = time;
@@ -805,7 +805,7 @@ return function(Vargs, GetEnv)
 		Message = function(title, message, players, scroll, time)
 			time = time or (#tostring(message) / 19) + 2.5;
 
-			for _, v in ipairs(players) do
+			for _, v in players do
 				Remote.RemoveGui(v, "Message")
 				Remote.MakeGui(v, "Message", {
 					Title = title;
@@ -819,7 +819,7 @@ return function(Vargs, GetEnv)
 		Notify = function(title, message, players, time)
 			time = time or (#tostring(message) / 19) + 2.5;
 
-			for _, v in ipairs(players) do
+			for _, v in players do
 				Remote.RemoveGui(v, "Notify")
 				Remote.MakeGui(v, "Notify", {
 					Title = title;
@@ -830,7 +830,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		Notification = function(title, message, players, tim, icon)
-			for _, v in ipairs(players) do
+			for _, v in players do
 				Remote.MakeGui(v, "Notification", {
 					Title = title;
 					Message = message;
@@ -853,14 +853,14 @@ return function(Vargs, GetEnv)
 			if service.Lighting[prop]~=nil then
 				service.Lighting[prop] = value
 				Variables.LightingSettings[prop] = value
-				for _, p in ipairs(service.GetPlayers()) do
+				for _, p in service.GetPlayers() do
 					Remote.SetLighting(p, prop, value)
 				end
 			end
 		end;
 
 		LoadEffects = function(plr)
-			for i, v in pairs(Variables.LocalEffects) do
+			for i, v in Variables.LocalEffects do
 				if (v.Part and v.Part.Parent) or v.NoPart then
 					if v.Type == "Cape" then
 						Remote.Send(plr, "Function", "NewCape", v.Data)
@@ -881,29 +881,29 @@ return function(Vargs, GetEnv)
 				Props = props;
 				Type = "Particle";
 			}
-			for _, v in ipairs(service.Players:GetPlayers()) do
+			for _, v in service.Players:GetPlayers() do
 				Remote.NewParticle(v, target, particleType, props)
 			end
 		end;
 
 		RemoveParticle = function(target,name)
-			for i, v in pairs(Variables.LocalEffects) do
+			for i, v in Variables.LocalEffects do
 				if v.Type == "Particle" and v.Part == target and (v.Props.Name == name or v.Class == name) then
 					Variables.LocalEffects[i] = nil
 				end
 			end
-			for _, v in ipairs(service.Players:GetPlayers()) do
+			for _, v in service.Players:GetPlayers() do
 				Remote.RemoveParticle(v, target, name)
 			end
 		end;
 
 		UnCape = function(plr)
-			for i, v in pairs(Variables.LocalEffects) do
+			for i, v in Variables.LocalEffects do
 				if v.Type == "Cape" and v.Player == plr then
 					Variables.LocalEffects[i] = nil
 				end
 			end
-			for _, v in ipairs(service.Players:GetPlayers()) do
+			for _, v in service.Players:GetPlayers() do
 				Remote.Send(v, "Function", "RemoveCape", plr.Character)
 			end
 		end;
@@ -939,7 +939,7 @@ return function(Vargs, GetEnv)
 						Data = data;
 						Type = "Cape";
 					}
-					for _, v in ipairs(service.Players:GetPlayers()) do
+					for _, v in service.Players:GetPlayers() do
 						Remote.Send(v, "Function", "NewCape", data)
 					end
 				end
@@ -958,7 +958,7 @@ return function(Vargs, GetEnv)
 
 		GetEnumValue = function(enum, item)
 			local valid = false
-			for _,v in ipairs(enum:GetEnumItems()) do
+			for _,v in enum:GetEnumItems() do
 				if v.Name == item then
 					valid = v.Value
 					break
@@ -982,8 +982,8 @@ return function(Vargs, GetEnv)
 				if part then
 					if rigType == "R6" then
 						local children = character:GetChildren()
-						for _,v in ipairs(part:GetChildren()) do
-							for _,x in ipairs(children) do
+						for _,v in part:GetChildren() do
+							for _,x in children do
 								if x:IsA("CharacterMesh") and x.BodyPart == v.BodyPart then
 									x:Destroy()
 								end
@@ -991,7 +991,7 @@ return function(Vargs, GetEnv)
 							v:Clone().Parent = character
 						end
 					elseif rigType == "R15" then
-						for _,v in ipairs(part:GetChildren()) do
+						for _,v in part:GetChildren() do
 							local value = Functions.GetEnumValue(Enum.BodyPartR15, v.Name)
 							if value then
 								humanoid:ReplaceBodyPartR15(value, v:Clone())
@@ -1004,7 +1004,7 @@ return function(Vargs, GetEnv)
 
 		GetJoints = function(character)
 			local temp = {}
-			for _,v in ipairs(character:GetDescendants()) do
+			for _,v in character:GetDescendants() do
 				if v:IsA("Motor6D") then
 					temp[v.Name] = v -- assumes no 2 joints have the same name, hopefully this wont cause issues
 				end
@@ -1062,7 +1062,7 @@ return function(Vargs, GetEnv)
 
 		CountTable = function(tab)
 			local num = 0
-			for i in pairs(tab) do
+			for i in tab do
 				num += 1
 			end
 			return num
@@ -1101,7 +1101,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		CleanWorkspace = function()
-			for _, v in ipairs(workspace:GetChildren()) do
+			for _, v in workspace:GetChildren() do
 				if v:IsA("BackpackItem") or v:IsA("Accoutrement") then
 					v:Destroy()
 				end
@@ -1110,7 +1110,7 @@ return function(Vargs, GetEnv)
 
 		RemoveSeatWelds = function(seat)
 			if seat then
-				for _,v in ipairs(seat:GetChildren()) do
+				for _,v in seat:GetChildren() do
 					if v:IsA("Weld") then
 						if v.Part1 and v.Part1.Name == "HumanoidRootPart" then
 							v:Destroy()
@@ -1122,7 +1122,7 @@ return function(Vargs, GetEnv)
 
 		GrabNilPlayers = function(name)
 			local AllGrabbedPlayers = {}
-			for _,v in ipairs(service.NetworkServer:GetChildren()) do
+			for _,v in service.NetworkServer:GetChildren() do
 				pcall(function()
 					if v:IsA("NetworkReplicator") then
 						if string.sub(string.lower(v:GetPlayer().Name),1,#name)==string.lower(name) or name=='all' then
@@ -1142,7 +1142,7 @@ return function(Vargs, GetEnv)
 				player:Kick("Server Shutdown\n\n".. tostring(reason or "No Reason Given"))
 			end)
 
-			for _, v in ipairs(service.Players:GetPlayers()) do
+			for _, v in service.Players:GetPlayers() do
 				v:Kick("Server Shutdown\n\n" .. tostring(reason or "No Reason Given"))
 			end
 		end;
@@ -1171,7 +1171,7 @@ return function(Vargs, GetEnv)
 			elseif type(check) == "table" and type(match) == "table" then
 				local good = false
 				local num = 0
-				for k,m in pairs(check) do
+				for k,m in check do
 					if m == match[k] then
 						good = true
 					else
@@ -1191,13 +1191,13 @@ return function(Vargs, GetEnv)
 			local tab = {}
 
 			if reverse then
-				for i,v in pairs(intab) do
+				for i,v in intab do
 					if tonumber(i) then
 						tab[tonumber(i)] = v;
 					end
 				end
 			else
-				for i,v in pairs(intab) do
+				for i,v in intab do
 					tab[tostring(i)] = v;
 				end
 			end
@@ -1206,12 +1206,12 @@ return function(Vargs, GetEnv)
 		end;
 
 		GetIndex = function(tab,match)
-			for i,v in pairs(tab) do
+			for i,v in tab do
 				if v==match then
 					return i
 				elseif type(v)=="table" and type(match)=="table" then
 					local good = false
-					for k,m in pairs(v) do
+					for k,m in v do
 						if m == match[k] then
 							good = true
 						else

--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -91,7 +91,7 @@ return function(Vargs, GetEnv)
 							if string.sub(cmd, 1, 1) == "$" then
 								local placeid = string.match(string.sub(cmd, 2), ".%d+")
 								cmd = string.sub(cmd, #placeid+2)
-								if tonumber(placeid) ~= game.PlaceId then 
+								if tonumber(placeid) ~= game.PlaceId then
 									return
 								end
 							end
@@ -215,13 +215,13 @@ return function(Vargs, GetEnv)
 						local lists: {List} = HTTP.Trello.API.getListsAndCards(board, true)
 						if #lists == 0 then error("L + ratio") end --TODO: Improve TrelloAPI error handling so we don't need to assume no lists = failed request
 
-						for _, list in pairs(lists) do 
+						for _, list in lists do
 							local foundOverride = false
 
-							for _, override in pairs(HTTP.Trello.Overrides) do 
+							for _, override in HTTP.Trello.Overrides do
 								if table.find(override.Lists, list.name) then
 									foundOverride = true
-									for _, card in ipairs(list.cards) do 
+									for _, card in list.cards do
 										override.Process(card, data)
 									end
 									break
@@ -234,7 +234,7 @@ return function(Vargs, GetEnv)
 
 								if rank and not rank.IsExternal then
 									local users = {}
-									for _, card in ipairs(list.cards) do
+									for _, card in list.cards do
 										table.insert(users, card.name)
 									end
 									data.Ranks[list.name] = users
@@ -245,12 +245,12 @@ return function(Vargs, GetEnv)
 
 					local success = true
 					local boards = {
-						Settings.Trello_Primary, 
+						Settings.Trello_Primary,
 						unpack(Settings.Trello_Secondary)
 					}
-					for i,v in pairs(boards) do
-						if not v or service.Trim(v) == "" then 
-							continue 
+					for i,v in boards do
+						if not v or service.Trim(v) == "" then
+							continue
 						end
 						local ran, err = pcall(grabData, v)
 						if not ran then
@@ -269,15 +269,15 @@ return function(Vargs, GetEnv)
 
 						Variables.Blacklist.Lists.Trello = data.Blacklist
 						Variables.Whitelist.Lists.Trello = data.Whitelist
-          
+
 						--// Clear any custom ranks that were not fetched from Trello
-						for rank, info in pairs(Settings.Ranks) do 
+						for rank, info in Settings.Ranks do
 							if rank.IsExternal and not data.Ranks[rank] then
 								Settings.Ranks[rank] = nil
 							end
 						end
 
-						for rank, users in pairs(data.Ranks) do 
+						for rank, users in data.Ranks do
 							local name = string.format("[Trello] %s", server.Functions.Trim(rank))
 							Settings.Ranks[name] = {
 								Level = Settings.Ranks[rank].Level or 1;
@@ -286,7 +286,7 @@ return function(Vargs, GetEnv)
 							}
 						end
 
-						for i, v in pairs(service.GetPlayers()) do
+						for i, v in service.GetPlayers() do
 							local isBanned, Reason = Admin.CheckBan(v)
 							if isBanned then
 								v:Kick(string.format("%s | Reason: %s", Variables.BanMessage, (Reason or "No reason provided")))
@@ -303,15 +303,15 @@ return function(Vargs, GetEnv)
 					end
 				end
 			end;
-			
+
 			GetOverrideLists = function()
 				local lists = {}
-				for _, override in ipairs(HTTP.Trello.Overrides) do 
-					for _, list in ipairs(override.Lists) do 
+				for _, override in HTTP.Trello.Overrides do
+					for _, list in override.Lists do
 						table.insert(lists, list)
 					end
 				end
-				for name, rank in pairs(Settings.Ranks) do 
+				for name, rank in Settings.Ranks do
 					if not rank.IsExternal and not table.find(lists, name) then
 						table.insert(lists, name)
 					end

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -63,7 +63,7 @@ return function(Vargs, GetEnv)
 				DateTime = "DateTime";
 			}
 
-			for ind, t in pairs(server.Logs) do
+			for ind, t in server.Logs do
 				if t == tab then
 					return indToName[ind] or ind
 				end
@@ -105,7 +105,7 @@ return function(Vargs, GetEnv)
 			end
 
 			warn("Saving command logs...")
-			
+
 			if Settings.SaveCommandLogs ~= true or Settings.DataStoreEnabled ~= true then
 				warn("Skipped saving command logs.")
 				return
@@ -122,7 +122,7 @@ return function(Vargs, GetEnv)
 			Core.UpdateData("OldCommandLogs", function(oldLogs)
 				local temp = {}
 
-				for _, m in ipairs(logsToSave) do
+				for _, m in logsToSave do
 					local newTab = type(m) == "table" and service.CloneTable(m) or m
 					if type(m) == "table" and newTab.Player then
 						local p = newTab.Player
@@ -135,7 +135,7 @@ return function(Vargs, GetEnv)
 				end
 
 				if oldLogs then
-					for _, m in ipairs(oldLogs) do
+					for _, m in oldLogs do
 						table.insert(temp, m)
 					end
 				end

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -55,7 +55,7 @@ return function(Vargs, GetEnv)
 
 		--// Load client onto existing players
 		if existingPlayers then
-			for i, p in ipairs(existingPlayers) do
+			for i, p in existingPlayers do
 				Core.LoadExistingPlayer(p)
 			end
 		end
@@ -408,7 +408,7 @@ return function(Vargs, GetEnv)
 				local taskName = string.format("Command :: %s : (%s)", p.Name, msg)
 
 				if #args > 0 and not isSystem and command.Filter or opts.Filter then
-					for i, arg in ipairs(args) do
+					for i, arg in args do
 						local cmdArg = cmdArgs[i]
 						if cmdArg then
 							if Admin.IsLax(cmdArg) == false then
@@ -478,7 +478,7 @@ return function(Vargs, GetEnv)
 
 		CrossServerChat = function(data)
 			if data then
-				for _, v in pairs(service.GetPlayers()) do
+				for _, v in service.GetPlayers() do
 					if Admin.GetLevel(v) > 0 then
 						Remote.Send(v, "handler", "ChatHandler", data.Player, data.Message, "Cross")
 					end
@@ -522,9 +522,10 @@ return function(Vargs, GetEnv)
 						end
 					end
 
-					for _, v in pairs(service.GetPlayers(p, target, {
+					for _, v in service.GetPlayers(p, target, {
 						DontError = true;
-						})) do
+						})
+					do
 						local a = service.Filter(a, p, v)
 						if p.Name == v.Name and b ~= "Private" and b ~= "Ignore" and b ~= "UnIgnore" then
 							Remote.Send(v,"Handler","ChatHandler",p,a,b)
@@ -680,7 +681,7 @@ return function(Vargs, GetEnv)
 					local listed = false
 
 					local CheckTable = Admin.CheckTable
-					for listName, list in pairs(Variables.Whitelist.Lists) do
+					for listName, list in Variables.Whitelist.Lists do
 						if CheckTable(p, list) then
 							listed = true
 							break;
@@ -773,7 +774,7 @@ return function(Vargs, GetEnv)
 			Core.SavePlayerData(p, data)
 
 			Variables.TrackingTable[p.Name] = nil
-			for otherPlrName, trackTargets in pairs(Variables.TrackingTable) do
+			for otherPlrName, trackTargets in Variables.TrackingTable do
 				if trackTargets[p] then
 					trackTargets[p] = nil
 					local otherPlr = service.Players:FindFirstChild(otherPlrName)
@@ -805,7 +806,7 @@ return function(Vargs, GetEnv)
 			})
 
 			--// Run OnJoin commands
-			for i,v in pairs(Settings.OnJoin) do
+			for i,v in Settings.OnJoin do
 				TrackTask("Thread: OnJoin_Cmd: ".. tostring(v), Admin.RunCommandAsPlayer, v, p)
 				AddLog("Script", {
 					Text = "OnJoin: Executed "..tostring(v);
@@ -922,10 +923,10 @@ return function(Vargs, GetEnv)
 				--// [-150x261x247x316x246x243x238x248x302x316x261x247x316x246x234x247x247x302]
 				--// END_ReF - 100392_659
 
-				for v: Player in pairs(Variables.IncognitoPlayers) do
+				for v: Player in Variables.IncognitoPlayers do
 					if v == p then continue end
 					server.Remote.LoadCode(p, [[
-						for _, p in pairs(service.Players:GetPlayers()) do
+						for _, p in service.Players:GetPlayers() do
 							if p.UserId == ]]..v.UserId..[[ then
 								if p:FindFirstChild("leaderstats") then p.leaderstats:Destroy() end
 								p:Destroy()
@@ -993,7 +994,7 @@ return function(Vargs, GetEnv)
 				end
 
 				--// Check muted
-				--[=[for ind,admin in pairs(Settings.Muted) do
+				--[=[for ind,admin in Settings.Muted do
 					if Admin.DoCheck(p, admin) then
 						Remote.LoadCode(p, [[service.StarterGui:SetCoreGuiEnabled("Chat",false) client.Variables.ChatEnabled = false client.Variables.Muted = true]])
 					end
@@ -1005,7 +1006,7 @@ return function(Vargs, GetEnv)
 				service.Events.CharacterAdded:Fire(p, char, ...)
 
 				--// Run OnSpawn commands
-				for _, v in pairs(Settings.OnSpawn) do
+				for _, v in Settings.OnSpawn do
 					TrackTask("Thread: OnSpawn_Cmd: ".. tostring(v), Admin.RunCommandAsPlayer, v, p)
 					AddLog("Script", {
 						Text = "OnSpawn: Executed "..tostring(v);
@@ -1018,7 +1019,7 @@ return function(Vargs, GetEnv)
 					and char:WaitForChild("Head", 5)
 					and char:WaitForChild("HumanoidRootPart", 2)
 				then
-					for otherPlrName, trackTargets in pairs(Variables.TrackingTable) do
+					for otherPlrName, trackTargets in Variables.TrackingTable do
 						if trackTargets[p] then
 							server.Commands.Track.Function(service.Players[otherPlrName], {"@"..p.Name, "true"})
 						end

--- a/MainModule/Server/Core/Remote.lua
+++ b/MainModule/Server/Core/Remote.lua
@@ -92,6 +92,8 @@ return function(Vargs, GetEnv)
 			DataStoreKey = true;
 			DataStoreEnabled = true;
 
+			LoadAdminsFromDS = true;
+
 			Creators = true;
 			Permissions = true;
 
@@ -180,7 +182,7 @@ return function(Vargs, GetEnv)
 
 				if type(setting) == "table" then
 					ret = {}
-					for _,set in pairs(setting) do
+					for _,set in setting do
 						if Defaults[set] and (not blocked[set] or level >= Settings.Ranks.Creators.Level) then
 							ret[set] = Defaults[set]
 						end
@@ -227,7 +229,7 @@ return function(Vargs, GetEnv)
 						CustomRanks = true; -- Not supported yet
 					}
 
-					for setting in pairs(sets.Settings) do
+					for setting in sets.Settings do
 						if blocked[setting] then
 							sets.Settings[setting] = nil
 						end
@@ -245,7 +247,7 @@ return function(Vargs, GetEnv)
 
 				if type(setting) == "table" then
 					ret = {}
-					for _,set in pairs(setting) do
+					for _,set in setting do
 						if Settings[set] and (allowed[set] or level>=Settings.Ranks.Creators.Level) then
 							ret[set] = Settings[set]
 						end
@@ -269,7 +271,7 @@ return function(Vargs, GetEnv)
 
 					local blocked = Remote.BlockedSettings
 
-					for setting in pairs(sets.Settings) do
+					for setting in sets.Settings do
 						if blocked[setting] then
 							sets.Settings[setting] = nil
 						end
@@ -403,9 +405,9 @@ return function(Vargs, GetEnv)
 			FormattedCommands = function(p: Player,args: {[number]: any})
 				local commands = Admin.SearchCommands(p,args[1] or "all")
 				local tab = {}
-				for _,v in pairs(commands) do
+				for _,v in commands do
 					if not v.Hidden and not v.Disabled then
-						for a in pairs(v.Commands) do
+						for a in v.Commands do
 							table.insert(tab,Admin.FormatCommand(v,a))
 						end
 					end
@@ -514,7 +516,7 @@ return function(Vargs, GetEnv)
 					Arguments = 1;
 					Description = "Sends a message in the Roblox chat";
 					Function = function(p, args, data)
-						for _,v in ipairs(service.GetPlayers()) do
+						for _,v in service.GetPlayers() do
 							Remote.Send(v,"Function","ChatMessage",args[1],Color3.fromRGB(255,64,77))
 						end
 					end
@@ -537,8 +539,8 @@ return function(Vargs, GetEnv)
 					Description = "Loads and runs the given lua string";
 					Function = function(p,args,data)
 						local newenv = GetEnv(getfenv(),{
-							print = function(...) local nums = {...} for _,v in ipairs(nums) do Remote.Terminal.LiveOutput(p,"PRINT: "..tostring(v)) end end;
-							warn = function(...) local nums = {...} for _,v in ipairs(nums) do Remote.Terminal.LiveOutput(p,"WARN: "..tostring(v)) end end;
+							print = function(...) local nums = {...} for _,v in nums do Remote.Terminal.LiveOutput(p,"PRINT: "..tostring(v)) end end;
+							warn = function(...) local nums = {...} for _,v in nums do Remote.Terminal.LiveOutput(p,"WARN: "..tostring(v)) end end;
 						})
 
 						if not server.Remote.RemoteExecutionConfirmed[p.UserId] then
@@ -599,7 +601,7 @@ return function(Vargs, GetEnv)
 					Function = function(p, args, data)
 						local plrs = service.GetPlayers(p,args[1])
 						if #plrs>0 then
-							for _,v in ipairs(plrs) do
+							for _,v in plrs do
 								v:Kick(args[2] or "Disconnected by server")
 								return {"Disconnect "..tostring(v.Name).." from the server"}
 							end
@@ -617,7 +619,7 @@ return function(Vargs, GetEnv)
 					Function = function(p,args,data)
 						local plrs = service.GetPlayers(p,args[1])
 						if #plrs>0 then
-							for _,v in ipairs(plrs) do
+							for _,v in plrs do
 								local char = v.Character
 								if char and char.ClassName == "Model" then
 									char:BreakJoints()
@@ -640,7 +642,7 @@ return function(Vargs, GetEnv)
 					Function = function(p,args,data)
 						local plrs = service.GetPlayers(p,args[1])
 						if #plrs>0 then
-							for _,v in ipairs(plrs) do
+							for _,v in plrs do
 								v:LoadCharacter()
 								return {"Respawned "..tostring(v.Name)}
 							end
@@ -660,7 +662,7 @@ return function(Vargs, GetEnv)
 							p:Kick()
 						end)
 
-						for _,v in ipairs(service.Players:GetPlayers()) do
+						for _,v in service.Players:GetPlayers() do
 							v:Kick()
 						end
 					end
@@ -794,7 +796,7 @@ return function(Vargs, GetEnv)
 
 					if setting == 'Prefix' or setting == 'AnyPrefix' or setting == 'SpecialPrefix' then
 						local orig = Settings[setting]
-						for _, v in pairs(Commands) do
+						for _, v in Commands do
 							if v.Prefix == orig then
 								v.Prefix = value
 							end
@@ -827,7 +829,7 @@ return function(Vargs, GetEnv)
 
 					if setting == "Prefix" or setting == "AnyPrefix" or setting == "SpecialPrefix" then
 						local orig = Settings[setting]
-						for _, v in pairs(Commands) do
+						for _, v in Commands do
 							if v.Prefix == orig then
 								v.Prefix = value
 							end
@@ -846,9 +848,9 @@ return function(Vargs, GetEnv)
 
 			TrelloOperation = function(p: Player,args: {[number]: any})
 				local adminLevel = Admin.GetLevel(p)
-				
+
 				local trello = HTTP.Trello.API
-				
+
 				local data = args[1]
 				if data.Action == "MakeCard" then
 					local command = Commands.MakeCard
@@ -856,14 +858,14 @@ return function(Vargs, GetEnv)
 						local listName = data.List
 						local name = data.Name
 						local desc = data.Desc
-						
-						for _, overrideList in ipairs(HTTP.Trello.GetOverrideLists()) do 
+
+						for _, overrideList in HTTP.Trello.GetOverrideLists() do 
 							if service.Trim(string.lower(overrideList)) == service.Trim(string.lower(listName)) then
 								Functions.Hint("You cannot create a card in that list", {p})
 								return
 							end
 						end
-						
+
 						local lists = trello.getLists(Settings.Trello_Primary)
 						local list = trello.getListObj(lists, listName)
 						if list then
@@ -1149,7 +1151,7 @@ return function(Vargs, GetEnv)
 
 		CheckKeys = function()
 			--// Check all keys for ones no longer in use for >10 minutes (so players who actually left aren't tracked forever)
-			for key, data in pairs(Remote.Clients) do
+			for key, data in Remote.Clients do
 				local continue = true;
 
 				if data.Player and data.Player.Parent == service.Players then
@@ -1179,14 +1181,14 @@ return function(Vargs, GetEnv)
 		MakeGui = function(p: Player,GUI: string,data: {[any]: any},themeData: {[string]: any})
 			if not p then return end
 			local theme = {Desktop = Settings.Theme; Mobile = Settings.MobileTheme}
-			if themeData then for ind,dat in pairs(themeData) do theme[ind] = dat end end
+			if themeData then for ind,dat in themeData do theme[ind] = dat end end
 			Remote.Send(p,"UI",GUI,theme,data or {})
 		end;
 
 		MakeGuiGet = function(p: Player,GUI: string,data: {[any]: any},themeData: {[string]: any})
 			if not p then return nil end
 			local theme = {Desktop = Settings.Theme; Mobile = Settings.MobileTheme}
-			if themeData then for ind,dat in pairs(themeData) do theme[ind] = dat end end
+			if themeData then for ind,dat in themeData do theme[ind] = dat end end
 			return Remote.Get(p,"UI",GUI,theme,data or {})
 		end;
 
@@ -1202,7 +1204,7 @@ return function(Vargs, GetEnv)
 		RefreshGui = function(p: Player,name: string | boolean | Instance,ignore: string,data: {[any]: any},themeData: {[string]: any})
 			if not p then return end
 			local theme = {Desktop = Settings.Theme; Mobile = Settings.MobileTheme}
-			if themeData then for ind,dat in pairs(themeData) do theme[ind] = dat end end
+			if themeData then for ind,dat in themeData do theme[ind] = dat end end
 			Remote.Send(p,"RefreshUI",name,ignore,themeData,data or {})
 		end;
 

--- a/MainModule/Server/Core/Variables.lua
+++ b/MainModule/Server/Core/Variables.lua
@@ -30,9 +30,9 @@ return function(Vargs, GetEnv)
 		Variables.BanMessage = Settings.BanMessage
 		Variables.LockMessage = Settings.LockMessage
 
-		for _, v in ipairs(Settings.MusicList or {}) do table.insert(Variables.MusicList, v) end
-		for _, v in ipairs(Settings.InsertList or {}) do table.insert(Variables.InsertList, v) end
-		for _, v in ipairs(Settings.CapeList or {}) do table.insert(Variables.Capes, v) end
+		for _, v in Settings.MusicList or {} do table.insert(Variables.MusicList, v) end
+		for _, v in Settings.InsertList or {} do table.insert(Variables.InsertList, v) end
+		for _, v in Settings.CapeList or {} do table.insert(Variables.Capes, v) end
 
 		Variables.Init = nil
 		Logs:AddLog("Script", "Variables Module Initialized")
@@ -198,4 +198,3 @@ return function(Vargs, GetEnv)
 		};
 	}
 end
-


### PR DESCRIPTION
``pairs()`` and ``ipairs()`` are no longer necessary with the introduction of the __iter metamethod.

## Character Difference/Reduction Counts
By how many characters have our file sizes been reduced after killing the pairs? (All figures are approximate.)

### Server Modules:

Commands\Admins - 420
Commands\Creators - 30
Commands\Donors - 20
Commands\Fun - 1460
Commands\HeadAdmins - 90
Commands\Moderators - 2320
Commands\Players - 210

Core\Admin - 330
Core\Anti - 50
Core\Commands - 50
Core\Core - 210
Core\Functions - 420
Core\HTTP - 80
Core\Logs - 20
Core\Process - 80
Core\Remote - 150
Core\Variables - 20

**Total:** 5960 characters

### Client Modules:

Core\Anti - 60
Core\Core - 0
Core\Functions - 240
Core\Process - 0
Core\Remote - 20
Core\UI - 70
Core\Variables - 0

**Total:** 390 characters