### PR TITLE
Add :load to respawn command

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -3398,7 +3398,7 @@ return function(Vargs, env)
 
 		Respawn = {
 			Prefix = Settings.Prefix;
-			Commands = {"respawn", "re", "reset", "res"};
+			Commands = {"respawn", "re", "reset", "res", "load"};
 			Args = {"player"};
 			Description = "Respawns the target player(s)";
 			AdminLevel = "Moderators";


### PR DESCRIPTION
In some games, like ER:LC, :load command is used for respawning the character. If they get used to :load they should just use :load with adonis too.