### PR TITLE
Fix ;clearscreenguis from removing mobile controls

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -4234,7 +4234,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for _, v in service.GetPlayers(plr, args[1]) do
-					Remote.LoadCode(v, [[for i, v in ipairs(service.PlayerGui:GetChildren()) do if not client.Core.GetGui(v) then pcall(v.Destroy, v) end end]])
+					Remote.LoadCode(v, [[for i, v in ipairs(service.PlayerGui:GetChildren()) do if not client.Core.GetGui(v) and v.Name ~= "TouchGui" then pcall(v.Destroy, v) end end]])
 				end
 			end
 		};


### PR DESCRIPTION
This PR changes `;clearscreenguis` so it doesn't remove mobile controls by checking to see if the gui is named "TouchGui"

## PoF
https://github.com/user-attachments/assets/46425c9b-48d1-4a7c-b197-4f4b11a2cc8d