### PR TITLE
Fix donor cape not updating from UserPanel

### DIFF
--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -533,7 +533,7 @@ return function(data, env)
 			local function updateStatus()
 				dStatus.Text = "Updating..."
 
-				if settingsData.Settings.DonorCapes and playerData.isDonor then
+				if chatMod.DonorCapes and playerData.isDonor then
 					if type(donorData) == "table" and donorData.Cape and type(donorData.Cape) == "table" then
 						if donorData.Enabled and service.Players.LocalPlayer.Character then
 							Functions.NewCape({


### PR DESCRIPTION
The donor cape worked for admins but it didn't work for regular users because it attempted to pool the data from game settings instead of the pooled settings. This fixes it so non-admins can update the cape as well

@Dimenpsyonal 

PoF:
![POFCAPEADONIS](https://github.com/user-attachments/assets/019788c0-a714-41f8-963d-72ecf155a3cc)
