### PR TITLE
Migrate deprecated APIs

### DIFF
--- a/MainModule/Client/Plugins/Anti_Cheat.luau
+++ b/MainModule/Client/Plugins/Anti_Cheat.luau
@@ -167,7 +167,7 @@ return function(Vargs)
 				end
 				hasActivated = true
 				Detected("crash", "Tamper Protection 0xC0FA6; "..tostring(message).."; ")
-				wait(1)
+				task.wait(1)
 				pcall(Disconnect, "Adonis_0xC0FA6")
 				pcall(Kill, "Adonis_0xC0FA6")
 				pcall(Kick, Player, "Adonis_0xC0FA6")
@@ -253,7 +253,7 @@ return function(Vargs)
 		--Detected('log','Client-Side Tool Detected')
 
 		HumanoidState = function()
-			wait(1)
+			task.wait(1)
 			local humanoid = service.Player.Character:WaitForChild("Humanoid", 2) or service.Player.Character:FindFirstChildOfClass("Humanoid")
 			local event
 			local doing = true

--- a/MainModule/Client/UI/Default/BlockedUsers.luau
+++ b/MainModule/Client/UI/Default/BlockedUsers.luau
@@ -77,7 +77,7 @@ return function(data, env)
 						end
 					})
 				end
-				spawn(function()
+				task.spawn(function()
 					entry:Add("ImageLabel", {
 						Image = service.Players:GetUserThumbnailAsync(userId, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size420x420);
 						BackgroundTransparency = 1;

--- a/MainModule/Client/UI/Default/Friends.luau
+++ b/MainModule/Client/UI/Default/Friends.luau
@@ -87,7 +87,7 @@ return function(data, env)
 					Position = UDim2.new(1, -120, 0, 0);
 					TextXAlignment = "Right";
 				})
-				spawn(function()
+				task.spawn(function()
 					entry:Add("ImageLabel", {
 						Image = service.Players:GetUserThumbnailAsync(friend.VisitorId, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size420x420);
 						BackgroundTransparency = 1;

--- a/MainModule/Client/UI/Default/List.luau
+++ b/MainModule/Client/UI/Default/List.luau
@@ -383,7 +383,7 @@ return function(data, env)
 	genList(Tab)
 
 	if Update and AutoUpdate then
-		while gTable.Active and wait(AutoUpdate) do
+		while gTable.Active and task.wait(AutoUpdate) do
 			window:Refresh()
 		end
 	end

--- a/MainModule/Client/UI/Default/Profile.luau
+++ b/MainModule/Client/UI/Default/Profile.luau
@@ -471,7 +471,7 @@ return function(data, env)
 					self.Active = false
 					self.AutoButtonColor = false
 					client.Remote.Send("ProcessCommand", string.format("%sviewtools%s%s", data.CmdPrefix, data.CmdSplitKey, player.Name))
-					wait(2)
+					task.wait(2)
 					self.AutoButtonColor = true
 					self.Active = true
 				end

--- a/MainModule/Client/UI/Default/SelectionPrompt.luau
+++ b/MainModule/Client/UI/Default/SelectionPrompt.luau
@@ -59,6 +59,6 @@ return function(data, env)
 
 	gTable = window.gTable
 	window:Ready()
-	repeat wait() until done == true;
+	repeat task.wait() until done == true;
 	return answer
 end

--- a/MainModule/Client/UI/Default/ServerDetails.luau
+++ b/MainModule/Client/UI/Default/ServerDetails.luau
@@ -154,7 +154,7 @@ return function(data, env)
 		overviewtab:ResizeCanvas(false, true, false, false, 5, 5)
 
 		task.spawn(function()
-			while wait(0.5) do
+			while task.wait(0.5) do
 				local timeNow = os.time()
 				if not displays["Server Speed"] or not displays["Server Age"] then break end
 				displays["Server Speed"].Text = math.round(data.ServerSpeed or 0)

--- a/MainModule/Client/UI/Default/ServerDetails.luau
+++ b/MainModule/Client/UI/Default/ServerDetails.luau
@@ -153,7 +153,7 @@ return function(data, env)
 
 		overviewtab:ResizeCanvas(false, true, false, false, 5, 5)
 
-		spawn(function()
+		task.spawn(function()
 			while wait(0.5) do
 				local timeNow = os.time()
 				if not displays["Server Speed"] or not displays["Server Age"] then break end
@@ -333,7 +333,7 @@ return function(data, env)
 					playerCount += 1
 				end
 
-				spawn(function()
+				task.spawn(function()
 					entry:Add("ImageLabel", {
 						Image = service.Players:GetUserThumbnailAsync(service.Players[playerName].UserId, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size48x48);
 						BackgroundTransparency = 1;

--- a/MainModule/Client/UI/Default/Settings.luau
+++ b/MainModule/Client/UI/Default/Settings.luau
@@ -120,7 +120,7 @@ return function(data, env)
 					end
 				end)
 
-				repeat wait() until gotKey
+				repeat task.wait() until gotKey
 
 				Variables.CustomConsoleKey = gotKey
 				event:Disconnect()

--- a/MainModule/Client/UI/Default/Teams.luau
+++ b/MainModule/Client/UI/Default/Teams.luau
@@ -88,7 +88,7 @@ return function(data, env)
 				client.Remote.Send("ProcessCommand", string.format("%snewteam%s%s%s%s", data.CmdPrefix, data.CmdSplitKey, `"{teamName.Text}"`, data.CmdSplitKey, teamColor.Text));
 				teamName.Text = ""
 				teamColor.Text = ""
-				wait(1.2)
+				task.wait(1.2)
 				if self then
 					self.Active = true
 					self.AutoButtonColor = true
@@ -154,7 +154,7 @@ return function(data, env)
 							self.AutoButtonColor = false
 							self.Text = "..."
 							client.Remote.Send("ProcessCommand", string.format("%steam%s%sme%s%s", data.CmdPrefix, data.CmdSplitKey, data.CmdSpecialPrefix, data.CmdSplitKey, team.Name));
-							wait(1.2)
+							task.wait(1.2)
 							if self then
 								self.Active = true
 								self.AutoButtonColor = true
@@ -172,7 +172,7 @@ return function(data, env)
 						OnClick = function(self)
 							self.Visible = false
 							client.Remote.Send("ProcessCommand", string.format("%sremoveteam%s%s", data.CmdPrefix, data.CmdSplitKey, team.Name));
-							wait(1.2)
+							task.wait(1.2)
 							if self then
 								self.Visible = true
 							end

--- a/MainModule/Client/UI/Default/Terminal.luau
+++ b/MainModule/Client/UI/Default/Terminal.luau
@@ -71,7 +71,7 @@ return function(data, env)
 				--textbox.Text = "Enter command"
 			end
 			
-			wait(0.1)
+			task.wait(0.1)
 		end)
 	end)
 
@@ -81,7 +81,7 @@ return function(data, env)
 	window:Ready()
 	
 	local last = 0
-	while gTable.Active and wait(0.5) do
+	while gTable.Active and task.wait(0.5) do
 		if #termLines > last then
 			last = #termLines
 			scroller:GenerateList(termLines, nil, true)

--- a/MainModule/Client/UI/Default/ToolPanel.luau
+++ b/MainModule/Client/UI/Default/ToolPanel.luau
@@ -161,7 +161,7 @@ return function(data, env)
 		generateAdded()
 	end
 
-	spawn(function()
+	task.spawn(function()
 		local tab = tabFrame:NewTab("Inventories", {
 			Text = "Inventory Monitor";
 		})
@@ -347,7 +347,7 @@ return function(data, env)
 		end)
 	end)
 
-	spawn(function()
+	task.spawn(function()
 		local tab = tabFrame:NewTab("Gear", {
 			Text = "Insert Gear"
 		})

--- a/MainModule/Client/UI/Default/ToolPanel.luau
+++ b/MainModule/Client/UI/Default/ToolPanel.luau
@@ -145,7 +145,7 @@ return function(data, env)
 								end
 							end)
 							client.Remote.Send("ProcessCommand", `{data.Prefix}clearaddedtools`)
-							wait(1)
+							task.wait(1)
 							if not refreshed then
 								refreshed = true
 								data = client.Remote.Get("UpdateList", "ToolList")
@@ -243,7 +243,7 @@ return function(data, env)
 							self.AutoButtonColor = false
 							self.Text = ". . ."
 							client.Remote.Send("ProcessCommand", string.format("%sremovetools%s%s%s", data.Prefix, data.SplitKey, data.SpecialPrefix, selected.Name))
-							wait(2)
+							task.wait(2)
 							if self then
 								self.Text = "Remove All Tools"
 								self.AutoButtonColor = true
@@ -386,7 +386,7 @@ return function(data, env)
 						self.AutoButtonColor = false
 						self.Text = ". . ."
 						client.Remote.Send("ProcessCommand", string.format("%sgear%s%sme%s%s", data.Prefix, data.SplitKey, data.SpecialPrefix, data.SplitKey, currentId))
-						wait(2)
+						task.wait(2)
 						if self then
 							self.Text = "Spawn"
 							self.AutoButtonColor = true

--- a/MainModule/Client/UI/Modern/List.luau
+++ b/MainModule/Client/UI/Modern/List.luau
@@ -349,7 +349,7 @@ return function(data, env)
 	genList(Tab)
 
 	if Update and AutoUpdate then
-		while gTable.Active and wait(AutoUpdate) do
+		while gTable.Active and task.wait(AutoUpdate) do
 			window:Refresh()
 		end
 	end

--- a/MainModule/Client/UI/Steampunk/List.luau
+++ b/MainModule/Client/UI/Steampunk/List.luau
@@ -365,7 +365,7 @@ return function(data, env)
 	genList(Tab)
 
 	if Update and AutoUpdate then
-		while gTable.Active and wait(AutoUpdate) do
+		while gTable.Active and task.wait(AutoUpdate) do
 			window:Refresh()
 		end
 	end

--- a/MainModule/Client/UI/TransBlack/List.luau
+++ b/MainModule/Client/UI/TransBlack/List.luau
@@ -365,7 +365,7 @@ return function(data, env)
 	genList(Tab)
 
 	if Update and AutoUpdate then
-		while gTable.Active and wait(AutoUpdate) do
+		while gTable.Active and task.wait(AutoUpdate) do
 			window:Refresh()
 		end
 	end

--- a/MainModule/Client/UI/Unity/Alert.luau
+++ b/MainModule/Client/UI/Unity/Alert.luau
@@ -23,7 +23,7 @@ return function(data, env)
 		AllowMultiple = false;
 		OnClose = function()
 			alarm:Stop()
-			wait()
+			task.wait()
 			alarm:Destroy()
 		end
 	})

--- a/MainModule/Client/UI/Unity/Countdown.luau
+++ b/MainModule/Client/UI/Unity/Countdown.luau
@@ -87,7 +87,7 @@ return function(data, env)
 		else
 			break
 		end
-		wait(waitTime - timeOff)
+		task.wait(waitTime - timeOff)
 		expectedDelay += waitTime
 		timeOff = os.clock() - startTime - expectedDelay
 	end
@@ -100,12 +100,12 @@ return function(data, env)
 		buzzer:Play()
 		for i = 1, 0, -0.1 do
 			label.TextTransparency = i
-			wait(0.05)
+			task.wait(0.05)
 		end
 
 		for i = 0, 1, 0.1 do
 			label.TextTransparency = i
-			wait(0.05)
+			task.wait(0.05)
 		end
 	end
 

--- a/MainModule/Client/UI/Unity/List.luau
+++ b/MainModule/Client/UI/Unity/List.luau
@@ -364,7 +364,7 @@ return function(data, env)
 	genList(Tab)
 
 	if Update and AutoUpdate then
-		while gTable.Active and wait(AutoUpdate) do
+		while gTable.Active and task.wait(AutoUpdate) do
 			window:Refresh()
 		end
 	end

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -2014,7 +2014,7 @@ return function(Vargs, env)
 						Admin.RunCommand(`{Settings.Prefix}nograv`, v.Name)
 						Admin.RunCommand(`{Settings.Prefix}smoke`, v.Name, color)
 						Admin.RunCommand(`{Settings.Prefix}spin`, v.Name)
-						repeat hum.PlatformStand = true wait() until not hum or hum == nil or hum.Parent == nil
+						repeat hum.PlatformStand = true task.wait() until not hum or hum == nil or hum.Parent == nil
 					end)
 				end
 			end
@@ -2125,7 +2125,7 @@ return function(Vargs, env)
 
 							task.defer(humanoid.ApplyDescription, humanoid, description, Enum.AssetTypeVerification.Always)
 							local run = true
-							task.spawn(function() wait(10) run = false end)
+							task.spawn(function() task.wait(10) run = false end)
 							repeat
 								task.wait(1)
 								humanoid:TakeDamage(5)

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -686,7 +686,7 @@ return function(Vargs, env)
 									ice.Size = Vector3.new(5, ice.Size.Y - i, 5)
 									ice.CFrame = v.Character.HumanoidRootPart.CFrame * CFrame.new(0, -i, 0)
 									plate.Size = Vector3.new(i + 5, 0.2, i + 5)
-									wait()
+									task.wait()
 								end
 								ice:Destroy()
 							end
@@ -696,7 +696,7 @@ return function(Vargs, env)
 									obj.Anchored = false
 								end
 							end
-							wait(3)
+							task.wait(3)
 							pcall(function() plate:Destroy() end)
 						end
 					end)
@@ -718,7 +718,7 @@ return function(Vargs, env)
 						local orig = hum.MaxHealth
 						local tools = service.New("Model")
 						hum.MaxHealth = math.huge
-						wait()
+						task.wait()
 						hum.Health = hum.MaxHealth
 						for k, t in v.Backpack:GetChildren() do
 							t.Parent = tools
@@ -739,7 +739,7 @@ return function(Vargs, env)
 							Admin.RunCommand(`{Functions.GetMainPrefix()}unname`, v.Name)
 							event:Disconnect()
 						end)
-						repeat torso.CFrame = pos wait() until not v or not v.Character or not torso or not running or not torso.Parent
+						repeat torso.CFrame = pos task.wait() until not v or not v.Character or not torso or not running or not torso.Parent
 					end)
 				end
 			end
@@ -1388,7 +1388,7 @@ return function(Vargs, env)
 				end
 				for i = 0.1, 5, 0.1 do
 					if service.CountTable(tab) - 2 >= service.CountTable(players) then break end
-					wait(0.1)
+					task.wait(0.1)
 				end
 				return tab
 			end;
@@ -3346,7 +3346,7 @@ return function(Vargs, env)
 							newChar = p.Character ~= oChar and p.Character or p.CharacterAdded:Wait()
 
 							if newChar then
-								wait(); -- Let it finish loading character contents
+								task.wait(); -- Let it finish loading character contents
 
 								newHumanoid = newChar:FindFirstChildOfClass("Humanoid");
 								newPrimary = newChar.PrimaryPart or (newHumanoid and newHumanoid.RootPart) or oChar:FindFirstChild("HumanoidRootPart");
@@ -5984,9 +5984,9 @@ return function(Vargs, env)
 						s.SoundId = `http://www.roblox.com/asset/?id={ind.ID}`
 						s.Pitch = ind.Pitch
 						s:Play()
-						wait(0.5)
-						wait(s.TimeLength+1)
-						wait(1)
+						task.wait(0.5)
+						task.wait(s.TimeLength+1)
+						task.wait(1)
 					end)
 
 					s:Stop()
@@ -6086,7 +6086,7 @@ return function(Vargs, env)
 					s.Looped = looped
 					s.Archivable = false
 					s.Parent = service.SoundService
-					wait(0.5)
+					task.wait(0.5)
 					s:Play()
 				elseif id == "off" or id == "0" then
 					for i, v in service.SoundService:GetChildren() do

--- a/MainModule/Server/Dependencies/Assets/HatPets.server.luau
+++ b/MainModule/Server/Dependencies/Assets/HatPets.server.luau
@@ -35,6 +35,6 @@ if hats then
 				end
 			end
 		end
-		wait(0.5)
+		task.wait(0.5)
 	until not script.Parent
 end


### PR DESCRIPTION
Migrated `spawn()` and `wait()` to instead use `task.spawn()` and `task.wait()` respectively.

Some UI related `.rbxmx` models have been skipped, I didn't want to touch those, however I can migrate those aswell, if needed