### PR TITLE
Add the leave reason to :leavelogs

### DIFF
--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -857,10 +857,12 @@ return function(Vargs, GetEnv)
 				["PlatformKick"] = "Kicked by Roblox",
 				["CreatorKick"] = "Kicked by Creator"
 			}
+			
+			local reason = reasons[r.Name] or r.Name
 
 			AddLog("Leaves", {
 				Text = service.FormatPlayer(p);
-				Desc = `{p.Name} left the server ({reasons[r.Name]})`;
+				Desc = `{p.Name} left the server ({reason})`;
 				Player = p;
 			})
 


### PR DESCRIPTION
Modified the description of each log in :leavelogs to show the [Roblox reason they have left the game](https://create.roblox.com/docs/reference/engine/enums/PlayerExitReason)

<img width="425" height="145" alt="image" src="https://github.com/user-attachments/assets/242c85c4-ecd1-44b0-80c5-770ba5236abf" />
<img width="446" height="172" alt="image" src="https://github.com/user-attachments/assets/075dc9ae-f7bb-4374-80c0-d50a584f187a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Departure logs now include a clear reason for player removals (e.g., platform kick, creator kick, or unknown), so server leave entries show "left the server (<reason>)" for easier auditing and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->