### PR TITLE
Make donor status updating asynchronous

### DIFF
--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -549,9 +549,11 @@ return function(data, env)
 					end
 				end
 
-				dStatus.Text = Remote.Get("UpdateDonor", playerData.Donor)
-				task.wait(0.5)
-				dStatus.Text = "Donated"
+				task.defer(function()
+					dStatus.Text = Remote.Get("UpdateDonor", playerData.Donor)
+					task.wait(0.5)
+					dStatus.Text = "Donated"
+				end)
 			end
 
 			donorTab:Add("TextLabel", {


### PR DESCRIPTION
This makes the UX for userpanel donor a lot better. Users can now update their donor status even when the status is already uploading. Previously they could only do so when the status had already updated. This leads to better UX for very slow internet connections