### PR TITLE
add :promptpluspurchase and :getplus command

### DIFF
--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -1165,6 +1165,19 @@ return function(Vargs, env)
 			end
 		};
 
+		PromptPlusPurchase = {
+			Prefix = Settings.Prefix;
+			Commands = {"promptpluspurchase", "pluspurchaseprompt"};
+			Args = {"player"};
+			Description = "Opens the Roblox Plus purchase prompt for the target player(s)";
+			AdminLevel = "Admins";
+			Function = function(plr: Player, args: {string})
+				for _, v in service.GetPlayers(plr, args[1]) do
+					service.MarketplaceService:PromptRobloxSubscriptionPurchase(v)
+				end
+			end
+		};
+
 		PromptPremiumPurchase = {
 			Prefix = Settings.Prefix;
 			Commands = {"promptpremiumpurchase", "premiumpurchaseprompt"};

--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -1178,19 +1178,6 @@ return function(Vargs, env)
 			end
 		};
 
-		PromptPremiumPurchase = {
-			Prefix = Settings.Prefix;
-			Commands = {"promptpremiumpurchase", "premiumpurchaseprompt"};
-			Args = {"player"};
-			Description = "Opens the Roblox Premium purchase prompt for the target player(s)";
-			AdminLevel = "Admins";
-			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
-					service.MarketplaceService:PromptPremiumPurchase(v)
-				end
-			end
-		};
-
 		RobloxNotify = {
 			Prefix = Settings.Prefix;
 			Commands = {"rbxnotify", "robloxnotify", "robloxnotif", "rblxnotify", "rnotif", "rn"};

--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -1167,7 +1167,7 @@ return function(Vargs, env)
 
 		PromptPlusPurchase = {
 			Prefix = Settings.Prefix;
-			Commands = {"promptpluspurchase", "pluspurchaseprompt"};
+			Commands = {"promptpluspurchase", "pluspurchaseprompt", "promptpremiumpurchase", "premiumpurchaseprompt"};
 			Args = {"player"};
 			Description = "Opens the Roblox Plus purchase prompt for the target player(s)";
 			AdminLevel = "Admins";

--- a/MainModule/Server/Commands/Players.luau
+++ b/MainModule/Server/Commands/Players.luau
@@ -649,6 +649,17 @@ return function(Vargs, env)
 			end
 		};
 
+		GetPlus = {
+			Prefix = Settings.PlayerPrefix;
+			Commands = {"getplus", "purchaseplus", "robloxplus"};
+			Args = {};
+			Description = "Prompts you to purchase Roblox Plus";
+			AdminLevel = "Players";
+			Function = function(plr: Player, args: {string})
+				service.MarketplaceService:PromptRobloxSubscriptionPurchase(plr)
+			end
+		};
+
 		GetPremium = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"getpremium", "purchasepremium", "robloxpremium"};

--- a/MainModule/Server/Commands/Players.luau
+++ b/MainModule/Server/Commands/Players.luau
@@ -660,17 +660,6 @@ return function(Vargs, env)
 			end
 		};
 
-		GetPremium = {
-			Prefix = Settings.PlayerPrefix;
-			Commands = {"getpremium", "purchasepremium", "robloxpremium"};
-			Args = {};
-			Description = "Prompts you to purchase Roblox Premium";
-			AdminLevel = "Players";
-			Function = function(plr: Player, args: {string})
-				service.MarketplaceService:PromptPremiumPurchase(plr)
-			end
-		};
-
 		InspectAvatar = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"inspectavatar", "avatarinspect", "viewavatar", "examineavatar"};

--- a/MainModule/Server/Commands/Players.luau
+++ b/MainModule/Server/Commands/Players.luau
@@ -651,7 +651,7 @@ return function(Vargs, env)
 
 		GetPlus = {
 			Prefix = Settings.PlayerPrefix;
-			Commands = {"getplus", "purchaseplus", "robloxplus"};
+			Commands = {"getplus", "purchaseplus", "robloxplus", "getpremium", "purchasepremium", "robloxpremium"};
 			Args = {};
 			Description = "Prompts you to purchase Roblox Plus";
 			AdminLevel = "Players";


### PR DESCRIPTION
## add :promptpluspurchase and :getplus commands

Added this command as Roblox is no longer supporting Premium and replaced it with Plus. 

Command(s) prompt users to purchase/subscribe to Roblox Plus.