### PR TITLE
Update ;dexnew to not allow deleting players who have a higher rank than you.

### DIFF
--- a/MainModule/Server/Plugins/ServerNewDex.rbxmx
+++ b/MainModule/Server/Plugins/ServerNewDex.rbxmx
@@ -77,7 +77,10 @@
 				if Admin.GetLevel(args[1]) < Admin.GetLevel(realPlr) then
 					args[1]:Destroy();
 				else 
-					Functions.Hint(`You do not have the permission to delete player {args[1].DisplayName} (@{args[1].Name})`, {realPlr})
+					Remote.MakeGui(realPlr, "Output", {
+						Title = "Missing Permissions";
+						Message = `You do not have the permission to delete player {args[1].DisplayName} (@{args[1].Name})`;
+					})
 				end
 			end
 			return true;


### PR DESCRIPTION
This PR prevents players with a lower rank from deleting players with higher ranks using ;dexnew. Certainly, this won't stop people from using ;s when CodeExecution is on, but having less holes that allow kicking higher ranks will still help.

Also, since those most certainly won't work without Adonis gaining higher security permission all of a sudden, cutting, copying, renaming, duplicating, grouping, ungrouping have been disabled on the Player class.

Hopefully, this one will go better than #1972.

POF:
<img width="1322" height="1304" alt="image" src="https://github.com/user-attachments/assets/ea7231aa-7809-4427-9a91-5971f9ab0013" />
