### PR TITLE
Fix using :bring on just yourself erroring

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -5001,7 +5001,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local players = service.GetPlayers(plr, if args[1] then args[1] else "me")
 				if #players == 1 and players[1] == plr then
-					Commands.Thru.Function(plr, {`@{plr.Name}`})
+					Commands.Thru.Function(plr, {})
 					return
 				end
 				if #players < 10 or not Commands.MassBring or Remote.GetGui(plr, "YesNoPrompt", {


### PR DESCRIPTION
This PR aims to fix a small issue with the Bring command whenever you just run `:bring` to teleport yourself it would error because of the new argument for the Thru command requiring a distance to go thru.


https://github.com/user-attachments/assets/4323da7b-4109-4717-8db8-9831a25e4094

