### PR TITLE
Add more robustness to Adonis loader boot sequence module loading

### DIFF
--- a/Loader/Loader/Loader.server.luau
+++ b/Loader/Loader/Loader.server.luau
@@ -46,7 +46,7 @@ local function yxpcall(f, callback, ...)
 end
 
 local function loadModuleAsset(moduleId: number)
-	local asset = ({yxpcall(function() return nil, AssetService:LoadAssetAsync(moduleId) end), warn)})[3] or InsertService:LoadAsset(moduleId)
+	local asset = ({yxpcall(function() return nil, AssetService:LoadAssetAsync(moduleId) end, warn))})[3] or InsertService:LoadAsset(moduleId)
 
 	if asset.Name == "MainModule" then
 		return assert(require(asset), ":LoadAsset() module returned invalid values!")

--- a/Loader/Loader/Loader.server.luau
+++ b/Loader/Loader/Loader.server.luau
@@ -46,7 +46,7 @@ local function yxpcall(f, callback, ...)
 end
 
 local function loadModuleAsset(moduleId: number)
-	local asset = ({yxpcall(function() return nil, AssetService:LoadAssetAsync(moduleId) end, warn))})[3] or InsertService:LoadAsset(moduleId)
+	local asset = ({yxpcall(function() return nil, AssetService:LoadAssetAsync(moduleId) end, warn)})[3] or InsertService:LoadAsset(moduleId)
 
 	if asset.Name == "MainModule" then
 		return assert(require(asset), ":LoadAsset() module returned invalid values!")

--- a/Loader/Loader/Loader.server.luau
+++ b/Loader/Loader/Loader.server.luau
@@ -33,6 +33,7 @@ end
 local ServerScriptService = game:GetService("ServerScriptService")
 local RunService = game:GetService("RunService")
 local InsertService = game:GetService("InsertService")
+local AssetService = game:GetService("AssetService")
 
 -- Support yieldable xpcall
 local function yxpcall(f, callback, ...)

--- a/Loader/Loader/Loader.server.luau
+++ b/Loader/Loader/Loader.server.luau
@@ -46,7 +46,7 @@ local function yxpcall(f, callback, ...)
 end
 
 local function loadModuleAsset(moduleId: number)
-	local asset = InsertService:LoadAsset(moduleId)
+	local asset = ({yxpcall(function() return nil, AssetService:LoadAssetAsync(moduleId) end), warn)})[3] or InsertService:LoadAsset(moduleId)
 
 	if asset.Name == "MainModule" then
 		return assert(require(asset), ":LoadAsset() module returned invalid values!")

--- a/Loader/Loader/Loader.server.luau
+++ b/Loader/Loader/Loader.server.luau
@@ -205,7 +205,7 @@ else
 			success = true
 		end, function(reason)
 			warn(`Failed to load Adonis mainmodule {moduleId} via :LoadAsset() method due to {reason}! Loading the nightly MainModule...`)
