### PR TITLE
Set CanDrop to false for :btools

### DIFF
--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -586,7 +586,7 @@ return function(Vargs, env)
 					assert(typeof(F3X) == "Instance", "Unable to load F3X.")
 				end
 
-				F3X.CanBeDropped = true
+				F3X.CanBeDropped = false
 
 				if Variables.F3XCached == nil then
 					Variables.F3XCached = F3X:Clone()


### PR DESCRIPTION
Makes a minor change to prevent people from dropping F3X

PoF:

https://github.com/user-attachments/assets/c253245f-1107-4533-a580-d717ce3d9b5b

