### PR TITLE
Fix :invisible and :visible to query all Decals and BillboardGui

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -3828,11 +3828,13 @@ return function(Vargs, env)
 						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") then
 								obj.Transparency = 1
-								if obj:FindFirstChild("face") then
-									obj.face.Transparency = 1
-								end
-								if obj:FindFirstChildOfClass("BillboardGui") then
-									obj:FindFirstChildOfClass("BillboardGui").Enabled = false
+								for b, subObj in obj:GetChildren() do
+									if subObj:IsA("Decal") then
+										subObj.Transparency = 1
+									end
+									if subObj:IsA("BillboardGui") then
+										subObj.Enabled = false
+									end
 								end
 							elseif obj:IsA("Accoutrement") and obj:FindFirstChild("Handle") then
 								obj.Handle.Transparency = 1
@@ -3871,11 +3873,13 @@ return function(Vargs, env)
 						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") and obj.Name~="HumanoidRootPart" then
 								obj.Transparency = 0
-								if obj:FindFirstChild("face") then
-									obj.face.Transparency = 0
-								end
-								if obj:FindFirstChildOfClass("BillboardGui") then
-									obj:FindFirstChildOfClass("BillboardGui").Enabled = true
+								for b, subObj in obj:GetChildren() do
+									if subObj:IsA("Decal") then
+										subObj.Transparency = 0
+									end
+									if subObj:IsA("BillboardGui") then
+										subObj.Enabled = true
+									end
 								end
 							elseif obj:IsA("Accoutrement") and obj:FindFirstChild("Handle") then
 								obj.Handle.Transparency = 0


### PR DESCRIPTION
The `:invisible` and `:visible` command already queries all children of player characters, however in BasePart(s), there are BillboardGui(s) and decals that could be placed inside those rig parts.

Some poorly-written scripts, or multiple scripts in a single game, could make a character have more than one decals and BillboardGui(s) placed inside a BasePart of the character.

With this PR, instead of only "face" and first BillboardGui in each BasePart(s), this approach will query all decals (including Textures since it's inherited from Decal class) and BillboardGui(s), so that the visibility is consistent across all parts, Decals, and BillboardGui(s).

# Proof-of-functionality

Rig used, which contains 2 different BillboardGui(s) and 2 different Decals in the Head part:

<img width="250" height="250" alt="Screenshot_20260328_102541" src="https://github.com/user-attachments/assets/32541578-a17c-41b6-83d4-a6e0c92121ae" />

Before (left) - only one of Decals and BillboardGuis are affected, After (right) - all Decals and BillboardGuis are affected :

<img width="250" height="250" alt="Screenshot_20260328_102608" src="https://github.com/user-attachments/assets/e31a28b6-519f-4ca9-965c-fddd774d4149" />  <img width="250" height="250" alt="Screenshot_20260328_103113" src="https://github.com/user-attachments/assets/c31b744a-308e-40a6-a709-640b25d2e1d3" />
