### PR TITLE
Remove CoreGui exploit detections

### DIFF
--- a/Loader/Config/Settings.luau
+++ b/Loader/Config/Settings.luau
@@ -390,7 +390,6 @@ settings.AntiGod = false 					-- (Default: false)	If a player does not respawn w
 settings.AntiSpeed = false 				-- (Default: false)	(Client-Sided) Attempts to detect speed exploits.
 settings.AntiBuildingTools = false		-- (Default: false)	(Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client.
 settings.AntiAntiIdle = false 			-- (Default: false)	(Client-Sided) Kick the player if they are using an anti-idle exploit. Highly useful for grinding/farming games.
-settings.ExploitGuiDetection = false 	-- (Default: false)	(Client-Sided) If any exploit GUIs are found in the CoreGui the exploiter gets kicked (If you use StarterGui:SetCore("SendNotification") with an image this will kick you).
 
 ---------------------
 -- END OF SETTINGS --

--- a/MainModule/Client/Plugins/Anti_Cheat.luau
+++ b/MainModule/Client/Plugins/Anti_Cheat.luau
@@ -284,112 +284,8 @@ return function(Vargs)
 		end;
 
 		AntiCoreGui = function()
-			if isStudio then
-				return
-			end
-
-			-- // Checks disallowed content URLs in the CoreGui
-			service.StartLoop("AntiCoreGui", 15, function()
-				xpcall(function()
-					local function getCoreUrls()
-						local coreUrls = {"rbxassetid://0", "rbxassetid://10066921516", "rbxassetid://13262267483", "rbxassetid://13253401424"}	-- Whitelist for Roblox Camera SFX and Quest Controls Scheme
-						local screenshotHud = service.GuiService:FindFirstChildOfClass("ScreenshotHud")
-
-						for _, container in {Player.Character, service.StarterPack, Player:FindFirstChildOfClass("Backpack")} do
-							for _, v: Instance in ipairs(container:GetChildren()) do
-								if v:IsA("BackpackItem") and service.Trim(v.TextureId) ~= "" then
-									table.insert(coreUrls, service.Trim(v.TextureId))
-								elseif v:IsA("MeshPart") then
-									table.insert(coreUrls, service.Trim(v.MeshId))
-									table.insert(coreUrls, service.Trim(v.TextureID)) -- For some reason, on MeshParts it's TextureID instead of TextureId
-								end
-							end
-						end
-
-						if screenshotHud and service.Trim(screenshotHud.CameraButtonIcon) ~= "" then
-							table.insert(coreUrls, service.Trim(screenshotHud.CameraButtonIcon))
-						end
-
-						return coreUrls
-					end
-
-					local hasDetected = false
-					local activated = false
-					local rawContentProvider = service.UnWrap(service.ContentProvider)
-					local workspace = service.UnWrap(workspace)
-					local tempDecal = service.UnWrap(Instance.new("Decal"))
-					tempDecal.Texture = "rbxasset://textures/face.png" -- It's a local asset and it's likely to never get removed, so it will never fail to load, unless the user's PC is corrupted
-					local coreUrls = getCoreUrls()
-
-					if not (service.GuiService.MenuIsOpen or service.ContentProvider.RequestQueueSize >= 50 or Player:GetNetworkPing() * 1000 >= 750) then
-						rawContentProvider.PreloadAsync(rawContentProvider, {tempDecal, tempDecal, tempDecal, service.UnWrap(service.CoreGui), tempDecal}, function(url, status)
-							if url == "rbxasset://textures/face.png" and status == Enum.AssetFetchStatus.Success then
-								activated = true
-							elseif not hasDetected and (string.match(url, "^rbxassetid://") or string.match(url, "^http://www%.roblox%.com/asset/%?id=")) then
-								local isItemIcon = false
-
-								for _, v in ipairs(coreUrls) do
-									if string.find(url, v, 1, true) then
-										isItemIcon = true
-										break
-									end
-								end
-
-								if isItemIcon == true then
-									return
-								end
-
-								hasDetected = true
-								Detected("Kick", "Disallowed content URL detected in CoreGui: " ..url)
-							end
-						end)
-
-						tempDecal:Destroy()
-						task.wait(6)
-						if not activated then -- // Checks for Anti-CoreGui detection bypasses
-							Detected("kick", "CoreGui detection bypass found")
-						end
-					end
-
-					local success, err = pcall(function()
-						rawContentProvider:preloadasync({tempDecal})
-					end)
-					local success2, err2 = pcall(function()
-						rawContentProvider.PreloadAsync(workspace, {tempDecal})
-					end)
-					local success3, err3 = pcall(function()
-						workspace:PreloadAsync({tempDecal})
-					end)
-
-					if
-						success or (string.match(err, "^%a+ is not a valid member of ContentProvider \"(.+)\"$") or "") ~= rawContentProvider:GetFullName() or
-						success2 or err2 ~= "Expected ':' not '.' calling member function PreloadAsync" or
-						success3 or (string.match(err3, "^PreloadAsync is not a valid member of Workspace \"(.+)\"$") or "") ~= workspace:GetFullName()
-					then
-						Detected("kick", "Content provider spoofing detected")
-					end
-
-					-- // GetFocusedTextBox detection
-					local textbox = service.UserInputService:GetFocusedTextBox()
-					local success, value = pcall(service.StarterGui.GetCore, service.StarterGui, "DeveloperConsoleVisible")
-					local textChatService = service.TextChatService
-					local chatBarConfig = textChatService and textChatService:FindFirstChildOfClass("ChatInputBarConfiguration")
-
-					if
-						textbox and Anti.RLocked(textbox) and not ((success and value) or service.GuiService.MenuIsOpen or (
-							service.Chat.LoadDefaultChat and
-								textChatService and
-								textChatService.ChatVersion == Enum.ChatVersion.TextChatService and
-								chatBarConfig and
-								chatBarConfig.Enabled
-							))
-					then
-						Detected("Kick", "Invalid CoreGui Textbox has been selected")
-					end
-				end, function()
-					Detected("kick", "Tamper Protection 0x6F832")
-				end)
-			end)
+			--// As of version 686 Roblox makes accessing `game.CoreGui` or trying to get the instance return nil or error making this obsolete
+			return
 		end,
 
 		MainDetection = function()
@@ -522,7 +418,7 @@ return function(Vargs)
 			}
 
 			local function check(Message)
-				if 
+				if
 					string.find(string.lower(Message), "failed to load", 1, true) or
 					string.find(string.lower(Message), "meshcontentprovider failed to process", 1, true) or
 					string.find(string.lower(Message), "unknown 'active' animation:", 1, true)

--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -969,9 +969,9 @@ return function(Vargs, GetEnv)
 						Enabled = (Settings.AntiAntiIdle ~= false or Settings.AntiClientIdle ~= false)
 					})
 
-					if Settings.ExploitGuiDetection and Settings.AllowClientAntiExploit then
-						Remote.Send(p, "LaunchAnti", "AntiCoreGui")
-					end
+					--if Settings.ExploitGuiDetection and Settings.AllowClientAntiExploit then
+					--	Remote.Send(p, "LaunchAnti", "AntiCoreGui")
+					--end
 				end
 
 				if Settings.AntiBuildingTools and Settings.AllowClientAntiExploit then


### PR DESCRIPTION
Since version 686 Roblox has made it so trying to access or reference CoreGui will result in an error or returning `nil` if the thread doesn't have access to CoreGui.

`settings.ExploitGuiDetection` now is useless.

PoF: Not needed since it just removes the entire code and launching of the check