### PR TITLE
Turn off DebugMode by default

### DIFF
--- a/Loader/Loader/Loader.server.luau
+++ b/Loader/Loader/Loader.server.luau
@@ -121,8 +121,8 @@ else
 		--// Module used in case MainModule is unavailable, containing only essential commands
 		Backup = 17438792001; 	--// https://create.roblox.com/store/asset/17438792001/
 
-		DebugMode = true;
-		SilentStartup = false;
+		DebugMode = false;
+		SilentStartup = true;
 	}
 
 	--// Init


### PR DESCRIPTION
This PR sets the DebugMode value the Loader to `false` by default. This is done because DebugMode opens more commands that are not needed for production servers.

This also set SilentStartup to `true` so less junk is in Output

No PoF because I change two variables