-			local newModuleId = not data.NightlyMode and data.NightlyModuleID or data.ModuleId
+			local newModuleId = not data.NightlyMode and data.NightlyModuleID or data.ModuleID
 			yxpcall(function()
 				module = assert(require(newModuleId), "Nightly module returned invalid values!")
 				success = true

--- a/Loader/Loader/Loader.server.luau
+++ b/Loader/Loader/Loader.server.luau
@@ -203,18 +203,31 @@ else
 			module = loadModuleAsset(moduleId)
 			success = true
 		end, function(reason)
-			warn(`Failed to load Adonis mainmodule {moduleId} via :LoadAsset() method due to {reason}! Loading the backup MainModule...`)
+			warn(`Failed to load Adonis mainmodule {moduleId} via :LoadAsset() method due to {reason}! Loading the nightly MainModule...`)
+			local newModuleId = not data.NightlyMode and data.NightlyModuleID or data.ModuleId
 			yxpcall(function()
-				module = assert(require(data.Backup), "Backup module returned invalid values!")
+				module = assert(require(newModuleId), "Nightly module returned invalid values!")
 				success = true
 			end, function(reason)
-				warn(`Failed to load Adonis backup MainModule {data.Backup} due to {reason}! If this does not work please purchase the Adonis backup MainModule to your inventory. Using backup method...`)
+				warn(`Failed to load Adonis nightly MainModule {newModuleId} due to {reason}! If this does not work please purchase the Adonis nightly MainModule to your inventory. Using backup method...`)
 				yxpcall(function()
-					module = loadModuleAsset(data.Backup)
+					module = loadModuleAsset(newModuleId)
 					success = true
 				end, function(reason)
-					module = nil
-					warn(`FATAL ERROR! Failed to load Adonis backup MainModule {moduleId} via :LoadAsset() method due to {reason}! Adonis can't be booted up! Please contact the Adonis helpers immediately and add both the regular MainModule and the backup MainModule to your user&group inventory!`)
+					warn(`Failed to load Adonis nightly mainmodule {newModuleId} via :LoadAsset() method due to {reason}! Loading the backup MainModule...`)
+					yxpcall(function()
+						module = assert(require(data.Backup), "Backup module returned invalid values!")
+						success = true
+					end, function(reason)
+						warn(`Failed to load Adonis backup MainModule {data.Backup} due to {reason}! If this does not work please purchase the Adonis backup MainModule to your inventory. Using backup method...`)
+						yxpcall(function()
+							module = loadModuleAsset(data.Backup)
+							success = true
+						end, function(reason)
+							module = nil
+							warn(`FATAL ERROR! Failed to load Adonis backup MainModule {moduleId} via :LoadAsset() method due to {reason}! Adonis can't be booted up! Please contact the Adonis helpers immediately and add both the regular MainModule and the backup MainModule to your user&group inventory!`)
+						end)
+					end)
 				end)
 			end)
 		end)

--- a/Loader/Loader/Loader.server.luau
+++ b/Loader/Loader/Loader.server.luau
@@ -47,13 +47,11 @@ local function yxpcall(f, callback, ...)
 end
 
 local function unSandbox(obj: Instance): Instance
-	xpcall(function()
-		for _, v in Enum.SecurityCapability:GetEnumItems() do
-			xpcall(function()
-				obj.Capabilities = obj.Capabilities:Add(v)
-			end, warn)
-		end
-	end, warn)
+	for _, v in Enum.SecurityCapability and Enum.SecurityCapability:GetEnumItems() or {} do
+		xpcall(function()
+			obj.Capabilities = obj.Capabilities:Add(v)
+		end, warn)
+	end
 
 	xpcall(function()
 		obj.Sandboxed = false

--- a/Loader/Loader/Loader.server.luau
+++ b/Loader/Loader/Loader.server.luau
@@ -46,8 +46,22 @@ local function yxpcall(f, callback, ...)
 	end
 end
 
+local function unSandbox(obj: Instance): Instance
+	xpcall(function()
+		for _, v in Enum.SecurityCapability:GetEnumItems() do
+			xpcall(function()
+				obj.Capabilities = obj.Capabilities:Add(v)
+			end, warn)
+		end
+	end, warn)
+
+	xpcall(function()
+		obj.Sandboxed = false
+	end, warn)
+end
+
 local function loadModuleAsset(moduleId: number)
-	local asset = ({yxpcall(function() return nil, AssetService:LoadAssetAsync(moduleId) end, warn)})[3] or InsertService:LoadAsset(moduleId)
+	local asset = unSandbox(({yxpcall(function() return nil, InsertService:LoadAsset(moduleId) end, warn)})[3] or AssetService:LoadAssetAsync(moduleId))
 
 	if asset.Name == "MainModule" then
 		return assert(require(asset), ":LoadAsset() module returned invalid values!")


### PR DESCRIPTION
Load nightly module in backup boot sequence + use new AssetService:LoadAssetAsync.

This makes Adonis loading a lot more robust.
The new load sequence is:

1. Attempt to load MainModule via require()
2. Attempt to load MainModule via AssetService
3. Attempt to load MainModule via InsertService
4. Attempt to load NightyModule via require()
5. Attempt to load NightyModule via AssetService
6. Attempt to load NightyModule via InsertService
7. Attempt to load BackupModule via require()
8. Attempt to load BackupModule via AssetService
9. Attempt to load BackupModule via InsertService

This more than doubles the amount of methods used to load Adonis from 4 methods previously.
The code should be probably replaced with a fully modular boot sequence, but this is fine for now. I'll do that when I'll have the time for it
