### PR TITLE
Add missing one in API

### DIFF
--- a/MainModule/Server/Core/Core.luau
+++ b/MainModule/Server/Core/Core.luau
@@ -1400,6 +1400,7 @@ return function(Vargs, GetEnv)
 			local ipairs = ipairs
 			local next = next
 			local table = table
+			local task = task
 			local getfenv = getfenv
 			local setfenv = setfenv
 			local require = require


### PR DESCRIPTION
Error that occurred when using `Message` in the Adonis API was resolved by adding `task`.

<img width="1521" height="77" alt="image" src="https://github.com/user-attachments/assets/a69c2a13-b159-4c99-b311-bb4ccd96e425" />

