### PR TITLE
Modify donation buttons & switch to t-shirts

### DIFF
--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -63,7 +63,7 @@ return function(data, env)
 		end
 	})
 
-	local function createPurchaseWindow(id)
+	local function createPurchaseWindow(id, isAvatarAsset)
 		local purchaseWindow = UI.Make("Window", {
 			Name = "Purchase window";
 			Title = `Purchase asset`;
@@ -91,16 +91,18 @@ return function(data, env)
 				ClearTextOnFocus = false;
 				TextEditable = false;
 				TextScaled = true;
-				Text = string.format("https://roblox.com/%s/%d/", "library", id)
+				Text = string.format("https://roblox.com/%s/%d/", if isAvatarAsset then "catalog" else "library", id)
 			})
 
 			purchaseWindow:Ready()
+
+			return purchaseWindow
 		end
 	end
 
 	local function promptPurchase(id)
 		if Variables.AllowThirdPartyPurchases == false then
-			createPurchaseWindow(id)
+			createPurchaseWindow(id, false)
 		else
 			local logEvent, finishEvent
 
@@ -131,21 +133,28 @@ return function(data, env)
 				return
 			end
 		end
-		if showSuccess then
-			local finishEvent
-			finishEvent = service.RbxEvent(service.MarketplaceService.PromptBulkPurchaseFinished, function(p, status, items)
-				if status == Enum.MarketplaceBulkPurchasePromptStatus.Completed then
-					if items and items.Items and items.Items[1] and items.Items[1].id == tostring(id) then
-						window:Close()
-						client.UI.Make("UserPanel", {
-							Tab = "Donate"
-						})
-					end
+		local backupWindow, finishEvent
+		finishEvent = service.RbxEvent(service.MarketplaceService.PromptBulkPurchaseFinished, function(p, status, items)
+			if showSuccess and status == Enum.MarketplaceBulkPurchasePromptStatus.Completed then
+				if items and items.Items and items.Items[1] and items.Items[1].id == tostring(id) then
+					window:Close()
+					client.UI.Make("UserPanel", {
+						Tab = "Donate"
+					})
 				end
-				finishEvent:Disconnect()
-			end)
-		end
+			end
+			if backupWindow and status ~= Enum.MarketplaceBulkPurchasePromptStatus.Error then
+				backupWindow:Close()
+			end
+			finishEvent:Disconnect()
+			finishEvent = nil
+		end)
 		Remote.Send("PromptBulkPurchase", {id})
+		task.delay(1, function()
+			if finishEvent then
+				backupWindow = createPurchaseWindow(id, true)
+			end
+		end)
 	end
 
 	local function showTable(tab, setting)

--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -63,7 +63,66 @@ return function(data, env)
 		end
 	})
 
