### PR TITLE
fix vuln that lets exploiters get chatlogs, cmdlogs, etc, without perms

### DIFF
--- a/MainModule/Server/Core/Remote.luau
+++ b/MainModule/Server/Core/Remote.luau
@@ -328,12 +328,14 @@ return function(Vargs, GetEnv)
 				local list = args[1]
 				local update = Logs.ListUpdaters[list]
 				if update then
-					if not Variables.UpdaterMemory then Variables.UpdaterMemory = {} end
-					local allowedUpdaters = Variables.UpdaterMemory[p]
-					if not allowedUpdaters then
-						return {}
-					elseif not table.find(allowedUpdaters, list) then
-						return {}
+					if list ~= "ServerDetails" then
+						if not Variables.UpdaterMemory then Variables.UpdaterMemory = {} end
+						local allowedUpdaters = Variables.UpdaterMemory[p]
+						if not allowedUpdaters then
+							return {}
+						elseif not table.find(allowedUpdaters, list) then
+							return {}
+						end
 					end
 					return update(p, unpack(args,2))
 				end

--- a/MainModule/Server/Core/Remote.luau
+++ b/MainModule/Server/Core/Remote.luau
@@ -328,6 +328,13 @@ return function(Vargs, GetEnv)
 				local list = args[1]
 				local update = Logs.ListUpdaters[list]
 				if update then
+					if not Variables.UpdaterMemory then Variables.UpdaterMemory = {} end
+					local allowedUpdaters = Variables.UpdaterMemory[p]
+					if not allowedUpdaters then
+						return {}
+					elseif not table.find(allowedUpdaters, list) then
+						return {}
+					end
 					return update(p, unpack(args,2))
 				end
 			end;
@@ -1248,6 +1255,34 @@ return function(Vargs, GetEnv)
 			if not p then return end
 			local theme = {Desktop = Settings.Theme; Mobile = Settings.MobileTheme}
 			if themeData then for ind,dat in themeData do theme[ind] = dat end end
+
+			-- TODO: Hardcoded checks are BAD!
+			if GUI == "ToolPanel" then
+				-- TODO: I shouldn't be using the Variables table for this, but I don't know where else to store temporary data about players that should clear.
+				if not Variables.UpdaterMemory then Variables.UpdaterMemory = {} end
+				local allowedUpdaters = Variables.UpdaterMemory[p]
+				if not allowedUpdaters then
+					Variables.UpdaterMemory[p] = {}
+					allowedUpdaters = Variables.UpdaterMemory[p]
+				end
+				if not table.find(allowedUpdaters, "ToolList") then
+					table.insert(Variables.UpdaterMemory[p], "ToolList")
+				end
+			end
+			if GUI == "List" then
+				if data and data.Update ~= nil then
+					if not Variables.UpdaterMemory then Variables.UpdaterMemory = {} end
+					local allowedUpdaters = Variables.UpdaterMemory[p]
+					if not allowedUpdaters then
+						Variables.UpdaterMemory[p] = {}
+						allowedUpdaters = Variables.UpdaterMemory[p]
+					end
+					if not table.find(allowedUpdaters, data.Update) then
+						table.insert(Variables.UpdaterMemory[p], data.Update)
+					end
+				end
+			end
+
 			Remote.Send(p,"UI",GUI,theme,data or {})
 		end;
 


### PR DESCRIPTION
the :logs, :chatlogs commands are permission locked and cannot be ran by random players on your game.
however, adonis will happily let you request the data that those logging commands fetch themselves, without any authentication.
this means that exploiters can simply dive into the client adonis env to use the communication functions, and make it get the data as the List modulescript would, which lets them view all the chat messages sent, see if they were detected by the anti-exploit, view command logs, etc etc.

i promise that i have tested commands such as :vote and :tools to work.
yes, it is hardcoded, i invite suggestions on how to improve this pr, because i am too tired to think atm.