### PR TITLE
Fix memory leak of player reference caused by logs

### DIFF
--- a/MainModule/Server/Core/Logs.luau
+++ b/MainModule/Server/Core/Logs.luau
@@ -93,7 +93,7 @@ return function(Vargs, GetEnv)
 				local pData = Core.PlayerData[tostring(id)]
 				local userInfo = pData.userInfo
 
-				if not userInfo then -- Cache table allocation for player KKK table to save on memory
+				if not userInfo then -- Cache table allocation for player userInfo table to save on memory
 					userInfo = {
 						Name = log.Player.Name;
 						UserId = id;


### PR DESCRIPTION
Fix memory leak of player reference caused by logs

Fixes #1923

This fixes it by changing the player reference to a userinfo table before instead of during old log dumping. Should provide a good memory usage boost.
Also intelligently caches the user info table to avoid excessive table allocation boosting memory greatly.
