### PR TITLE
Add :highlight and :unhighlight commands

### DIFF
--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -4357,6 +4357,50 @@ return function(Vargs, env)
 			end
 		};
 
+		Highlight = {
+			Prefix = Settings.Prefix;
+			Commands = {"highlight", "glow", "outline"};
+			Args = {"player", "color"};
+			Description = "Adds a highlight outline and fill to the target player(s) with the desired color";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local color = Color3.new(1, 1, 1)
+				if args[2] then
+					local input = args[2]:gsub("(%a)([%w]*)", function(a, b) return a:upper() .. b:lower() end)
+					color = Functions.ParseColor3(args[2]) or Functions.ParseColor3(input) or color
+				end
+				for _, v in service.GetPlayers(plr, args[1]) do
+					if v.Character then
+						Functions.RemoveParticle(v.Character, "HIGHLIGHT")
+						Functions.NewParticle(v.Character, "Highlight", {
+							Name = "HIGHLIGHT";
+							FillColor = color;
+							OutlineColor = color;
+							FillTransparency = 0.5;
+							OutlineTransparency = 0;
+						})
+					end
+				end
+			end
+		};
+
+		UnHighlight = {
+			Prefix = Settings.Prefix;
+			Commands = {"unhighlight", "unglow", "unoutline", "removehighlight"};
+			Args = {"player"};
+			Description = "Removes the highlight from the target player(s)";
+			Fun = true;
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				for _, v in service.GetPlayers(plr, args[1]) do
+					if v.Character then
+						Functions.RemoveParticle(v.Character, "HIGHLIGHT")
+					end
+				end
+			end
+		};
+
 		Animation = {
 			Prefix = Settings.Prefix;
 			Commands = {"animation", "loadanim", "animate"};


### PR DESCRIPTION
## Summary
- Adds `:highlight` (aliases: `:glow`, `:outline`) command that applies a Highlight effect to the target player(s) with an optional colour argument
- Adds `:unhighlight` (aliases: `:unglow`, `:unoutline`, `:removehighlight`) command to remove the highlight
- Supports colour input via RGB values (e.g. `255,0,0`), BrickColor names (e.g. `Cyan`), and `random`
- Re-running `:highlight` on an already-highlighted player replaces the existing highlight with the new colour
- Fun command at Moderator admin level, consistent with `:fire`, `:smoke`, and `:sparkles`

## Changes
- `MainModule/Server/Commands/Fun.luau` — added `Highlight` and `UnHighlight` command definitions

## Test plan
- [ ] `:highlight me` — applies white highlight
- [ ] `:highlight me Cyan` — applies cyan highlight
- [ ] `:highlight me 255,0,0` — applies red highlight via RGB
- [ ] `:highlight me random` — applies random colour highlight
- [ ] `:highlight me Cyan` then `:highlight me 255,0,0` — replaces colour
- [ ] `:unhighlight me` — removes highlight
- [ ] `:highlight all` — highlights all players

## Demo
<!-- Drag and drop your video recording here -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)