### PR TITLE
Set argument range limits on :lowres

### DIFF
--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -429,7 +429,9 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				local size = tonumber(args[2]) or 19
+				assert(size >= 10, "Pixel size too small (< 10)")
 				local dist = tonumber(args[3]) or 100
+				assert(dist <= 10_000, "Render distance too large (> 10,000)")
 				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Effect", {
 						Mode = "Pixelize";
@@ -2724,7 +2726,7 @@ return function(Vargs, env)
 									local lc0 = service.New("CFrameValue", {Name = "LastC0";Value = v.C0;Parent = v})
 								end
 							end
-							
+
 							for _, v in lowertorso:GetChildren() do
 								if v:IsA("Motor6D") then
 									local lc0 = service.New("CFrameValue", {Name = "LastC0";Value = v.C0;Parent = v})


### PR DESCRIPTION
This should prevent severe lag/crash issues due to passing extreme parameters.