### PR TITLE
Indicate to users that bubble chat is local only

### DIFF
--- a/MainModule/Client/UI/Default/BubbleChat.luau
+++ b/MainModule/Client/UI/Default/BubbleChat.luau
@@ -13,7 +13,7 @@ return function(data, env)
 	else
 		local window = client.UI.Make("Window",{
 			Name  = "BubbleChat";
-			Title = "Bubble Chat";
+			Title = "Bubble Chat (Only you can see messages)";
 			Icon = client.MatIcons.Chat;
 			Size  = {260,57};
 			Position = UDim2.new(0, 10, 1, -80);

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -2902,7 +2902,7 @@ return function(Vargs, env)
 			Prefix = Settings.Prefix;
 			Commands = {"bchat", "dchat", "bubblechat", "dialogchat"};
 			Args = {"player", "color(red/green/blue/white/off)"};
-			Description = "Gives the target player(s) a little chat gui, when used will let them chat using dialog bubbles";
+			Description = "Gives the target player(s) a little chat gui, when used will let them chat (local only messages) using dialog bubbles";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local CHAT_COLORS = {


### PR DESCRIPTION
There has been some confusion regarding the bubble chat command so this PR clarifies to users that only they can see their own bubblechats.