### PR TITLE
Re-add GetPlayers and RunCommandAsNonAdmin

### DIFF
--- a/MainModule/Server/Core/Core.luau
+++ b/MainModule/Server/Core/Core.luau
@@ -1564,9 +1564,9 @@ return function(Vargs, GetEnv)
 
 				Hint = MetaFunc(Functions.Hint, true, { t.string, t.array(t.instanceOf("Player")), t.optional(t.number), t.string, t.optional(t.string) });
 
-				RunCommandAsNonAdmin = MetaFunc(Admin.RunCommandAsNonAdmin, true);
+				RunCommandAsNonAdmin = MetaFunc(Admin.RunCommandAsNonAdmin, true, {t.string, t.instanceOf("Player") });
 
-				GetPlayers = MetaFunc(Functions.GetPlayers, true);
+				GetPlayers = MetaFunc(Functions.GetPlayers, true, { t.instanceOf("Player"), t.optional(t.string), t.array(t.any) });
 
 				Message = MetaFunc(function(title: string, message: string, players: {Player}, scroll: boolean?, duration: number?)
 					duration = duration or (#tostring(message) / 19) + 2.5


### PR DESCRIPTION
- Re-added back GetPlayers and RunCommandAsNonAdmin into _G.Adonis API
[**resolves this issue**](https://github.com/Epix-Incorporated/Adonis/issues/2008)