### PR TITLE
Add back accidentally removed contributors

### DIFF
--- a/MainModule/Shared/Credits.luau
+++ b/MainModule/Shared/Credits.luau
@@ -17,7 +17,6 @@ return {
 		{Text = "@TheCakeChicken", 	Desc = "Open Source Contributor"};
 		{Text = "@NNickey", 		Desc = "Open Source Contributor"};
 		{Text = "@FungusGenerator", Desc = "Open Source Contributor"};
-		{Text = "@gjkeller", 		Desc = "Open Source Contributor"};
 		{Text = "@Kan18", 			Desc = "Open Source Contributor"};
 		{Text = "@Brandon-Beck", 	Desc = "Open Source Contributor"};
 		{Text = "@AaronVickers", 	Desc = "Open Source Contributor"};
@@ -31,7 +30,6 @@ return {
 		{Text = "@krampuszc",		Desc = "Open Source Contributor"};
 		{Text = "@Dimenpsyonal",	Desc = "Open Source Contributor"};
 		{Text = "@policetonyR",		Desc = "Open Source Contributor"};
-		{Text = "@enescglyn",		Desc = "Open Source Contributor"};
 		{Text = "@EpicFazbear",		Desc = "Open Source Contributor"};
 		{Text = "@P3tray",			Desc = "Open Source Contributor"};
 		{Text = "@okgabe",			Desc = "Open Source Contributor"};
@@ -44,7 +42,7 @@ return {
 		{Text = "@GalacticInspired",Desc = "Open Source Contributor"};
 		{Text = "@lukashoracek",	Desc = "Open Source Contributor"};
 		{Text = "@DrewBokman",		Desc = "Open Source Contributor"};
-		{Text = "@Kw6m",			Desc = "Open Source Contributor"};
+		{Text = "Kw6m",			Desc = "Open Source Contributor"};
 		{Text = "@chexburger",		Desc = "Open Source Contributor"};
 		{Text = "@TjeerdoBoy112",	Desc = "Open Source Contributor"};
 		{Text = "@Jack5079",		Desc = "Open Source Contributor"};
@@ -59,7 +57,7 @@ return {
 		{Text = "@sea4h",			Desc = "Open Source Contributor"};
 		{Text = "@Tj33rd",			Desc = "Open Source Contributor"};
 		{Text = "@DaRealGandhi20",	Desc = "Open Source Contributor"};
-		{Text = "@L8X",				Desc = "Open Source Contributor"};
+		{Text = "L8X",				Desc = "Open Source Contributor"};
 		{Text = "@h0nzzz",			Desc = "Open Source Contributor"};
 		{Text = "@Smaltin", 		Desc = "Open Source Contributor"};
 		{Text = "@xvarmkorv2",		Desc = "Open Source Contributor"};

--- a/MainModule/Shared/Credits.luau
+++ b/MainModule/Shared/Credits.luau
@@ -17,9 +17,12 @@ return {
 		{Text = "@TheCakeChicken", 	Desc = "Open Source Contributor"};
 		{Text = "@NNickey", 		Desc = "Open Source Contributor"};
 		{Text = "@FungusGenerator", Desc = "Open Source Contributor"};
+		{Text = "@gjkeller", 		Desc = "Open Source Contributor"};
 		{Text = "@Kan18", 			Desc = "Open Source Contributor"};
 		{Text = "@Brandon-Beck", 	Desc = "Open Source Contributor"};
+		{Text = "@AaronVickers", 	Desc = "Open Source Contributor"};
 		{Text = "@moo1210", 		Desc = "Open Source Contributor"};
+		{Text = "@ken-tn", 			Desc = "Open Source Contributor"};
 		{Text = "@crywink", 		Desc = "Open Source Contributor"};
 		{Text = "@jaydns",	 		Desc = "Open Source Contributor"};
 		{Text = "@ccuser44",		Desc = "Open Source Contributor"};
@@ -28,6 +31,7 @@ return {
 		{Text = "@krampuszc",		Desc = "Open Source Contributor"};
 		{Text = "@Dimenpsyonal",	Desc = "Open Source Contributor"};
 		{Text = "@policetonyR",		Desc = "Open Source Contributor"};
+		{Text = "@enescglyn",		Desc = "Open Source Contributor"};
 		{Text = "@EpicFazbear",		Desc = "Open Source Contributor"};
 		{Text = "@P3tray",			Desc = "Open Source Contributor"};
 		{Text = "@okgabe",			Desc = "Open Source Contributor"};
@@ -40,6 +44,7 @@ return {
 		{Text = "@GalacticInspired",Desc = "Open Source Contributor"};
 		{Text = "@lukashoracek",	Desc = "Open Source Contributor"};
 		{Text = "@DrewBokman",		Desc = "Open Source Contributor"};
+		{Text = "@Kw6m",			Desc = "Open Source Contributor"};
 		{Text = "@chexburger",		Desc = "Open Source Contributor"};
 		{Text = "@TjeerdoBoy112",	Desc = "Open Source Contributor"};
 		{Text = "@Jack5079",		Desc = "Open Source Contributor"};
@@ -54,6 +59,7 @@ return {
 		{Text = "@sea4h",			Desc = "Open Source Contributor"};
 		{Text = "@Tj33rd",			Desc = "Open Source Contributor"};
 		{Text = "@DaRealGandhi20",	Desc = "Open Source Contributor"};
+		{Text = "@L8X",				Desc = "Open Source Contributor"};
 		{Text = "@h0nzzz",			Desc = "Open Source Contributor"};
 		{Text = "@Smaltin", 		Desc = "Open Source Contributor"};
 		{Text = "@xvarmkorv2",		Desc = "Open Source Contributor"};

--- a/MainModule/Shared/Credits.luau
+++ b/MainModule/Shared/Credits.luau
@@ -17,6 +17,7 @@ return {
 		{Text = "@TheCakeChicken", 	Desc = "Open Source Contributor"};
 		{Text = "@NNickey", 		Desc = "Open Source Contributor"};
 		{Text = "@FungusGenerator", Desc = "Open Source Contributor"};
+		{Text = "@gjkeller", 		Desc = "Open Source Contributor"};
 		{Text = "@Kan18", 			Desc = "Open Source Contributor"};
 		{Text = "@Brandon-Beck", 	Desc = "Open Source Contributor"};
 		{Text = "@AaronVickers", 	Desc = "Open Source Contributor"};


### PR DESCRIPTION
Add back accidentally removed contributors from https://github.com/Epix-Incorporated/Adonis/commit/6dea67a6688cee649d1f94c3e86cdb2b3e6f2a49

I couldn't find any information about NoUserSet who changed from ExternalScript and before that was apparently known as Obelusis.
Also unrelated to this it's unknown if the user 24rr is in the credits but under a different name.

No PoF needed for obvious reasons.