-	local function promptPurchase(id: number, showWarning: boolean?, showSuccess: boolean?)
+	local function createPurchaseWindow(id)
+		local purchaseWindow = UI.Make("Window", {
+			Name = "Purchase window";
+			Title = `Purchase asset`;
+			Icon = client.MatIcons["Shopping cart"];
+			AllowMultiple = false;
+			Size = {380, 160};
+			SizeLocked = true;
+		})
+
+		if purchaseWindow then
+			purchaseWindow:Add("TextLabel", {
+				Size = UDim2.new(1, -20, 1, -55);
+				Position = UDim2.new(0.5, 0, 0, 10);
+				AnchorPoint = Vector2.new(0.5, 0);
+				ZIndex = 2;
+				TextScaled = true;
+				Text = "This game does not allow third party purchases. If you would like to purchase, please copy the link below and put it in your browser.";
+			})
+
+			purchaseWindow:Add("TextBox", {
+				Size = UDim2.new(1, -20, 0, 30);
+				Position = UDim2.new(0.5, 0, 1, -10);
+				AnchorPoint = Vector2.new(0.5, 1);
+				ZIndex = 2;
+				ClearTextOnFocus = false;
+				TextEditable = false;
+				TextScaled = true;
+				Text = string.format("https://roblox.com/%s/%d/", "library", id)
+			})
+
+			purchaseWindow:Ready()
+		end
+	end
+
+	local function promptPurchase(id)
+		if Variables.AllowThirdPartyPurchases == false then
+			createPurchaseWindow(id)
+		else
+			local logEvent, finishEvent
+
+			logEvent = service.LogService.MessageOut:Connect(function(msg, typ)
+				if typ == Enum.MessageType.MessageWarning and string.find(msg, "AllowThirdPartySales has blocked the purchase prompt") then
+					Variables.AllowThirdPartyPurchases = false
+
+					createPurchaseWindow(id)
+				end
+			end)
+			finishEvent = service.MarketPlace["PromptPurchaseFinished"]:Connect(function(plr, aid)
+				if plr == service.Players.LocalPlayer and aid == id then
+					logEvent:Disconnect()
+					finishEvent:Disconnect()
+				end
+			end)
+
+			service.MarketPlace:PromptPurchase(service.Players.LocalPlayer, id)
+		end
+	end
+
+	local function promptBulkPurchase(id: number, showWarning: boolean?, showSuccess: boolean?)
 		if showWarning then
 			if UI.MakeGui("YesNoPrompt", {
 				Title = "Are you sure?",
@@ -793,7 +852,7 @@ return function(data, env)
 				BackgroundTransparency = 0.5;
 				BackgroundColor3 = Color3.fromRGB(231, 6, 141);
 				OnClick = function()
-					promptPurchase(6878510605, playerData.isDonor, true)
+					promptBulkPurchase(6878510605, playerData.isDonor, true)
 				end
 			})
 
@@ -804,7 +863,7 @@ return function(data, env)
 				BackgroundTransparency = 0.5;
 				BackgroundColor3 = Color3.fromRGB(231, 6, 141):lerp(Color3.new(1,0,0), 0.6);
 				OnClick = function()
-					promptPurchase(82180417686588, playerData.isDonor, true)
+					promptBulkPurchase(82180417686588, playerData.isDonor, true)
 				end
 			})
 
@@ -815,7 +874,7 @@ return function(data, env)
 				BackgroundTransparency = 0.5;
 				BackgroundColor3 = Color3.fromRGB(231, 6, 141):lerp(Color3.new(1,0,0), 1);
 				OnClick = function()
-					promptPurchase(113285285080347, playerData.isDonor, true)
+					promptBulkPurchase(113285285080347, playerData.isDonor, true)
 				end
 			})
 
@@ -834,7 +893,7 @@ return function(data, env)
 				BackgroundTransparency = 0.7;
 				BackgroundColor3 = Color3.new(0,1,0):lerp(Color3.new(1,0,0), 0.1);
 				OnClick = function()
-					promptPurchase(86164337425437)
+					promptBulkPurchase(86164337425437)
 				end
 			})
 
@@ -845,7 +904,7 @@ return function(data, env)
 				BackgroundTransparency = 0.5;
 				BackgroundColor3 = Color3.new(0,1,0):lerp(Color3.new(1,0,0), 0.3);
 				OnClick = function()
-					promptPurchase(75165550059686)
+					promptBulkPurchase(75165550059686)
 				end
 			})
 		end

