### PR TITLE
Fix singer not tilting head

### DIFF
--- a/MainModule/Server/Dependencies/Assets/Singer.server.luau
+++ b/MainModule/Server/Dependencies/Assets/Singer.server.luau
@@ -37,7 +37,7 @@ local neck = torso and torso:FindFirstChild("Neck") or head:FindFirstChild("Neck
 local mouth = character.ADONIS_MOUTH
 local mouthMesh = mouth:FindFirstChildOfClass("SpecialMesh")
 local originalSize = mouthMesh.Scale
-local orgC0 = neck.C0
+local orgC0 = CFrame.new()
 local isR15 = humanoid and humanoid.RigType == Enum.HumanoidRigType.R15 or false
 
 local SIZE_SMOOTHNESS = 0.8
@@ -46,9 +46,10 @@ local WIDTH_SUPRESS = 20000
 local HEIGHT_SUPRESS = 1000
 local ANGLE_MULTIPLY = 100
 
-game:GetService("RunService").Heartbeat:Connect(function()
+game:GetService("RunService").PreSimulation:Connect(function()
 	local relativeSize = head.Size / (isR15 and Vector3.new(1.2, 1.2, 1.2) or Vector3.new(2, 1, 1))
 	local loudness = script.Parent.PlaybackLoudness
 	mouthMesh.Scale = mouthMesh.Scale:Lerp(Vector3.new(originalSize.X + loudness/WIDTH_SUPRESS * relativeSize.X, loudness/HEIGHT_SUPRESS * relativeSize.Y, originalSize.Z), SIZE_SMOOTHNESS)
-	neck.C0 = neck.C0:Lerp(orgC0 * CFrame.Angles(math.rad(mouthMesh.Scale.Y / relativeSize.Y * ANGLE_MULTIPLY) * (isR15 and 1 or -1), 0, 0), ANGLE_SMOOTHNESS)
+	orgC0 = orgC0:Lerp(CFrame.Angles(math.rad(mouthMesh.Scale.Y / relativeSize.Y * ANGLE_MULTIPLY) * (isR15 and 1 or -1), 0, 0), ANGLE_SMOOTHNESS)
+	neck.Transform *= orgC0
 end)

--- a/MainModule/Server/Dependencies/Assets/Singer.server.luau
+++ b/MainModule/Server/Dependencies/Assets/Singer.server.luau
@@ -47,9 +47,11 @@ local HEIGHT_SUPRESS = 1000
 local ANGLE_MULTIPLY = 100
 
 game:GetService("RunService").PreSimulation:Connect(function()
-	local relativeSize = head.Size / (isR15 and Vector3.new(1.2, 1.2, 1.2) or Vector3.new(2, 1, 1))
-	local loudness = script.Parent.PlaybackLoudness
-	mouthMesh.Scale = mouthMesh.Scale:Lerp(Vector3.new(originalSize.X + loudness/WIDTH_SUPRESS * relativeSize.X, loudness/HEIGHT_SUPRESS * relativeSize.Y, originalSize.Z), SIZE_SMOOTHNESS)
-	orgC0 = orgC0:Lerp(CFrame.Angles(math.rad(mouthMesh.Scale.Y / relativeSize.Y * ANGLE_MULTIPLY) * (isR15 and 1 or -1), 0, 0), ANGLE_SMOOTHNESS)
-	neck.Transform *= orgC0
+	task.defer(function()
+		local relativeSize = head.Size / (isR15 and Vector3.new(1.2, 1.2, 1.2) or Vector3.new(2, 1, 1))
+		local loudness = script.Parent.PlaybackLoudness
+		mouthMesh.Scale = mouthMesh.Scale:Lerp(Vector3.new(originalSize.X + loudness/WIDTH_SUPRESS * relativeSize.X, loudness/HEIGHT_SUPRESS * relativeSize.Y, originalSize.Z), SIZE_SMOOTHNESS)
+		orgC0 = orgC0:Lerp(CFrame.Angles(math.rad(mouthMesh.Scale.Y / relativeSize.Y * ANGLE_MULTIPLY) * (isR15 and 1 or -1), 0, 0), ANGLE_SMOOTHNESS)
+		neck.Transform *= orgC0
+	end)
 end)


### PR DESCRIPTION
This fixes a bug in the singer script caused by Roblox locking C0 of the Motor6D for some reason.
As a bonus it also makes the script a lot more performant as well as fixes some visual glitches and increases compatibility.
