### PR TITLE
Fix AddLog player reference error

### DIFF
--- a/MainModule/Server/Core/Core.luau
+++ b/MainModule/Server/Core/Core.luau
@@ -716,13 +716,13 @@ return function(Vargs, GetEnv)
 					local data = service.DeepCopy(pData)
 
 					--// Temporary junk that will be removed on save.
-					for _, blacklistedData in ipairs({"Groups", "LastChat", "AdminRank", "AdminLevel", "LastLevelUpdate", "LastDataSave"}) do
+					for _, blacklistedData in ipairs({"Groups", "LastChat", "AdminRank", "AdminLevel", "LastLevelUpdate", "LastDataSave", "UserInfo"}) do
 						data[blacklistedData] = nil
 					end
 
 					--// We want to only save data if actual user data is different
 					local CompareOptions = {
-						IgnoreKeys = {"Groups", "AdminLevel", "AdminRank", "LastLevelUpdate", "LastDataSave"}
+						IgnoreKeys = {"Groups", "AdminLevel", "AdminRank", "LastLevelUpdate", "LastDataSave", "UserInfo"}
 					}
 
 					data.AdminNotes = Functions.DSKeyNormalize(data.AdminNotes)

--- a/MainModule/Server/Core/Logs.luau
+++ b/MainModule/Server/Core/Logs.luau
@@ -88,20 +88,15 @@ return function(Vargs, GetEnv)
 				log.Time = os.time()
 			end
 
-			if log.Player and type(log.Player) ~= "table" then
-				local id = log.Player.UserId
-				local pData = Core.PlayerData[tostring(id)]
-				local userInfo = pData.userInfo
-
-				if not userInfo then -- Cache table allocation for player userInfo table to save on memory
-					userInfo = {
-						Name = log.Player.Name;
-						UserId = id;
-					}
-					pData.userInfo = userInfo
+			local p = log.Player
+			if p and type(p) ~= "table" then
+				local pData = Core.PlayerData[tostring(p.UserId)]
+				local UserInfo = pData and pData.UserInfo or { Name = p.Name, UserId = p.UserId }
+				if pData and not pData.UserInfo then
+					pData.UserInfo = UserInfo
 				end
 
-				log.Player = userInfo
+				log.Player = UserInfo
 			end
 
 			if tab then
@@ -113,7 +108,7 @@ return function(Vargs, GetEnv)
 						table.remove(tab, #tab)
 					end
 				end
-				
+
 				service.Events.LogAdded:Fire(Logs.TabToType(tab), log, tab)
 			end
 		end;


### PR DESCRIPTION
Fixes an issue where if a player wasn't inside the PlayerData it would error any AddLog calls (i.e: NetworkAdded) and also removes the temporary reference whilst saving player data.

PoF:
<img width="460" height="161" alt="image" src="https://github.com/user-attachments/assets/61c5bf69-955b-45ba-ad6f-d7e708b9763c" />

