### PR TITLE
Fix Issue #1910 in UserPanel.luau

### DIFF
--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -362,6 +362,10 @@ return function(data, env)
 			Text = "Game";
 		})
 
+		-- Fix for GitHub issue #1910 - Game Tab should be deactivated by default, since it requires 
+		-- permissions to be shown, which we don't know at this time.
+		gameTab:Disable() 
+
 		if data.Tab then
 			local Tab = string.lower(data.Tab)
 			if Tab == "donate" then
@@ -1853,10 +1857,8 @@ return function(data, env)
 						})
 					end
 				end
-
 				gameTab:ResizeCanvas(false, true, false, false, 5, 5)
-			else
-				gameTab:Disable()
+				gameTab:Enable()
 			end
 		end
 

--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -362,8 +362,7 @@ return function(data, env)
 			Text = "Game";
 		})
 
-		-- Fix for GitHub issue #1910 - Game Tab should be deactivated by default, since it requires 
-		-- permissions to be shown, which we don't know at this time.
+		-- Disable settings tab until permissions are checked
 		gameTab:Disable() 
 
 		if data.Tab then


### PR DESCRIPTION
Fixed issue #1910 by changing the default behavior of GameTab

Explanation: GameTab should only be accessible if the user in question has sufficient permissions to view that tab. By default, as issue #1910 describes, this tab is active for a split second due to loading lag. I changed the behavior, so that GameTab is disabled by default, and when loading finishes (and the user has sufficient permissions) the tab gets enabled.