--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -847,8 +847,8 @@ return function(data, env)
 			})
 			
 			dFrame:Add("TextLabel", {
-				Text = "Donate (Perks):";
-				TextXAlignment = "Left";
+				Text = "Donate (Perks)";
+				TextXAlignment = "Center";
 				Size = UDim2.new(1, 0, 0, 30);
 				Position = UDim2.new(0, 5, 0, 0);
 				BackgroundTransparency = 1;
@@ -867,8 +867,8 @@ return function(data, env)
 
 			dFrame:Add("TextButton", {
 				Text = ` 500`;
-				Size = UDim2.new(0, 62, 0, 20);
-				Position = UDim2.new(0, 5, 0, 75);
+				Size = UDim2.new(0, 62, 0, 25);
+				Position = UDim2.new(0, 5, 0, 76);
 				BackgroundTransparency = 0.5;
 				BackgroundColor3 = Color3.fromRGB(231, 6, 141):lerp(Color3.new(1,0,0), 0.6);
 				OnClick = function()
@@ -878,8 +878,8 @@ return function(data, env)
 
 			dFrame:Add("TextButton", {
 				Text = ` 1000`;
-				Size = UDim2.new(0, 62, 0, 20);
-				Position = UDim2.new(0.5, 3, 0, 75);
+				Size = UDim2.new(0, 62, 0, 25);
+				Position = UDim2.new(0.5, 3, 0, 76);
 				BackgroundTransparency = 0.5;
 				BackgroundColor3 = Color3.fromRGB(231, 6, 141):lerp(Color3.new(1,0,0), 1);
 				OnClick = function()
@@ -887,18 +887,25 @@ return function(data, env)
 				end
 			})
 
+			dFrame:Add("Frame", {
+				Size = UDim2.new(1, -10, 0, 1),
+				Position = UDim2.new(0, 5, 1, -55),
+				BackgroundColor3 = Color3.new(1, 1, 1),
+				BackgroundTransparency = 0.5;
+			})
+
 			dFrame:Add("TextLabel", {
-				Text = "Other (No Perks): ";
-				TextXAlignment = "Left";
+				Text = "Other (No Perks)";
+				TextXAlignment = "Center";
 				Size = UDim2.new(1, 0, 0, 30);
-				Position = UDim2.new(0, 5, 1, -50);
+				Position = UDim2.new(0, 5, 1, -55);
 				BackgroundTransparency = 1;
 			})
 
 			dFrame:Add("TextButton", {
 				Text = ` 50`;
-				Size = UDim2.new(0, 62, 0, 20);
-				Position = UDim2.new(0, 5, 1, -20);
+				Size = UDim2.new(0, 62, 0, 25);
+				Position = UDim2.new(0, 5, 1, -25);
 				BackgroundTransparency = 0.7;
 				BackgroundColor3 = Color3.new(0,1,0):lerp(Color3.new(1,0,0), 0.1);
 				OnClick = function()
@@ -908,8 +915,8 @@ return function(data, env)
 
 			dFrame:Add("TextButton", {
 				Text = ` 100`;
-				Size = UDim2.new(0, 62, 0, 20);
-				Position = UDim2.new(0.5, 3, 1, -20);
+				Size = UDim2.new(0, 62, 0, 25);
+				Position = UDim2.new(0.5, 3, 1, -25);
 				BackgroundTransparency = 0.5;
 				BackgroundColor3 = Color3.new(0,1,0):lerp(Color3.new(1,0,0), 0.3);
 				OnClick = function()

--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -63,67 +63,30 @@ return function(data, env)
 		end
 	})
 
-	local function createPurchaseWindow(isGamepass, id)
-		local purchaseWindow = UI.Make("Window", {
-			Name = "Purchase window";
-			Title = `Purchase {isGamepass and "gamepass" or "asset"}`;
-			Icon = client.MatIcons["Shopping cart"];
-			AllowMultiple = false;
-			Size = {380, 160};
-			SizeLocked = true;
-		})
-
-		if purchaseWindow then
-			purchaseWindow:Add("TextLabel", {
-				Size = UDim2.new(1, -20, 1, -55);
-				Position = UDim2.new(0.5, 0, 0, 10);
-				AnchorPoint = Vector2.new(0.5, 0);
-				ZIndex = 2;
-				TextScaled = true;
-				Text = "This game does not allow third party purchases. If you would like to purchase, please copy the link below and put it in your browser.";
-			})
-
-			purchaseWindow:Add("TextBox", {
-				Size = UDim2.new(1, -20, 0, 30);
-				Position = UDim2.new(0.5, 0, 1, -10);
-				AnchorPoint = Vector2.new(0.5, 1);
-				ZIndex = 2;
-				ClearTextOnFocus = false;
-				TextEditable = false;
-				TextScaled = true;
-				Text = string.format("https://roblox.com/%s/%d/", isGamepass and "game-pass" or "library", id)
-			})
-
-			purchaseWindow:Ready()
-		end
-	end
-
-	local function promptPurchase(isGamepass, id)
-		if Variables.AllowThirdPartyPurchases == false then
-			createPurchaseWindow(isGamepass, id)
-		else
-			local logEvent, finishEvent
-
-			logEvent = service.LogService.MessageOut:Connect(function(msg, typ)
-				if typ == Enum.MessageType.MessageWarning and string.find(msg, "AllowThirdPartySales has blocked the purchase prompt") then
-					Variables.AllowThirdPartyPurchases = false
-
-					createPurchaseWindow(isGamepass, id)
-				end
-			end)
-			finishEvent = service.MarketPlace[isGamepass and "PromptGamePassPurchaseFinished" or "PromptPurchaseFinished"]:Connect(function(plr, aid)
-				if plr == service.Players.LocalPlayer and aid == id then
-					logEvent:Disconnect()
-					finishEvent:Disconnect()
-				end
-			end)
-
-			if isGamepass then
-				service.MarketPlace:PromptGamePassPurchase(service.Players.LocalPlayer, id)
-			else
-				service.MarketPlace:PromptPurchase(service.Players.LocalPlayer, id)
+	local function promptPurchase(id: number, showWarning: boolean?, showSuccess: boolean?)
+		if showWarning then
+			if UI.MakeGui("YesNoPrompt", {
+				Title = "Are you sure?",
+				Question = "You already have donor perks. Additional donations provide no extra benefits."
+			}) ~= "Yes" then
+				return
 			end
 		end
+		if showSuccess then
+			local finishEvent
+			finishEvent = service.RbxEvent(service.MarketplaceService.PromptBulkPurchaseFinished, function(p, status, items)
+				if status == Enum.MarketplaceBulkPurchasePromptStatus.Completed then
+					if items and items.Items and items.Items[1] and items.Items[1].id == tostring(id) then
+						window:Close()
+						client.UI.Make("UserPanel", {
+							Tab = "Donate"
+						})
+					end
+				end
+				finishEvent:Disconnect()
+			end)
+		end
+		Remote.Send("PromptBulkPurchase", {id})
 	end
 
 	local function showTable(tab, setting)
@@ -437,7 +400,7 @@ return function(data, env)
 				BackgroundTransparency = 0.5;
 				Events = {
 					MouseButton1Down = function()
-						promptPurchase(false, 7510622625)
+						promptPurchase(7510622625)
 					end
 				}
 			}):Add("ImageLabel", {
@@ -455,7 +418,7 @@ return function(data, env)
 				BackgroundTransparency = 0.5;
 				Events = {
 					MouseButton1Down = function()
-						promptPurchase(false, 7510592873)
+						promptPurchase(7510592873)
 					end
 				}
 			}):Add("ImageLabel", {
@@ -814,67 +777,75 @@ return function(data, env)
 				Position = UDim2.new(1, -140, 0, 105);
 				BackgroundTransparency = 1;
 			})
-
-			dFrame:Add("TextButton", {
-				Text = "Donate (Perks)";
-				Size = UDim2.new(1, -10, 0, 40);
-				Position = UDim2.new(0, 5, 0, 5);
-				BackgroundTransparency = 0.5;
-				BackgroundColor3 = Color3.fromRGB(231, 6, 141);
-				OnClick = function()
-					promptPurchase(true, 1348327) --497917601)
-				end
-			})
-
+			
 			dFrame:Add("TextLabel", {
-				Text = "Extra (No Perks): ";
+				Text = "Donate (Perks):";
 				TextXAlignment = "Left";
 				Size = UDim2.new(1, 0, 0, 30);
-				Position = UDim2.new(0, 5, 1, -80);
+				Position = UDim2.new(0, 5, 0, 0);
 				BackgroundTransparency = 1;
 			})
 
 			dFrame:Add("TextButton", {
-				Text = "50";
-				Size = UDim2.new(0, 60, 0, 20);
+				Text = ` 300`;
+				Size = UDim2.new(1, -10, 0, 40);
+				Position = UDim2.new(0, 5, 0, 30);
+				BackgroundTransparency = 0.5;
+				BackgroundColor3 = Color3.fromRGB(231, 6, 141);
+				OnClick = function()
+					promptPurchase(6878510605, playerData.isDonor, true)
+				end
+			})
+
+			dFrame:Add("TextButton", {
+				Text = ` 500`;
+				Size = UDim2.new(0, 62, 0, 20);
+				Position = UDim2.new(0, 5, 0, 75);
+				BackgroundTransparency = 0.5;
+				BackgroundColor3 = Color3.fromRGB(231, 6, 141):lerp(Color3.new(1,0,0), 0.6);
+				OnClick = function()
+					promptPurchase(82180417686588, playerData.isDonor, true)
+				end
+			})
+
+			dFrame:Add("TextButton", {
+				Text = ` 1000`;
+				Size = UDim2.new(0, 62, 0, 20);
+				Position = UDim2.new(0.5, 3, 0, 75);
+				BackgroundTransparency = 0.5;
+				BackgroundColor3 = Color3.fromRGB(231, 6, 141):lerp(Color3.new(1,0,0), 1);
+				OnClick = function()
+					promptPurchase(113285285080347, playerData.isDonor, true)
+				end
+			})
+
+			dFrame:Add("TextLabel", {
+				Text = "Other (No Perks): ";
+				TextXAlignment = "Left";
+				Size = UDim2.new(1, 0, 0, 30);
 				Position = UDim2.new(0, 5, 1, -50);
+				BackgroundTransparency = 1;
+			})
+
+			dFrame:Add("TextButton", {
+				Text = ` 50`;
+				Size = UDim2.new(0, 62, 0, 20);
+				Position = UDim2.new(0, 5, 1, -20);
 				BackgroundTransparency = 0.7;
 				BackgroundColor3 = Color3.new(0,1,0):lerp(Color3.new(1,0,0), 0.1);
 				OnClick = function()
-					promptPurchase(true, 5212076)
+					promptPurchase(86164337425437)
 				end
 			})
 
 			dFrame:Add("TextButton", {
-				Text = "100";
-				Size = UDim2.new(0, 60, 0, 20);
-				Position = UDim2.new(0.5, 5, 1, -50);
+				Text = ` 100`;
+				Size = UDim2.new(0, 62, 0, 20);
+				Position = UDim2.new(0.5, 3, 1, -20);
 				BackgroundTransparency = 0.5;
 				BackgroundColor3 = Color3.new(0,1,0):lerp(Color3.new(1,0,0), 0.3);
 				OnClick = function()
-					promptPurchase(true, 5212077)
-				end
-			})
-
-			dFrame:Add("TextButton", {
-				Text = "500";
-				Size = UDim2.new(0, 60, 0, 20);
-				Position = UDim2.new(0, 5, 1, -25);
-				BackgroundTransparency = 0.5;
-				BackgroundColor3 = Color3.new(0,1,0):lerp(Color3.new(1,0,0), 0.6);
-				OnClick = function()
-					promptPurchase(true, 5212081)
-				end
-			})
-
-			dFrame:Add("TextButton", {
-				Text = "1000";
-				Size = UDim2.new(0, 60, 0, 20);
-				Position = UDim2.new(0.5, 5, 1, -25);
-				BackgroundTransparency = 0.5;
-				BackgroundColor3 = Color3.new(0,1,0):lerp(Color3.new(1,0,0), 0.9);
-				OnClick = function()
-					promptPurchase(true, 5212082)
+					promptPurchase(75165550059686)
 				end
 			})
 		end

--- a/MainModule/Server/Core/Admin.luau
+++ b/MainModule/Server/Core/Admin.luau
@@ -305,12 +305,6 @@ return function(Vargs, GetEnv)
 		AddLog("Script", "Admin Module RunAfterPlugins Finished")
 	end
 
-	service.RbxEvent(service.MarketplaceService.PromptGamePassPurchaseFinished, function(player, id, purchased)
-		if Variables and player.Parent and table.find(Variables.DonorPass, id) and purchased then
-			Variables.CachedDonors[tostring(player.UserId)] = os.time()
-		end
-	end)
-
 	local function stripArgPlaceholders(alias)
 		return service.Trim(string.gsub(alias, "<%S+>", ""))
 	end
@@ -891,10 +885,14 @@ return function(Vargs, GetEnv)
 				return true
 			else
 				local pGroup = Admin.GetPlayerGroup(p, 886423)
+				if pGroup and pGroup.Rank >= 10 then 
+					--// Complimentary donor access is given to Adonis contributors & developers.
+					Variables.CachedDonors[key] = os.time()
+					return true
+				end
+
 				for _, pass in Variables.DonorPass do
-					if p.Parent ~= service.Players then
-						return false
-					end
+					if p.Parent ~= service.Players then break end
 
 					local ran, ret
 					if type(pass) == "number" then
@@ -903,11 +901,13 @@ return function(Vargs, GetEnv)
 						ran, ret = pcall(service.MarketPlace.PlayerOwnsAsset, service.MarketPlace, p, tonumber(pass))
 					end
 
-					if (ran and ret) or (pGroup and pGroup.Rank >= 10) then --// Complimentary donor access is given to Adonis contributors & developers.
+					if ran and ret then
 						Variables.CachedDonors[key] = os.time()
 						return true
 					end
 				end
+
+				return false
 			end
 		end;
 

--- a/MainModule/Server/Core/Remote.luau
+++ b/MainModule/Server/Core/Remote.luau
@@ -1025,6 +1025,18 @@ return function(Vargs, GetEnv)
 					end)
 				end
 			end,
+
+			PromptBulkPurchase = function(p: Player, args: {{number}})
+				local ids = args[1]
+				local lineItems = {}
+				for _, id in ids do
+					table.insert(lineItems, {
+						Type = Enum.MarketplaceProductType.AvatarAsset,
+						Id = tostring(id)
+					})
+				end
+				service.MarketplaceService:PromptBulkPurchase(p, lineItems, {})
+			end;
 		};
 
 		NewSession = function(sessionType: string)

--- a/MainModule/Server/Core/Variables.luau
+++ b/MainModule/Server/Core/Variables.luau
@@ -81,7 +81,7 @@ return function(Vargs, GetEnv)
 		BanMessage = "Banned",
 		PlayerJoinFilters = {};
 		LockMessage = "Not Whitelisted",
-		DonorPass = {1348327, 1990427, 1911740, 167686, 98593, "6878510605", 5212082, 5212081}, --// Strings are items; numbers are gamepasses
+		DonorPass = {1348327, 1990427, 1911740, 167686, 98593, "6878510605", 5212082, 5212081, "82180417686588", "113285285080347"}, --// Strings are items; numbers are gamepasses
 		WebPanel_Initiated = false,
 		HTTPCheckUrl = "https://www.google.com/humans.txt",
 		IPInfoUrl = "https://speed.cloudflare.com/meta",


### PR DESCRIPTION
- Changes the design of the donation section to include 500 and 1000 options under perks (since the old gamepasses already gave perks)
- Changes all donation buttons to use t-shirts instead of gamepasses inside of the Epix group (50, 100, 500, and 1000 t-shirts newly created, previously existing 300 t-shirt used)
- Adds warning when clicking a perk donation button if the user already has donor perks
<img width="607" height="440" alt="RobloxStudioBeta_ez0VM87t0s" src="https://github.com/user-attachments/assets/0070e5e3-5a16-4fd4-bd72-9e6613e97452" />
<img width="608" height="446" alt="RobloxStudioBeta_PtG5CSUOp2" src="https://github.com/user-attachments/assets/dc48f7be-af47-4ac3-8a3c-abd0f8960773" />
