### PR TITLE
Allow :insert command to load 3rd party assets without sandbox

### DIFF
--- a/MainModule/Shared/Service.luau
+++ b/MainModule/Shared/Service.luau
@@ -1366,7 +1366,8 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 		UnallowedCache = {},
 		Insert = function(id, rawModel)
 			if service.UnallowedCache and service.UnallowedCache[id] then return end
-			local model = service.InsertService:LoadAsset(id)
+			local model = ({xpcall(function() return nil, service.AssetService:LoadAssetAsync(id) end, warn)})[3] or service.InsertService:LoadAsset(id)
+			model.Sandboxed=false
 			if not rawModel and model:IsA("Model") and model.Name == "Model" then
 				local asset = model:GetChildren()[1]
 				asset.Parent = model.Parent


### PR DESCRIPTION
because it got reverted https://github.com/Epix-Incorporated/Adonis/pull/2019#issuecomment-4027201838

the only fix for that is to set Sandboxed property to false then 1st party scripts should load without any problem thru AssetService