### PR TITLE
Fix Syntax Errors & Deprecated API Replacements

### DIFF
--- a/MainModule/Client/Client.luau
+++ b/MainModule/Client/Client.luau
@@ -208,7 +208,7 @@ do
 	Kill = Immutable(function(info)
 		--if true then print(info or "SOMETHING TRIED TO CRASH CLIENT?") return end
 		if type(info) == "string" then
-			spawn(pcall, function()
+			task.spawn(pcall, function()
 				if Detected then
 					Detected("kick", info)
 				elseif Fire then
@@ -217,19 +217,19 @@ do
 			end)
 		end
 
-		spawn(pcall, function()
+		task.spawn(pcall, function()
 			task.wait(1)
-			spawn(pcall, Kick, service.Player, info)
+			task.spawn(pcall, Kick, service.Player, info)
 			service.Player:Kick(info)
 		end)
 
 		if not isStudio then
-			spawn(pcall, function()
+			task.spawn(pcall, function()
 				task.wait(5)
-				spawn(pcall, function() task.wait(5) while true do continue end end)
+				task.spawn(pcall, function() task.wait(5) while true do continue end end)
 				if client.Core and client.Core.RemoteEvent then
-					spawn(pcall, table.clear, client.Core.RemoteEvent)
-					spawn(pcall, table.freeze, client.Core.RemoteEvent)
+					task.spawn(pcall, table.clear, client.Core.RemoteEvent)
+					task.spawn(pcall, table.freeze, client.Core.RemoteEvent)
 					client.Core.RemoteEvent = nil
 				end
 

--- a/MainModule/Client/Core/Functions.luau
+++ b/MainModule/Client/Core/Functions.luau
@@ -96,7 +96,7 @@ return function(Vargs, GetEnv)
 							bb.Parent = part
 
 							if player ~= LocalPlayer then
-								spawn(function()
+								task.spawn(function()
 									repeat
 										if not part then
 											break

--- a/MainModule/Server/Core/Admin.luau
+++ b/MainModule/Server/Core/Admin.luau
@@ -41,7 +41,7 @@ return function(Vargs, GetEnv)
 					AddLog("Script", `Connected to TextChannel: {textchannel.Name}`)
 
 					if Settings.OverrideChatCallbacks ~= false then --// Default to "on" this for all games
-						AddLog("Script", "Overriding ShouldDeliverCallback for " .. textchannel.Name)
+						AddLog("Script", `Overriding ShouldDeliverCallback for {textchannel.Name}`)
 						textchannel.ShouldDeliverCallback = function(chatMessage, textSource)
 							if
 								chatMessage.Status == Enum.TextChatMessageStatus.Success
@@ -79,7 +79,7 @@ return function(Vargs, GetEnv)
 								end
 
 								if Variables.DisguiseBindings[SenderId] then -- // Disguise command handler
-									chatMessage.PrefixText = Variables.DisguiseBindings[SenderId].TargetUsername..":"
+									chatMessage.PrefixText = `{Variables.DisguiseBindings[SenderId].TargetUsername}:`
 								end
 
 								if Admin.SlowMode and IsOriginalSender then
@@ -1202,25 +1202,23 @@ return function(Vargs, GetEnv)
 							for _, v in data.Commands do
 								if type(data.Prefix) == "table" then
 									for _, p in data.Prefix do
-										if not blacklistedCommands["/"..p..v] then
+										if not blacklistedCommands[`/{p}{v}`] then
 											if not command1 then
-												command1 = "/"..p..v
+												command1 = `/{p}{v}`
 											else
-												command2 = "/"..p..v
+												command2 = `/{p}{v}`
 											end
 										end
 									end
 								else
-									if not blacklistedCommands["/"..data.Prefix..v] then
+									if not blacklistedCommands[`/{data.Prefix}{v}`] then
 										if not command1 then
-											command1 = "/"..data.Prefix..v
+											command1 = `/{data.Prefix}{v}`
 										else
-											command2 = "/"..data.Prefix..v
+											command2 = `/{data.Prefix}{v}`
 										end
 									end
-
 								end
-
 							end
 
 							if command1 then

--- a/MainModule/Server/Core/Core.luau
+++ b/MainModule/Server/Core/Core.luau
@@ -730,7 +730,7 @@ return function(Vargs, GetEnv)
 
 					if Core.SavedPlayerData[p.UserId] and Functions.LaxCheckMatch(Core.SavedPlayerData[p.UserId], data, CompareOptions) and Functions.LaxCheckMatch(data, Core.SavedPlayerData[p.UserId], CompareOptions) then
 						AddLog(Logs.Script, {
-							Text = "Didn't save data due to redundancy ".. p.Name;
+							Text = `Didn't save data due to redundancy {p.Name}`;
 							Desc = "Player data was not saved to the datastore due to it being already saved.";
 						})
 					elseif not Functions.LaxCheckMatch(Core.DefaultPlayerData(p), data, CompareOptions) or Core.SavedPlayerData[p.UserId] and not (Functions.LaxCheckMatch(Core.SavedPlayerData[p.UserId], data, CompareOptions) or Functions.LaxCheckMatch(data, Core.SavedPlayerData[p.UserId], CompareOptions)) then
@@ -802,7 +802,7 @@ return function(Vargs, GetEnv)
             local ShouldSaltKey = not IsPlayer and not SettingIsTrue
             local EncryptionKey = Settings.DataStoreKey
             if ShouldSaltKey then
-                EncryptionKey = ("SALT_" .. Settings.DataStoreKey):sub(1,50)
+                EncryptionKey = (`SALT_{Settings.DataStoreKey}`):sub(1,50)
             end
 
             return Functions.Base64Encode(Remote.Encrypt(tostring(key), EncryptionKey))

--- a/MainModule/Server/Core/Functions.luau
+++ b/MainModule/Server/Core/Functions.luau
@@ -481,7 +481,7 @@ return function(Vargs, GetEnv)
 
 				for _, data in Functions.PlayerFinders do
 					if not data.Level or (data.Level and PlrLevel >= data.Level) then
-						local check = ((data.Prefix and Settings.SpecialPrefix) or "")..data.Match
+						local check = `{(data.Prefix and Settings.SpecialPrefix) or ""}{data.Match}`
 						if (data.Absolute and msg == check) or (not data.Absolute and string.sub(msg, 1, #check) == string.lower(check)) then
 							if data.Absolute then
 								return data

--- a/MainModule/Server/Dependencies/ClientLoader.client.luau
+++ b/MainModule/Server/Dependencies/ClientLoader.client.luau
@@ -70,8 +70,8 @@ end
 local function Kill(info)
 	if DebugMode then warn(info) return end
 	pcall(function() Kick(player, info) end)
-	wait(1)
-	pcall(function() while not DebugMode and wait() do pcall(function() while true do end end) end end)
+	task.wait(1)
+	pcall(function() while not DebugMode and task.wait() do pcall(function() while true do end end) end end)
 end
 
 local function Locked(obj)
@@ -120,7 +120,7 @@ local function loadingTime()
 end
 
 local function checkChild(child)
-	print(`Checking child: child and child.ClassName} : {child and child:GetFullName()}`)
+	print(`Checking child: {child and child.ClassName} : {child and child:GetFullName()}`)
 	callCheck(child)
 	if child and not foundClient and not checkedChildren[child] and child:IsA("Folder") and child.Name == "Adonis_Client" then
 		print("Loading Folder...")
@@ -151,8 +151,8 @@ local function checkChild(child)
 
 		print("Destroying parent...")
 		if container and container:IsA("ScreenGui") and container.Name == "Adonis_Container" then
-			spawn(function()
-				wait(0.5)
+			task.spawn(function()
+				task.wait(0.5)
 				container:Destroy()
 			end)
 		end
@@ -254,7 +254,7 @@ else
 	print("Waiting and scanning (incase event fails)...")
 	repeat
 		scan(playerGui)
-		wait(5)
+		task.wait(5)
 	until (time() - start > 600) or foundClient
 
 	print(`Elapsed: {time() - start}`)

--- a/MainModule/Server/Dependencies/ClientMover.client.luau
+++ b/MainModule/Server/Dependencies/ClientMover.client.luau
@@ -157,8 +157,8 @@ end
 local function Kill(info)
 	if DebugMode then warn(info) return end
 	pcall(function() Kick(player, info) end)
-	wait(1)
-	pcall(function() while not DebugMode and wait() do pcall(function() while true do end end) end end)
+	task.wait(1)
+	pcall(function() while not DebugMode and task.wait() do pcall(function() while true do end end) end end)
 end
 
 local function Locked(obj)
@@ -218,7 +218,7 @@ if module and module:IsA("ModuleScript") then
 	--// Sometimes we load a little too fast and generate a warning from Roblox so we need to introduce some (minor) artificial loading lag...
 	print("Changing child parent...")
 	mainFolder.Name = ""
-	wait(0.01)
+	task.wait(0.01)
 	mainFolder.Parent = nil --// We cannot do this asynchronously or it will disconnect events that manage to connect before it changes parent to nil...
 
 	print("Debug: Loading the client?")

--- a/MainModule/Server/Plugins/Cross_Server.luau
+++ b/MainModule/Server/Plugins/Cross_Server.luau
@@ -265,7 +265,7 @@ return function(Vargs, GetEnv)
 					TextSelectable = true;
 				})
 
-				delay(500, doDisconnect)
+				task.delay(500, doDisconnect)
 			end
 		end;
 	};
@@ -354,7 +354,7 @@ return function(Vargs, GetEnv)
 				AutoUpdate = 1,
 			})
 
-			delay(120, function()
+			task.delay(120, function()
 				Logs.TempUpdaters[voteKey] = nil
 				msgSub:Disconnect()
 			end)

--- a/MainModule/Shared/Service.luau
+++ b/MainModule/Shared/Service.luau
@@ -189,7 +189,7 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 			end)
 
 			if props.Interval then
-				while wait(props.Interval) and new.Running do
+				while task.wait(props.Interval) and new.Running do
 					new:Trigger(os.time())
 				end
 			end
@@ -1220,19 +1220,19 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 				elseif delay == "Heartbeat" then
 					repeat
 						func()
-						service.RunService.Heartbeat:wait()
+						service.RunService.Heartbeat:Wait()
 					until RunningLoops[index] ~= tab or not tab.Running
 					kill()
 				elseif delay == "RenderStepped" then
 					repeat
 						func()
-						service.RunService.RenderStepped:wait()
+						service.RunService.RenderStepped:Wait()
 					until RunningLoops[index] ~= tab or not tab.Running
 					kill()
 				elseif delay == "Stepped" then
 					repeat
 						func()
-						service.RunService.Stepped:wait()
+						service.RunService.Stepped:Wait()
 					until RunningLoops[index] ~= tab or not tab.Running
 					kill()
 				else
@@ -1334,11 +1334,11 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 		end;
 		Wait = function(mode)
 			if not mode or mode == "Stepped" then
-				service.RunService.Stepped:wait()
+				service.RunService.Stepped:Wait()
 			elseif mode == "Heartbeat" then
-				service.RunService.Heartbeat:wait()
+				service.RunService.Heartbeat:Wait()
 			elseif mode and tonumber(mode) then
-				wait(tonumber(mode))
+				task.wait(tonumber(mode))
 			end
 		end;
 		OrigRawEqual = rawequal;


### PR DESCRIPTION
Fixed a syntax error in a string missing { before `child` and `child.ClassName` in `ClientLoader.client.luau`

Fixed Deprecated API Replacements (`wait > task.wait`); `Service.luau, ClientLoader.client.luau, ClientMover.client.luau` & task.spawn in Client.luau & ClientLoader, and task.delay replacements.

Replaced instances of concatenation with backtick interpolation 

Simple fixes, and maintainability updates.
